### PR TITLE
chore(document-processor): increase MAX_PATTERN_RETRIES to 19 for improved parsing robustness

### DIFF
--- a/packages/document-processor/src/parsers/page-range-parser.ts
+++ b/packages/document-processor/src/parsers/page-range-parser.ts
@@ -69,7 +69,7 @@ interface SampleResult {
 export class PageRangeParser extends VisionLLMComponent {
   // Configuration constants
   private readonly SAMPLE_SIZE = 3;
-  private readonly MAX_PATTERN_RETRIES = 6;
+  private readonly MAX_PATTERN_RETRIES = 19;
   private readonly SIZE_TOLERANCE = 5.0;
 
   constructor(


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Increase the maximum pattern retry limit to make page-range parsing more robust when dealing with noisy or inconsistent document inputs.

## Changes

- Increased the maximum number of pattern-matching retries from 6 to 19 to improve parsing success rates.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #