### PR TITLE
feat(document-processor): improve TOC validation for mixed content + resolved markdown

### DIFF
--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -608,9 +608,21 @@ export class DocumentProcessor {
         );
         markdown = null;
       } else {
-        this.logger.info(
-          `[DocumentProcessor] TOC validation passed (confidence: ${validation.confidence})`,
-        );
+        const validMarkdown =
+          this.tocContentValidator!.getValidMarkdown(validation);
+        if (validMarkdown) {
+          if (validation.contentType === 'mixed') {
+            this.logger.info(
+              `[DocumentProcessor] Mixed TOC detected, using extracted main TOC (${validMarkdown.length} chars)`,
+            );
+          }
+          markdown = validMarkdown;
+          this.logger.info(
+            `[DocumentProcessor] TOC validation passed (confidence: ${validation.confidence})`,
+          );
+        } else {
+          markdown = null;
+        }
       }
     } catch (error) {
       if (error instanceof TocNotFoundError) {

--- a/packages/document-processor/src/extractors/vision-toc-extractor.ts
+++ b/packages/document-processor/src/extractors/vision-toc-extractor.ts
@@ -181,8 +181,16 @@ export class VisionTocExtractor extends VisionLLMComponent {
   ): Promise<VisionTocExtractionResult> {
     this.log('info', `Extracting from pages ${startPage}-${endPage}`);
 
+    this.log(
+      'info',
+      `Preparing images for vision analysis. This can be very slow (10+ minutes, sometimes 30+ minutes) depending on batch size and image resolution.`,
+    );
     const imageContents = this.loadPageImages(startPage, endPage);
 
+    this.log(
+      'info',
+      `Calling vision LLM for TOC extraction (pages ${startPage}-${endPage})`,
+    );
     const result = await LLMCaller.callVision({
       schema: VisionTocExtractionSchema,
       messages: [
@@ -205,6 +213,10 @@ export class VisionTocExtractor extends VisionLLMComponent {
       component: 'VisionTocExtractor',
       phase: 'extraction',
     });
+    this.log(
+      'info',
+      `Vision LLM call completed (pages ${startPage}-${endPage})`,
+    );
 
     this.trackUsage(result.usage);
 

--- a/packages/document-processor/src/validators/index.ts
+++ b/packages/document-processor/src/validators/index.ts
@@ -6,8 +6,10 @@ export {
   TocContentValidationSchema,
 } from './toc-content-validator';
 export type {
+  TocContentType,
   TocContentValidationResult,
   TocContentValidatorOptions,
+  TocValidationOutput,
 } from './toc-content-validator';
 
 export { CaptionValidator, CaptionValidationError } from './caption-validator';

--- a/packages/document-processor/src/validators/toc-content-validator.ts
+++ b/packages/document-processor/src/validators/toc-content-validator.ts
@@ -9,21 +9,44 @@ import { z } from 'zod';
 import { BaseValidator } from './base-validator';
 
 /**
+ * Content type for TOC validation
+ */
+export type TocContentType = 'pure_toc' | 'mixed' | 'resource_only' | 'invalid';
+
+/**
  * Schema for TOC content validation response
  */
 export const TocContentValidationSchema = z.object({
-  isToc: z.boolean().describe('Whether the content is a table of contents'),
+  isValid: z.boolean().describe('Whether valid main document TOC was found'),
   confidence: z
     .number()
     .min(0)
     .max(1)
     .describe('Confidence score between 0 and 1'),
-  reason: z.string().describe('Brief explanation for the decision'),
+  contentType: z
+    .enum(['pure_toc', 'mixed', 'resource_only', 'invalid'])
+    .describe('Type of content detected'),
+  extractedTocMarkdown: z
+    .string()
+    .nullable()
+    .describe('Extracted main TOC markdown when mixed; null otherwise'),
+  reason: z.string().describe('Brief explanation in English'),
 });
 
 export type TocContentValidationResult = z.infer<
   typeof TocContentValidationSchema
 >;
+
+/**
+ * Output type for TOC validation with resolved markdown
+ */
+export interface TocValidationOutput {
+  isValid: boolean;
+  confidence: number;
+  contentType: TocContentType;
+  validTocMarkdown: string | null;
+  reason: string;
+}
 
 /**
  * Options for TocContentValidator
@@ -40,6 +63,7 @@ export interface TocContentValidatorOptions extends BaseValidatorOptions {
  *
  * Uses LLM to validate whether extracted markdown content is actually a TOC.
  * This is a semantic validation, not structural validation.
+ * Supports mixed content extraction where main TOC is combined with resource indices.
  */
 export class TocContentValidator extends BaseValidator<
   typeof TocContentValidationSchema,
@@ -69,9 +93,9 @@ export class TocContentValidator extends BaseValidator<
    * Validate if the markdown content is a table of contents
    *
    * @param markdown - Markdown content to validate
-   * @returns Validation result with isToc, confidence, and reason
+   * @returns Validation output with resolved markdown for valid TOC
    */
-  async validate(markdown: string): Promise<TocContentValidationResult> {
+  async validate(markdown: string): Promise<TocValidationOutput> {
     this.logger.info(
       `[TocContentValidator] Validating content (${markdown.length} chars)`,
     );
@@ -81,8 +105,10 @@ export class TocContentValidator extends BaseValidator<
         '[TocContentValidator] Empty markdown, returning invalid',
       );
       return {
-        isToc: false,
+        isValid: false,
         confidence: 1.0,
+        contentType: 'invalid',
+        validTocMarkdown: null,
         reason: 'Empty content',
       };
     }
@@ -96,56 +122,116 @@ export class TocContentValidator extends BaseValidator<
     );
 
     this.logger.info(
-      `[TocContentValidator] Result: isToc=${result.isToc}, confidence=${result.confidence}`,
+      `[TocContentValidator] Result: isValid=${result.isValid}, contentType=${result.contentType}, confidence=${result.confidence}`,
     );
 
-    return result;
+    // Resolve valid markdown based on content type
+    let validTocMarkdown: string | null = null;
+    if (result.isValid && result.confidence >= this.confidenceThreshold) {
+      if (result.contentType === 'pure_toc') {
+        validTocMarkdown = markdown;
+      } else if (
+        result.contentType === 'mixed' &&
+        result.extractedTocMarkdown
+      ) {
+        validTocMarkdown = result.extractedTocMarkdown;
+      }
+    }
+
+    return {
+      isValid: result.isValid,
+      confidence: result.confidence,
+      contentType: result.contentType,
+      validTocMarkdown,
+      reason: result.reason,
+    };
   }
 
   /**
    * Check if validation result passes threshold
    *
-   * @param result - Validation result from validate()
+   * @param result - Validation output from validate()
    * @returns true if content is valid TOC with sufficient confidence
    */
-  isValid(result: TocContentValidationResult): boolean {
-    return result.isToc && result.confidence >= this.confidenceThreshold;
+  isValid(result: TocValidationOutput): boolean {
+    return result.isValid && result.confidence >= this.confidenceThreshold;
+  }
+
+  /**
+   * Get the valid TOC markdown from validation result
+   *
+   * @param result - Validation output from validate()
+   * @returns Valid TOC markdown or null if invalid
+   */
+  getValidMarkdown(result: TocValidationOutput): string | null {
+    return result.validTocMarkdown;
   }
 
   /**
    * Build system prompt for TOC content validation
    */
   protected buildSystemPrompt(): string {
-    return `You are a document structure analyst. Your task is to determine if the provided content is a Table of Contents (TOC).
+    return `You are a document structure analyst. Your task is to analyze the provided content and classify it into one of four categories.
 
-## What IS a Table of Contents:
-- A structured list of chapters/sections with corresponding page numbers
-- Contains hierarchical section titles (e.g., "Chapter 1", "제1장", "1.1 Introduction", etc.)
-- Has page number references for each entry (e.g., "..... 10", "... 5", or just a number at the end)
-- Multiple entries organized by document structure
-- Main document outline listing major chapters and sections
+## Content Type Classification:
 
-## What is NOT a Table of Contents:
+### 1. pure_toc
+The content is ONLY a main document Table of Contents with:
+- Structured list of chapters/sections with page numbers
+- Hierarchical section titles (e.g., "Chapter 1", "제1장", "1.1 Introduction")
+- Multiple entries (3 or more) organized by document structure
+- NO resource indices mixed in
+
+### 2. mixed
+The content contains BOTH:
+- A valid main document TOC (chapters/sections with page numbers)
+- AND resource indices (photo/table/drawing indices)
+
+When classifying as "mixed", you MUST extract ONLY the main TOC portion and return it in extractedTocMarkdown.
+
+### 3. resource_only
+The content contains ONLY resource indices such as:
 - Photo/image indices (사진 목차, 사진목차, Photo Index, List of Figures, List of Photos)
 - Table indices (표 목차, 표목차, Table Index, List of Tables)
 - Drawing/diagram indices (도면 목차, 도면목차, Drawing Index, List of Drawings)
 - Appendix indices (부록 목차, Appendix Index)
-- Random body text from the document
+
+### 4. invalid
+The content is none of the above:
+- Random body text
 - Single entries or incomplete lists (fewer than 3 items)
 - Reference lists or bibliographies
 - Index pages (alphabetical keyword lists)
+- Unstructured content
 
 ## Response Guidelines:
-- Set isToc to true ONLY if content is clearly a main document TOC
+- Set isValid to true for "pure_toc" and "mixed" types
+- Set isValid to false for "resource_only" and "invalid" types
 - Set confidence between 0.0 and 1.0 based on your certainty
-- Provide a brief reason explaining your decision (1-2 sentences)`;
+- For "mixed" type: extractedTocMarkdown MUST contain only the main TOC entries (preserve original formatting)
+- For other types: extractedTocMarkdown should be null
+- IMPORTANT: reason MUST be written in English
+
+## Example Scenarios:
+
+### Scenario 1: pure_toc
+Input: "제1장 서론 ..... 1\\n제2장 조사개요 ..... 5\\n제3장 조사결과 ..... 15"
+Output: { isValid: true, contentType: "pure_toc", extractedTocMarkdown: null }
+
+### Scenario 2: mixed
+Input: "제1장 서론 ..... 1\\n제2장 조사개요 ..... 5\\n\\n사진목차\\n사진 1 전경 ..... 50\\n사진 2 유물 ..... 51"
+Output: { isValid: true, contentType: "mixed", extractedTocMarkdown: "제1장 서론 ..... 1\\n제2장 조사개요 ..... 5" }
+
+### Scenario 3: resource_only
+Input: "사진목차\\n사진 1 전경 ..... 50\\n사진 2 유물 ..... 51"
+Output: { isValid: false, contentType: "resource_only", extractedTocMarkdown: null }`;
   }
 
   /**
    * Build user prompt with markdown content
    */
   protected buildUserPrompt(markdown: string): string {
-    return `Determine if the following content is a Table of Contents:
+    return `Analyze the following content and classify it:
 
 ${markdown}`;
   }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Enhance TOC validation to classify mixed content and provide a resolved “valid TOC markdown” output, improving downstream extraction decisions and reliability. Add more detailed logging around the vision-based TOC extraction flow to make slow steps and model call boundaries observable.

## Changes

- Extend TOC validation to return `contentType` (pure/mixed/resource_only/invalid) and resolved `validTocMarkdown` (including extraction of the main TOC from mixed content).
- Update TOC extraction flow to consume the resolved markdown, emit a dedicated “mixed TOC detected” log, and fall back when no valid markdown is available.
- Add additional informational logs for vision TOC extraction (image preparation warning + LLM call start/end markers).

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #