### PR TITLE
feat(demo-web): prevent max listeners error during large file uploads

### DIFF
--- a/apps/demo-web/src/app/api/upload/complete/route.ts
+++ b/apps/demo-web/src/app/api/upload/complete/route.ts
@@ -39,6 +39,10 @@ async function mergeChunks(
   const uploadPaths = paths.upload(uploadId);
   const writeStream = createWriteStream(outputPath);
 
+  // Each pipeline() call adds an error listener to the writeStream.
+  // For files with many chunks, this exceeds the default limit of 10.
+  writeStream.setMaxListeners(totalChunks + 1);
+
   try {
     for (let i = 0; i < totalChunks; i++) {
       const chunkPath = uploadPaths.chunk(i);


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Prevent “MaxListenersExceededWarning” during large multipart uploads by adjusting the writable stream’s max listener limit based on the number of chunks.

## Changes

- Set the write stream max listeners to `totalChunks + 1` to avoid exceeding Node.js’s default listener limit when merging many chunks via repeated `pipeline()` calls.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #