### PR TITLE
feat(demo-web): display app version in header and footer with link to releases

### DIFF
--- a/.github/workflows/cd-demo-web.yml
+++ b/.github/workflows/cd-demo-web.yml
@@ -118,6 +118,9 @@ jobs:
           
           # Chunked Upload Settings (required for large file uploads >= 50MB)
           UPLOAD_SESSION_SECRET=${{ secrets.DEMO_WEB_UPLOAD_SESSION_SECRET }}
+
+          # App Version (from root package.json)
+          NEXT_PUBLIC_APP_VERSION=$(node -p "require('./package.json').version")
           EOF
 
           # Remove leading whitespace from each line

--- a/apps/demo-web/src/components/layout/footer.tsx
+++ b/apps/demo-web/src/components/layout/footer.tsx
@@ -31,6 +31,19 @@ export function Footer() {
           >
             GitHub
           </a>
+          {process.env.NEXT_PUBLIC_APP_VERSION && (
+            <>
+              <span>|</span>
+              <a
+                href="https://github.com/heripo-lab/heripo-engine/releases"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-foreground underline underline-offset-4"
+              >
+                v{process.env.NEXT_PUBLIC_APP_VERSION} Releases
+              </a>
+            </>
+          )}
           {publicModeConfig.isOfficialDemo && (
             <>
               <span>|</span>

--- a/apps/demo-web/src/components/layout/header.tsx
+++ b/apps/demo-web/src/components/layout/header.tsx
@@ -23,6 +23,16 @@ export function Header() {
             <Image src={logoIcon} alt="heripo engine" width={24} height={24} />
             <span className="font-bold">heripo engine</span>
           </Link>
+          {process.env.NEXT_PUBLIC_APP_VERSION && (
+            <a
+              href="https://github.com/heripo-lab/heripo-engine/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-muted text-muted-foreground hover:bg-muted/80 ml-2 rounded-full px-2 py-0.5 text-xs"
+            >
+              v{process.env.NEXT_PUBLIC_APP_VERSION}
+            </a>
+          )}
         </div>
         <nav className="flex items-center">
           <LinkButton href="/tasks" variant="ghost" size="sm">


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Expose the app version at build time and display it in the demo-web header and footer, with a link to the GitHub releases page.

## Changes

- Inject `NEXT_PUBLIC_APP_VERSION` from the root `package.json` during the demo-web CD workflow
- Show the app version badge in the header (links to releases)
- Add a footer “vX.Y.Z Releases” link when the version is available

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #