### PR TITLE
chore: update Node.js version to >=24 in package files and CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "packageManager": "pnpm@10.30.1",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "pnpm": {
     "overrides": {

--- a/packages/document-processor/package.json
+++ b/packages/document-processor/package.json
@@ -45,7 +45,7 @@
     "archaeology"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -45,7 +45,7 @@
     "archaeology"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pdf-parser/package.json
+++ b/packages/pdf-parser/package.json
@@ -47,7 +47,7 @@
     "macos"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [x] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Update the project’s minimum supported Node.js version to **>= 24** and align CI to use **Node 24** to keep runtime requirements consistent across environments.

## Changes

- Bumped Node.js engine requirement from **>= 22** to **>= 24** across packages
- Updated CI to run with **Node 24**

## Breaking Changes

- [ ] None
- If any, describe migration steps:
  - Upgrade local/CI Node.js to **24+** (e.g., via your Node version manager) before running `pnpm install` and builds

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #