### PR TITLE
feat(demo-web): improve failed-task UX with dismissible error dialog and timeline failure state

### DIFF
--- a/apps/demo-web/src/app/process/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/process/[taskId]/page.tsx
@@ -30,6 +30,7 @@ export default function ProcessPage({ params }: PageProps) {
   const searchParams = useSearchParams();
   const deleteTaskMutation = useDeleteTask();
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [errorDialogDismissed, setErrorDialogDismissed] = useState(false);
   const disableAutoNavigate = searchParams.get('stay') === 'true';
 
   const { data: task } = useTask(taskId);
@@ -82,8 +83,10 @@ export default function ProcessPage({ params }: PageProps) {
         <ProcessInfoCard />
 
         <ProcessErrorDialog
-          open={status === 'failed'}
-          onOpenChange={() => {}}
+          open={status === 'failed' && !errorDialogDismissed}
+          onOpenChange={(open) => {
+            if (!open) setErrorDialogDismissed(true);
+          }}
           error={error}
         />
 

--- a/apps/demo-web/src/app/process/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/process/[taskId]/page.tsx
@@ -10,6 +10,7 @@ import { Progress } from '~/components/ui/progress';
 import {
   LogViewer,
   ProcessErrorAlert,
+  ProcessErrorDialog,
   ProcessHeader,
   ProcessInfoCard,
   ProcessTimeline,
@@ -68,13 +69,23 @@ export default function ProcessPage({ params }: PageProps) {
         <ProcessErrorAlert error={error} />
         <div className="flex flex-col gap-6 lg:flex-row">
           <div className="w-full lg:w-2/5">
-            <ProcessTimeline currentStep={currentStep} progress={progress} />
+            <ProcessTimeline
+              currentStep={currentStep}
+              progress={progress}
+              status={status}
+            />
           </div>
           <div className="w-full lg:w-3/5">
             <LogViewer logs={logs} />
           </div>
         </div>
         <ProcessInfoCard />
+
+        <ProcessErrorDialog
+          open={status === 'failed'}
+          onOpenChange={() => {}}
+          error={error}
+        />
 
         <ConfirmDialog
           open={showCancelDialog}

--- a/apps/demo-web/src/features/process/components/process-error-dialog.tsx
+++ b/apps/demo-web/src/features/process/components/process-error-dialog.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { AlertTriangle, Construction, ExternalLink, Info } from 'lucide-react';
+import Link from 'next/link';
+
+import { Button } from '~/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui/dialog';
+import { KNOWN_LIMITATIONS } from '~/features/upload/constants/known-limitations';
+import { useBrowserLanguage } from '~/features/upload/hooks/use-browser-language';
+
+const GITHUB_ISSUES_URL = 'https://github.com/heripo-lab/heripo-engine/issues';
+
+interface ProcessErrorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  error?: { code: string; message: string };
+}
+
+export function ProcessErrorDialog({
+  open,
+  onOpenChange,
+  error,
+}: ProcessErrorDialogProps) {
+  const lang = useBrowserLanguage();
+
+  const technicalLimitations = KNOWN_LIMITATIONS.filter(
+    (l) => l.id !== 'automation-scope',
+  );
+  const automationScope = KNOWN_LIMITATIONS.find(
+    (l) => l.id === 'automation-scope',
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-red-600">
+            <AlertTriangle className="h-5 w-5" />
+            {lang === 'ko' ? '처리 실패' : 'Processing Failed'}
+          </DialogTitle>
+          <DialogDescription>
+            {lang === 'ko'
+              ? '문서 처리 중 오류가 발생했습니다.'
+              : 'An error occurred during document processing.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Error Message */}
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            <strong>Error:</strong> {error.message}
+          </div>
+        )}
+
+        {/* Known Limitations */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Construction className="h-4 w-4 text-amber-500" />
+            {lang === 'ko' ? '알려진 제한사항' : 'Known Limitations'}
+          </div>
+          <ul className="space-y-2 text-sm text-amber-700">
+            {technicalLimitations.map((limitation) => (
+              <li key={limitation.id} className="flex items-start gap-2">
+                <Construction className="mt-0.5 h-4 w-4 shrink-0" />
+                <span>
+                  <strong>
+                    {lang === 'ko' ? limitation.titleKo : limitation.titleEn}:
+                  </strong>{' '}
+                  {lang === 'ko'
+                    ? limitation.descriptionKo
+                    : limitation.descriptionEn}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          {automationScope && (
+            <div className="flex items-start gap-2 border-t border-amber-200 pt-3">
+              <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <div>
+                <p className="text-sm font-medium text-amber-800">
+                  {lang === 'ko'
+                    ? automationScope.titleKo
+                    : automationScope.titleEn}
+                </p>
+                <div className="mt-1 space-y-1 text-sm leading-relaxed text-amber-700">
+                  {(lang === 'ko'
+                    ? automationScope.descriptionKo
+                    : automationScope.descriptionEn
+                  )
+                    .split('\n')
+                    .map((paragraph, index) => (
+                      <p key={index}>{paragraph}</p>
+                    ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Demo Notice */}
+        <div className="bg-muted/50 rounded-md border p-3 text-sm">
+          {lang === 'ko' ? (
+            <>
+              <p>
+                이 서비스는 완성된 소프트웨어가 아닌 <strong>데모</strong>
+                이며, 지속 개선 중인 살아있는 오픈소스 프로젝트입니다.
+              </p>
+              <p className="mt-2">
+                문제가 지속되거나 개선이 필요하다고 느끼시면{' '}
+                <a
+                  href={GITHUB_ISSUES_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 font-medium text-blue-600 underline underline-offset-4 hover:text-blue-800"
+                >
+                  GitHub Issues
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+                에 남겨주세요.
+              </p>
+            </>
+          ) : (
+            <>
+              <p>
+                This is a <strong>demo</strong>, not a finished product. It is a
+                living open-source project under continuous improvement.
+              </p>
+              <p className="mt-2">
+                If the issue persists or you have suggestions, please report it
+                on{' '}
+                <a
+                  href={GITHUB_ISSUES_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 font-medium text-blue-600 underline underline-offset-4 hover:text-blue-800"
+                >
+                  GitHub Issues
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+                .
+              </p>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button asChild>
+            <Link href="/tasks">
+              {lang === 'ko' ? '작업 목록으로' : 'Go to Tasks'}
+            </Link>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/demo-web/src/features/process/index.ts
+++ b/apps/demo-web/src/features/process/index.ts
@@ -1,6 +1,7 @@
 // Components
 export { LogViewer } from './components/log-viewer';
 export { ProcessErrorAlert } from './components/process-error-alert';
+export { ProcessErrorDialog } from './components/process-error-dialog';
 export { ProcessHeader } from './components/process-header';
 export { ProcessInfoCard } from './components/process-info-card';
 export { ProcessTimeline } from './components/process-timeline';

--- a/apps/demo-web/src/features/tasks/components/task-list-table.tsx
+++ b/apps/demo-web/src/features/tasks/components/task-list-table.tsx
@@ -124,7 +124,11 @@ export function TaskListTable() {
   const handleRowClick = (task: Task) => {
     if (task.status === 'completed') {
       router.push(`/result/${task.id}`);
-    } else if (task.status === 'running' || task.status === 'queued') {
+    } else if (
+      task.status === 'running' ||
+      task.status === 'queued' ||
+      task.status === 'failed'
+    ) {
       router.push(`/process/${task.id}`);
     }
   };

--- a/apps/demo-web/src/features/upload/constants/known-limitations.ts
+++ b/apps/demo-web/src/features/upload/constants/known-limitations.ts
@@ -63,7 +63,7 @@ export const KNOWN_LIMITATIONS: KnownLimitation[] = [
     titleEn: 'Automation Scope',
     descriptionKo:
       '이 엔진은 완전 자동화를 지향하지 않습니다. 기존에 100% 수동으로만 가능했던 작업을 90% 자동화하는 것에 목표와 의의를 둡니다.\n' +
-      '페이지 맵핑과 목차 추출은 이 파이프라인의 근간이며, 보고서 형식이 매우 다양해 100%에 가까운 자동화가 불가능합니다. 보편적인 패턴에 집중하며 최적의 지점에서 개선을 멈춥니다. 직접 보기에도 구조 파악이 어려운 보고서라면 자동 처리가 실패하는 것이 정상입니다.\n' +
+      '페이지 매핑과 목차 추출은 이 파이프라인의 근간이며, 보고서 형식이 매우 다양해 100%에 가까운 자동화가 불가능합니다. 보편적인 패턴에 집중하며 최적의 지점에서 개선을 멈춥니다. 직접 보기에도 구조 파악이 어려운 보고서라면 자동 처리가 실패하는 것이 정상입니다.\n' +
       '이후 단계(유구·유물 추출 등)에서는 100%에 가까운 자동화를 지향합니다. 이 데모에서 실패하는 특이 케이스는 플랫폼 서비스에서 하이브리드 방식(필요 시 수동 입력)으로 대응할 예정입니다.',
     descriptionEn:
       'This engine does not aim for full automation. Our goal is to automate 90% of work that previously required 100% manual effort.\n' +


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [x] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Improve the UX for failed processing tasks by adding a user-friendly error dialog, reflecting failure state in the processing timeline, and ensuring navigation routes failed tasks to the processing view. Also fixes a minor typo in the known limitations copy.

## Changes

- Add a processing-failed dialog that surfaces error details, known limitations, and a clear path back to the task list / issue reporting.
- Update the timeline to visually mark the active step as failed when the task fails.
- Route failed tasks from the task list to the processing page (instead of leaving them without a clear destination).
- Make the error dialog dismissible and prevent it from re-opening automatically after dismissal.
- Fix a typo in known limitations text.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #