### PR TITLE
feat(document-processor): harden TOC extraction to cover more excavation report formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "turbo build",
+    "build:force": "turbo build --force",
     "demo-web:dev": "pnpm --filter @heripo/demo-web dev",
     "demo-web:build": "pnpm --filter @heripo/demo-web build",
     "demo-web:start": "pnpm --filter @heripo/demo-web start",

--- a/packages/document-processor/src/document-processor.test.ts
+++ b/packages/document-processor/src/document-processor.test.ts
@@ -264,15 +264,17 @@ describe('DocumentProcessor', () => {
           (processor as any).tocExtractor = {
             extract: vi.fn().mockResolvedValue({
               entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-              usage: {
-                component: 'TocExtractor',
-                phase: 'extraction',
-                model: 'primary',
-                modelName: 'test-model',
-                inputTokens: 100,
-                outputTokens: 50,
-                totalTokens: 150,
-              },
+              usages: [
+                {
+                  component: 'TocExtractor',
+                  phase: 'extraction',
+                  model: 'primary',
+                  modelName: 'test-model',
+                  inputTokens: 100,
+                  outputTokens: 50,
+                  totalTokens: 150,
+                },
+              ],
             }),
           };
           (processor as any).visionTocExtractor = {
@@ -1487,15 +1489,17 @@ describe('DocumentProcessor', () => {
       const mockTocExtractor = {
         extract: vi.fn().mockResolvedValue({
           entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 
@@ -1616,15 +1620,17 @@ describe('DocumentProcessor', () => {
       const mockTocExtractor = {
         extract: vi.fn().mockResolvedValue({
           entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 
@@ -1732,15 +1738,17 @@ describe('DocumentProcessor', () => {
             { title: '제1장 서론', level: 1, pageNo: 1 },
             { title: '제2장 조사개요', level: 1, pageNo: 5 },
           ],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 
@@ -1861,15 +1869,17 @@ describe('DocumentProcessor', () => {
       const mockTocExtractor = {
         extract: vi.fn().mockResolvedValue({
           entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 
@@ -2118,15 +2128,17 @@ describe('DocumentProcessor', () => {
       const mockTocExtractor = {
         extract: vi.fn().mockResolvedValue({
           entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 
@@ -2269,15 +2281,17 @@ describe('DocumentProcessor', () => {
       const mockTocExtractor = {
         extract: vi.fn().mockResolvedValue({
           entries: [],
-          usage: {
-            component: 'TocExtractor',
-            phase: 'extraction',
-            model: 'primary',
-            modelName: 'test-model',
-            inputTokens: 100,
-            outputTokens: 50,
-            totalTokens: 150,
-          },
+          usages: [
+            {
+              component: 'TocExtractor',
+              phase: 'extraction',
+              model: 'primary',
+              modelName: 'test-model',
+              inputTokens: 100,
+              outputTokens: 50,
+              totalTokens: 150,
+            },
+          ],
         }),
       };
 

--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -661,8 +661,10 @@ export class DocumentProcessor {
       totalPages,
     });
 
-    // Track token usage
-    this.usageAggregator.track(tocResult.usage);
+    // Track token usage (initial extraction + any correction retries)
+    for (const usage of tocResult.usages) {
+      this.usageAggregator.track(usage);
+    }
 
     if (tocResult.entries.length === 0) {
       const reason =

--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -656,7 +656,10 @@ export class DocumentProcessor {
     }
 
     // Stage 5: Extract structure with LLM (with fallback retry)
-    const tocResult = await this.tocExtractor!.extract(markdown);
+    const totalPages = Object.keys(doclingDoc.pages).length;
+    const tocResult = await this.tocExtractor!.extract(markdown, {
+      totalPages,
+    });
 
     // Track token usage
     this.usageAggregator.track(tocResult.usage);

--- a/packages/document-processor/src/extractors/toc-extractor.test.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.test.ts
@@ -23,10 +23,11 @@ vi.mock('./toc-validator');
 
 describe('TocEntrySchema', () => {
   test('validates valid TOC entry structure', () => {
-    const validEntry: TocEntry = {
+    const validEntry = {
       title: 'Chapter 1',
       level: 1,
       pageNo: 1,
+      children: [],
     };
 
     const result = TocEntrySchema.safeParse(validEntry);
@@ -44,8 +45,8 @@ describe('TocEntrySchema', () => {
       level: 1,
       pageNo: 1,
       children: [
-        { title: 'Section 1.1', level: 2, pageNo: 3 },
-        { title: 'Section 1.2', level: 2, pageNo: 5 },
+        { title: 'Section 1.1', level: 2, pageNo: 3, children: [] },
+        { title: 'Section 1.2', level: 2, pageNo: 5, children: [] },
       ],
     };
 
@@ -67,7 +68,9 @@ describe('TocEntrySchema', () => {
           title: 'Chapter 1',
           level: 2,
           pageNo: 2,
-          children: [{ title: 'Section 1.1', level: 3, pageNo: 3 }],
+          children: [
+            { title: 'Section 1.1', level: 3, pageNo: 3, children: [] },
+          ],
         },
       ],
     };
@@ -81,6 +84,7 @@ describe('TocEntrySchema', () => {
       title: 'Chapter 1',
       level: 0,
       pageNo: 1,
+      children: [],
     };
 
     const result = TocEntrySchema.safeParse(invalidEntry);
@@ -92,6 +96,7 @@ describe('TocEntrySchema', () => {
       title: 'Chapter 1',
       level: 1,
       pageNo: 0,
+      children: [],
     };
 
     const result = TocEntrySchema.safeParse(invalidEntry);
@@ -112,8 +117,8 @@ describe('TocResponseSchema', () => {
   test('validates valid TOC response', () => {
     const validResponse = {
       entries: [
-        { title: 'Chapter 1', level: 1, pageNo: 1 },
-        { title: 'Chapter 2', level: 1, pageNo: 10 },
+        { title: 'Chapter 1', level: 1, pageNo: 1, children: [] },
+        { title: 'Chapter 2', level: 1, pageNo: 10, children: [] },
       ],
     };
 

--- a/packages/document-processor/src/extractors/toc-extractor.test.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.test.ts
@@ -12,6 +12,7 @@ import {
   TocExtractor,
   TocResponseSchema,
 } from './toc-extractor';
+import { TocValidator } from './toc-validator';
 
 vi.mock('@heripo/shared', () => ({
   LLMCaller: {
@@ -142,9 +143,38 @@ describe('TocExtractor', () => {
   let mockModel: LanguageModel;
   let mockLLMCaller: ReturnType<typeof vi.fn>;
 
+  const makeLLMResult = (
+    entries: TocEntry[],
+    phase = 'extraction',
+    inputTokens = 100,
+    outputTokens = 50,
+  ) => ({
+    output: { entries },
+    usage: {
+      component: 'TocExtractor',
+      phase,
+      model: 'primary',
+      modelName: 'test-model',
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    },
+    usedFallback: false,
+  });
+
   beforeEach(() => {
     mockLLMCaller = vi.mocked(LLMCaller.call);
     mockLLMCaller.mockClear();
+
+    // Default: TocValidator.validate() returns valid result
+    vi.mocked(TocValidator).mockImplementation(
+      () =>
+        ({
+          validate: vi
+            .fn()
+            .mockReturnValue({ valid: true, errorCount: 0, issues: [] }),
+        }) as any,
+    );
 
     mockLogger = {
       info: vi.fn(),
@@ -163,26 +193,14 @@ describe('TocExtractor', () => {
   });
 
   describe('extract', () => {
-    test('returns entries and usage for simple flat TOC', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            { title: 'Chapter 1', level: 1, pageNo: 1 },
-            { title: 'Chapter 2', level: 1, pageNo: 10 },
-            { title: 'Chapter 3', level: 1, pageNo: 20 },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+    test('returns entries and usages for simple flat TOC', async () => {
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          { title: 'Chapter 1', level: 1, pageNo: 1 },
+          { title: 'Chapter 2', level: 1, pageNo: 10 },
+          { title: 'Chapter 3', level: 1, pageNo: 20 },
+        ]),
+      );
 
       const markdown = `- Chapter 1 ..... 1
 - Chapter 2 ..... 10
@@ -196,40 +214,29 @@ describe('TocExtractor', () => {
       expect(result.entries[0].pageNo).toBe(1);
       expect(result.entries[1].title).toBe('Chapter 2');
       expect(result.entries[2].title).toBe('Chapter 3');
-      expect(result.usage.component).toBe('TocExtractor');
-      expect(result.usage.phase).toBe('extraction');
-      expect(result.usage.model).toBe('primary');
-      expect(result.usage.inputTokens).toBe(100);
+      expect(result.usages).toHaveLength(1);
+      expect(result.usages[0].component).toBe('TocExtractor');
+      expect(result.usages[0].phase).toBe('extraction');
+      expect(result.usages[0].model).toBe('primary');
+      expect(result.usages[0].inputTokens).toBe(100);
       expect(mockLLMCaller).toHaveBeenCalledTimes(1);
     });
 
-    test('returns entries and usage for nested TOC with children', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            {
-              title: 'Chapter 1',
-              level: 1,
-              pageNo: 1,
-              children: [
-                { title: 'Section 1.1', level: 2, pageNo: 3 },
-                { title: 'Section 1.2', level: 2, pageNo: 5 },
-              ],
-            },
-            { title: 'Chapter 2', level: 1, pageNo: 10 },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 200,
-          outputTokens: 100,
-          totalTokens: 300,
-        },
-        usedFallback: false,
-      });
+    test('returns entries and usages for nested TOC with children', async () => {
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          {
+            title: 'Chapter 1',
+            level: 1,
+            pageNo: 1,
+            children: [
+              { title: 'Section 1.1', level: 2, pageNo: 3 },
+              { title: 'Section 1.2', level: 2, pageNo: 5 },
+            ],
+          },
+          { title: 'Chapter 2', level: 1, pageNo: 10 },
+        ]),
+      );
 
       const markdown = `- Chapter 1 ..... 1
   - Section 1.1 ..... 3
@@ -242,32 +249,20 @@ describe('TocExtractor', () => {
       expect(result.entries[0].children).toHaveLength(2);
       expect(result.entries[0].children?.[0].title).toBe('Section 1.1');
       expect(result.entries[0].children?.[1].title).toBe('Section 1.2');
-      expect(result.usage.totalTokens).toBe(300);
+      expect(result.usages[0].totalTokens).toBe(150);
     });
 
     test('normalizes inconsistent levels to start from 1', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            {
-              title: 'Chapter 1',
-              level: 5,
-              pageNo: 1,
-              children: [{ title: 'Section 1.1', level: 10, pageNo: 3 }],
-            },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          {
+            title: 'Chapter 1',
+            level: 5,
+            pageNo: 1,
+            children: [{ title: 'Section 1.1', level: 10, pageNo: 3 }],
+          },
+        ]),
+      );
 
       const markdown = '- Chapter 1 ..... 1\n  - Section 1.1 ..... 3';
 
@@ -278,21 +273,9 @@ describe('TocExtractor', () => {
     });
 
     test('trims title whitespace', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: '  Chapter 1  ', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 50,
-          outputTokens: 25,
-          totalTokens: 75,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: '  Chapter 1  ', level: 1, pageNo: 1 }]),
+      );
 
       const markdown = '-   Chapter 1   ..... 1';
 
@@ -317,38 +300,26 @@ describe('TocExtractor', () => {
     });
 
     test('supports multi-level hierarchy (3+ levels)', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            {
-              title: 'Part 1',
-              level: 1,
-              pageNo: 1,
-              children: [
-                {
-                  title: 'Chapter 1',
-                  level: 2,
-                  pageNo: 2,
-                  children: [
-                    { title: 'Section 1.1', level: 3, pageNo: 3 },
-                    { title: 'Section 1.2', level: 3, pageNo: 4 },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 150,
-          outputTokens: 75,
-          totalTokens: 225,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          {
+            title: 'Part 1',
+            level: 1,
+            pageNo: 1,
+            children: [
+              {
+                title: 'Chapter 1',
+                level: 2,
+                pageNo: 2,
+                children: [
+                  { title: 'Section 1.1', level: 3, pageNo: 3 },
+                  { title: 'Section 1.2', level: 3, pageNo: 4 },
+                ],
+              },
+            ],
+          },
+        ]),
+      );
 
       const markdown = `- Part 1 ..... 1
   - Chapter 1 ..... 2
@@ -365,25 +336,13 @@ describe('TocExtractor', () => {
     });
 
     test('includes usage data with proper structure', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: { entries: [] },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(makeLLMResult([]));
 
       const result = await extractor.extract('- Chapter 1 ..... 1');
 
-      expect(result.usage.modelName).toBe('test-model');
-      expect(result.usage.component).toBe('TocExtractor');
-      expect(result.usage.phase).toBe('extraction');
+      expect(result.usages[0].modelName).toBe('test-model');
+      expect(result.usages[0].component).toBe('TocExtractor');
+      expect(result.usages[0].phase).toBe('extraction');
     });
   });
 
@@ -433,10 +392,6 @@ describe('TocExtractor', () => {
       await expect(
         extractorWithValidation.extract('- Chapter 1 ..... 1'),
       ).rejects.toThrow(TocValidationError);
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Validation failed'),
-      );
     });
   });
 
@@ -446,21 +401,9 @@ describe('TocExtractor', () => {
         skipValidation: false,
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
 
       const result = await extractorWithValidation.extract(
         '- Chapter 1 ..... 1',
@@ -543,28 +486,16 @@ describe('TocExtractor', () => {
 
   describe('normalizeLevel', () => {
     test('normalizes nested levels correctly', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            {
-              title: 'Chapter 1',
-              level: 10,
-              pageNo: 1,
-              children: [{ title: 'Section 1.1', level: 20, pageNo: 3 }],
-            },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          {
+            title: 'Chapter 1',
+            level: 10,
+            pageNo: 1,
+            children: [{ title: 'Section 1.1', level: 20, pageNo: 3 }],
+          },
+        ]),
+      );
 
       const result = await extractor.extract(
         '- Chapter 1 ..... 1\n  - Section 1.1 ..... 3',
@@ -575,24 +506,12 @@ describe('TocExtractor', () => {
     });
 
     test('handles entries without children', async () => {
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [
-            { title: 'Chapter 1', level: 1, pageNo: 1 },
-            { title: 'Chapter 2', level: 1, pageNo: 10 },
-          ],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          { title: 'Chapter 1', level: 1, pageNo: 1 },
+          { title: 'Chapter 2', level: 1, pageNo: 10 },
+        ]),
+      );
 
       const result = await extractor.extract(
         '- Chapter 1 ..... 1\n- Chapter 2 ..... 10',
@@ -609,21 +528,9 @@ describe('TocExtractor', () => {
         skipValidation: false,
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
 
       // This test verifies validation is called on non-empty entries
       const result = await extractorWithValidation.extract(
@@ -638,21 +545,9 @@ describe('TocExtractor', () => {
         skipValidation: true,
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
 
       const result = await extractorSkipValidation.extract(
         '- Chapter 1 ..... 1',
@@ -667,21 +562,9 @@ describe('TocExtractor', () => {
         skipValidation: false,
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
 
       const result = await extractorWithValidation.extract(
         '- Chapter 1 ..... 1',
@@ -696,21 +579,9 @@ describe('TocExtractor', () => {
         validation: { maxTitleLength: 100 },
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
 
       // Pass totalPages override - should merge with constructor validation options
       const result = await extractorWithValidation.extract(
@@ -727,27 +598,365 @@ describe('TocExtractor', () => {
         skipValidation: false,
       });
 
-      mockLLMCaller.mockResolvedValueOnce({
-        output: {
-          entries: [],
-        },
-        usage: {
-          component: 'TocExtractor',
-          phase: 'extraction',
-          model: 'primary',
-          modelName: 'test-model',
-          inputTokens: 100,
-          outputTokens: 50,
-          totalTokens: 150,
-        },
-        usedFallback: false,
-      });
+      mockLLMCaller.mockResolvedValueOnce(makeLLMResult([]));
 
       const result = await extractorWithValidation.extract(
         '- Invalid TOC format',
       );
 
       expect(result.entries).toHaveLength(0);
+    });
+  });
+
+  describe('validation-feedback retry', () => {
+    test('retries with correction feedback when validation fails then succeeds', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      // First call: initial extraction (bad result)
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([
+          { title: 'Chapter 1', level: 1, pageNo: 10 },
+          { title: 'Chapter 2', level: 1, pageNo: 5 }, // V001: page decrease
+        ]),
+      );
+
+      // Second call: correction (fixed result)
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult(
+          [
+            { title: 'Chapter 1', level: 1, pageNo: 5 },
+            { title: 'Chapter 2', level: 1, pageNo: 10 },
+          ],
+          'correction-1',
+          120,
+          60,
+        ),
+      );
+
+      // Make validator fail on first call, succeed on second
+      const mockValidate = vi.fn();
+      mockValidate
+        .mockReturnValueOnce({
+          valid: false,
+          errorCount: 1,
+          issues: [
+            {
+              code: 'V001',
+              message: 'Page number decreased from 10 to 5',
+              path: '[1]',
+              entry: { title: 'Chapter 2', level: 1, pageNo: 5 },
+            },
+          ],
+        })
+        .mockReturnValueOnce({ valid: true, errorCount: 0, issues: [] });
+
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      const result = await extractorWithValidation.extract('- some markdown');
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(2);
+      expect(result.usages).toHaveLength(2);
+      expect(result.usages[0].phase).toBe('extraction');
+      expect(result.usages[1].phase).toBe('correction-1');
+      expect(result.entries[0].pageNo).toBe(5);
+      expect(result.entries[1].pageNo).toBe(10);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed (attempt 1/3)'),
+      );
+    });
+
+    test('throws last TocValidationError after all retries fail', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      const badEntries = [
+        { title: 'Chapter 1', level: 1, pageNo: 10 },
+        { title: 'Chapter 2', level: 1, pageNo: 5 },
+      ];
+
+      // Initial + 3 retries = 4 LLM calls
+      mockLLMCaller
+        .mockResolvedValueOnce(makeLLMResult(badEntries))
+        .mockResolvedValueOnce(makeLLMResult(badEntries, 'correction-1'))
+        .mockResolvedValueOnce(makeLLMResult(badEntries, 'correction-2'))
+        .mockResolvedValueOnce(makeLLMResult(badEntries, 'correction-3'));
+
+      // Validator always fails
+      const mockValidate = vi.fn().mockReturnValue({
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V001',
+            message: 'Page number decreased from 10 to 5',
+            path: '[1]',
+            entry: { title: 'Chapter 2', level: 1, pageNo: 5 },
+          },
+        ],
+      });
+
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      await expect(
+        extractorWithValidation.extract('- some markdown'),
+      ).rejects.toThrow(TocValidationError);
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(4);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed after 3 retries'),
+      );
+    });
+
+    test('does not retry when skipValidation is true', async () => {
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
+
+      const result = await extractor.extract('- some markdown');
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(1);
+      expect(result.usages).toHaveLength(1);
+    });
+
+    test('does not retry when entries are empty', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      mockLLMCaller.mockResolvedValueOnce(makeLLMResult([]));
+
+      const result = await extractorWithValidation.extract('- some markdown');
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(1);
+      expect(result.usages).toHaveLength(1);
+      expect(result.entries).toHaveLength(0);
+    });
+
+    test('tracks usages from extraction and correction phases', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      mockLLMCaller
+        .mockResolvedValueOnce(
+          makeLLMResult(
+            [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+            'extraction',
+            100,
+            50,
+          ),
+        )
+        .mockResolvedValueOnce(
+          makeLLMResult(
+            [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+            'correction-1',
+            200,
+            100,
+          ),
+        );
+
+      const mockValidate = vi.fn();
+      mockValidate
+        .mockReturnValueOnce({
+          valid: false,
+          errorCount: 1,
+          issues: [
+            {
+              code: 'V003',
+              message: 'Title is empty',
+              path: '[0]',
+              entry: { title: '', level: 1, pageNo: 1 },
+            },
+          ],
+        })
+        .mockReturnValueOnce({ valid: true, errorCount: 0, issues: [] });
+
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      const result = await extractorWithValidation.extract('- some markdown');
+
+      expect(result.usages).toHaveLength(2);
+      expect(result.usages[0].inputTokens).toBe(100);
+      expect(result.usages[0].outputTokens).toBe(50);
+      expect(result.usages[1].inputTokens).toBe(200);
+      expect(result.usages[1].outputTokens).toBe(100);
+    });
+
+    test('throws TocParseError when LLM fails during correction retry', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      // Initial extraction succeeds
+      mockLLMCaller.mockResolvedValueOnce(
+        makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),
+      );
+      // Correction call fails
+      mockLLMCaller.mockRejectedValueOnce(new Error('LLM call failed'));
+
+      const mockValidate = vi.fn().mockReturnValue({
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V001',
+            message: 'Page order error',
+            path: '[0]',
+            entry: { title: 'Chapter 1', level: 1, pageNo: 1 },
+          },
+        ],
+      });
+
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      await expect(
+        extractorWithValidation.extract('- some markdown'),
+      ).rejects.toThrow(TocParseError);
+    });
+  });
+
+  describe('buildCorrectionPrompt', () => {
+    test('includes validation errors, original markdown, and previous entries', () => {
+      const ext = new TocExtractor(mockLogger, mockModel);
+      const markdown = '- Chapter 1 ..... 1';
+      const entries: TocEntry[] = [{ title: 'Chapter 1', level: 1, pageNo: 1 }];
+      const issues = [
+        {
+          code: 'V001',
+          message: 'Page number decreased from 10 to 5',
+          path: '[1]',
+          entry: { title: 'Chapter 2', level: 1, pageNo: 5 },
+        },
+      ];
+
+      const prompt = (ext as any).buildCorrectionPrompt(
+        markdown,
+        entries,
+        issues,
+      );
+
+      expect(prompt).toContain('[V001]');
+      expect(prompt).toContain('Page number decreased from 10 to 5');
+      expect(prompt).toContain(markdown);
+      expect(prompt).toContain(JSON.stringify(entries, null, 2));
+      expect(prompt).toContain('Hierarchy confusion');
+      expect(prompt).toContain('Page number misread');
+      expect(prompt).toContain('non-decreasing order');
+    });
+
+    test('includes error code descriptions for each issue', () => {
+      const ext = new TocExtractor(mockLogger, mockModel);
+      const issues = [
+        {
+          code: 'V005',
+          message: 'Child before parent',
+          path: '[0].children[0]',
+          entry: { title: 'Section 1', level: 2, pageNo: 1 },
+        },
+      ];
+
+      const prompt = (ext as any).buildCorrectionPrompt(
+        '- md',
+        [{ title: 'Chapter', level: 1, pageNo: 5 }],
+        issues,
+      );
+
+      expect(prompt).toContain(
+        'Child page number is before parent page number',
+      );
+    });
+
+    test('uses fallback description for unknown error codes', () => {
+      const ext = new TocExtractor(mockLogger, mockModel);
+      const issues = [
+        {
+          code: 'V999',
+          message: 'Some unknown error',
+          path: '[0]',
+          entry: { title: 'Chapter 1', level: 1, pageNo: 1 },
+        },
+      ];
+
+      const prompt = (ext as any).buildCorrectionPrompt(
+        '- md',
+        [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+        issues,
+      );
+
+      expect(prompt).toContain('Unknown validation error.');
+    });
+  });
+
+  describe('tryValidateEntries', () => {
+    test('returns null for empty entries', () => {
+      const ext = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      const result = (ext as any).tryValidateEntries([], {});
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null when validation passes', () => {
+      const ext = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      const mockValidate = vi
+        .fn()
+        .mockReturnValue({ valid: true, errorCount: 0, issues: [] });
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      const result = (ext as any).tryValidateEntries(
+        [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+        {},
+      );
+
+      expect(result).toBeNull();
+    });
+
+    test('returns TocValidationError when validation fails', () => {
+      const ext = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+      });
+
+      const mockValidate = vi.fn().mockReturnValue({
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V001',
+            message: 'Page order error',
+            path: '[0]',
+            entry: { title: 'Chapter 1', level: 1, pageNo: 1 },
+          },
+        ],
+      });
+      vi.mocked(TocValidator).mockImplementation(
+        () => ({ validate: mockValidate }) as any,
+      );
+
+      const result = (ext as any).tryValidateEntries(
+        [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+        {},
+      );
+
+      expect(result).toBeInstanceOf(TocValidationError);
+      expect(result.validationResult.errorCount).toBe(1);
     });
   });
 });

--- a/packages/document-processor/src/extractors/toc-extractor.test.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.test.ts
@@ -411,8 +411,18 @@ describe('TocExtractor', () => {
         skipValidation: false,
       });
 
-      // @ts-ignore
-      const validationError = new TocValidationError('Validation failed');
+      const validationError = new TocValidationError('Validation failed', {
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V003',
+            message: 'Title is empty or contains only whitespace',
+            path: '[0]',
+            entry: { title: '', level: 1, pageNo: 1 },
+          },
+        ],
+      });
       mockLLMCaller.mockRejectedValueOnce(validationError);
 
       await expect(

--- a/packages/document-processor/src/extractors/toc-extractor.test.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.test.ts
@@ -690,6 +690,38 @@ describe('TocExtractor', () => {
       expect(result.entries).toHaveLength(1);
     });
 
+    test('passes validation overrides to validator', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+        validation: { maxTitleLength: 100 },
+      });
+
+      mockLLMCaller.mockResolvedValueOnce({
+        output: {
+          entries: [{ title: 'Chapter 1', level: 1, pageNo: 1 }],
+        },
+        usage: {
+          component: 'TocExtractor',
+          phase: 'extraction',
+          model: 'primary',
+          modelName: 'test-model',
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+        },
+        usedFallback: false,
+      });
+
+      // Pass totalPages override - should merge with constructor validation options
+      const result = await extractorWithValidation.extract(
+        '- Chapter 1 ..... 1',
+        { totalPages: 200 },
+      );
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].title).toBe('Chapter 1');
+    });
+
     test('does not validate empty entries list', async () => {
       const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
         skipValidation: false,

--- a/packages/document-processor/src/extractors/toc-extractor.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.ts
@@ -85,12 +85,14 @@ export class TocExtractor extends TextLLMComponent {
    * Extract TOC structure from Markdown
    *
    * @param markdown - Markdown representation of TOC area
+   * @param validationOverrides - Optional overrides for validation options (merged with constructor options)
    * @returns Object with entries array and token usage information
    * @throws {TocParseError} When LLM fails to parse structure
    * @throws {TocValidationError} When validation fails
    */
   async extract(
     markdown: string,
+    validationOverrides?: Partial<TocValidationOptions>,
   ): Promise<{ entries: TocEntry[]; usage: ExtendedTokenUsage }> {
     this.log('info', `Starting TOC extraction (${markdown.length} chars)`);
 
@@ -113,7 +115,7 @@ export class TocExtractor extends TextLLMComponent {
 
       // Validate entries
       if (!this.skipValidation) {
-        this.validateEntries(entries);
+        this.validateEntries(entries, validationOverrides);
       }
 
       this.log(
@@ -142,12 +144,16 @@ export class TocExtractor extends TextLLMComponent {
    *
    * @throws {TocValidationError} When validation fails
    */
-  private validateEntries(entries: TocEntry[]): void {
+  private validateEntries(
+    entries: TocEntry[],
+    overrides?: Partial<TocValidationOptions>,
+  ): void {
     if (entries.length === 0) {
       return;
     }
 
-    const validator = new TocValidator(this.validationOptions);
+    const options = { ...this.validationOptions, ...overrides };
+    const validator = new TocValidator(options);
     validator.validateOrThrow(entries);
   }
 

--- a/packages/document-processor/src/extractors/toc-extractor.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.ts
@@ -123,7 +123,7 @@ export class TocExtractor extends TextLLMComponent {
     } catch (error) {
       // Re-throw TocValidationError as-is
       if (error instanceof TocValidationError) {
-        this.log('error', `Validation failed: ${error.message}`);
+        this.log('error', `Validation failed:\n${error.getSummary()}`);
         throw error;
       }
 

--- a/packages/document-processor/src/extractors/toc-extractor.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.ts
@@ -22,7 +22,9 @@ export const TocEntrySchema: z.ZodType<TocEntry> = z.lazy(() =>
     title: z.string().describe('Chapter or section title'),
     level: z.number().int().min(1).describe('Hierarchy depth (1 = top level)'),
     pageNo: z.number().int().min(1).describe('Starting page number'),
-    children: z.array(TocEntrySchema).optional().describe('Child sections'),
+    children: z
+      .array(TocEntrySchema)
+      .describe('Child sections (use empty array [] if none)'),
   }),
 );
 
@@ -165,11 +167,12 @@ export class TocExtractor extends TextLLMComponent {
    - Level 3: Subsections (e.g., "1.1.1", "a.", "(1)")
    - Use indentation and numbering patterns to infer level
 
-3. **Page Number**: Extract the page number from each entry. Convert Roman numerals to Arabic numerals if present (e.g., "iv" → 4).
+3. **Page Number**: Extract the page number from each entry. Use only Arabic numerals for page numbers.
 
 4. **Children**: Nest child entries under parent entries based on their hierarchy level.
 
-5. **IMPORTANT - Extract Main TOC Only**: Only extract the main document table of contents. EXCLUDE the following supplementary indices:
+5. **IMPORTANT - Extract Main TOC Only**: Only extract the main document table of contents. EXCLUDE the following:
+   - **Front matter with Roman numeral pages**: Entries whose page numbers are Roman numerals (i, ii, xxi, etc.) such as 일러두기, 발간사, 서문, 범례, Preface, Foreword, Editorial Notes. These use a separate page numbering system and are not part of the main content.
    - Photo/image indices (사진 목차, 사진목차, 화보 목차, Photo Index, List of Photos, List of Figures)
    - Drawing/diagram indices (도면 목차, 도면목차, 삽도 목차, Drawing Index, List of Drawings)
    - Table indices (표 목차, 표목차, Table Index, List of Tables)
@@ -196,11 +199,11 @@ Output:
       "level": 1,
       "pageNo": 1,
       "children": [
-        { "title": "1. 연구 배경", "level": 2, "pageNo": 3 },
-        { "title": "2. 연구 목적", "level": 2, "pageNo": 5 }
+        { "title": "1. 연구 배경", "level": 2, "pageNo": 3, "children": [] },
+        { "title": "2. 연구 목적", "level": 2, "pageNo": 5, "children": [] }
       ]
     },
-    { "title": "제2장 방법론", "level": 1, "pageNo": 10 }
+    { "title": "제2장 방법론", "level": 1, "pageNo": 10, "children": [] }
   ]
 }`;
   }

--- a/packages/document-processor/src/extractors/toc-finder.ts
+++ b/packages/document-processor/src/extractors/toc-finder.ts
@@ -337,6 +337,7 @@ export class TocFinder {
     doc: DoclingDocument,
   ): TocAreaResult {
     const itemRefs = [...initial.itemRefs];
+    const seenRefs = new Set<string>(itemRefs);
     let startPage = initial.startPage;
     let endPage = initial.endPage;
 
@@ -347,7 +348,11 @@ export class TocFinder {
         break;
       }
 
-      itemRefs.unshift(...continuationItems);
+      const newItems = continuationItems.filter((ref) => !seenRefs.has(ref));
+      for (const ref of newItems) {
+        seenRefs.add(ref);
+      }
+      itemRefs.unshift(...newItems);
       startPage = pageNo;
       this.logger.info(`[TocFinder] Expanded TOC backward to page ${pageNo}`);
     }
@@ -363,7 +368,11 @@ export class TocFinder {
         break;
       }
 
-      itemRefs.push(...continuationItems);
+      const newItems = continuationItems.filter((ref) => !seenRefs.has(ref));
+      for (const ref of newItems) {
+        seenRefs.add(ref);
+      }
+      itemRefs.push(...newItems);
       endPage = pageNo;
       this.logger.info(`[TocFinder] Expanded TOC forward to page ${pageNo}`);
     }

--- a/packages/document-processor/src/extractors/toc-validator.test.ts
+++ b/packages/document-processor/src/extractors/toc-validator.test.ts
@@ -440,5 +440,32 @@ describe('TocValidator', () => {
 
       expect(() => validator.validateOrThrow(entries)).toThrow(/2 error\(s\)/);
     });
+
+    test('error message contains detailed issue information', () => {
+      const entries: TocEntry[] = [
+        { title: '', level: 1, pageNo: 1 },
+        { title: 'Chapter 2', level: 1, pageNo: 30 },
+        { title: 'Chapter 1', level: 1, pageNo: 10 },
+      ];
+
+      try {
+        validator.validateOrThrow(entries);
+        expect.fail('Expected error to be thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TocValidationError);
+        const validationError = error as TocValidationError;
+        expect(validationError.message).toContain('[V003]');
+        expect(validationError.message).toContain(
+          'Title is empty or contains only whitespace',
+        );
+        expect(validationError.message).toContain('path: [0]');
+        expect(validationError.message).toContain('[V001]');
+        expect(validationError.message).toContain(
+          'Page number decreased from 30 to 10',
+        );
+        expect(validationError.message).toContain('path: [2]');
+        expect(validationError.message).toContain('entry: "Chapter 1" page 10');
+      }
+    });
   });
 });

--- a/packages/document-processor/src/extractors/toc-validator.ts
+++ b/packages/document-processor/src/extractors/toc-validator.ts
@@ -79,8 +79,14 @@ export class TocValidator {
     const result = this.validate(entries);
 
     if (!result.valid) {
+      const details = result.issues
+        .map(
+          (issue) =>
+            `  [${issue.code}] ${issue.message} (path: ${issue.path}, entry: "${issue.entry.title}" page ${issue.entry.pageNo})`,
+        )
+        .join('\n');
       throw new TocValidationError(
-        `TOC validation failed with ${result.errorCount} error(s)`,
+        `TOC validation failed with ${result.errorCount} error(s):\n${details}`,
         result,
       );
     }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR hardens the TOC extraction pipeline to better handle a wider variety of excavation report layouts and edge cases. It improves robustness by validating extracted TOC entries and automatically retrying extraction with targeted correction feedback when validation fails.

## Changes

- Strengthen TOC extraction by adding a validation-driven correction retry mechanism to recover from common extraction errors.
- Expand TOC detection/coverage across multi-page TOCs (including continuation handling) to capture more real-world excavation report structures.
- Refine TOC validation rules and error feedback to improve extraction quality and reduce incomplete/incorrect outputs.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #