### PR TITLE
feat(demo-web): disable process auto-redirect and gate removeConsole to prod

### DIFF
--- a/apps/demo-web/next.config.ts
+++ b/apps/demo-web/next.config.ts
@@ -2,9 +2,8 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   compiler: {
-    removeConsole: {
-      exclude: ['error'],
-    },
+    removeConsole:
+      process.env.NODE_ENV === 'production' ? { exclude: ['error'] } : false,
   },
   images: {
     remotePatterns: [

--- a/apps/demo-web/src/app/process/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/process/[taskId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { use, useState } from 'react';
 
 import { MobileWarningBanner } from '~/components/layout/mobile-warning-banner';
@@ -26,15 +26,17 @@ interface PageProps {
 export default function ProcessPage({ params }: PageProps) {
   const { taskId } = use(params);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const deleteTaskMutation = useDeleteTask();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const disableAutoNavigate = searchParams.get('stay') === 'true';
 
   const { data: task } = useTask(taskId);
   const { status, progress, currentStep, logs, error, resultUrl } =
     useTaskStream(taskId);
   const isProcessing = status === 'queued' || status === 'running';
 
-  useAutoNavigate({ status, resultUrl, taskId });
+  useAutoNavigate({ status, resultUrl, taskId, disabled: disableAutoNavigate });
 
   const handleCancelClick = () => {
     setShowCancelDialog(true);

--- a/apps/demo-web/src/features/process/hooks/use-auto-navigate.ts
+++ b/apps/demo-web/src/features/process/hooks/use-auto-navigate.ts
@@ -10,6 +10,7 @@ interface UseAutoNavigateOptions {
   resultUrl: string | undefined;
   taskId: string;
   delay?: number;
+  disabled?: boolean;
 }
 
 /**
@@ -20,15 +21,18 @@ export function useAutoNavigate({
   resultUrl,
   taskId,
   delay = 1500,
+  disabled = false,
 }: UseAutoNavigateOptions): void {
   const router = useRouter();
 
   useEffect(() => {
+    if (disabled) return;
+
     if (status === 'completed' && resultUrl) {
       const timer = setTimeout(() => {
         router.push(`/result/${taskId}`);
       }, delay);
       return () => clearTimeout(timer);
     }
-  }, [status, resultUrl, router, taskId, delay]);
+  }, [status, resultUrl, router, taskId, delay, disabled]);
 }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Improve the demo-web UX and production build output by (1) enabling console stripping only in production and (2) allowing users to disable automatic navigation on the process page via a query parameter.

## Changes

- Enable `removeConsole` only for production builds (while preserving `console.error`).
- Add a `stay=true` query param to disable auto-navigation from the process page.
- Extend the auto-navigation hook to support a `disabled` option.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #