### PR TITLE
chore: Improve release publish script UX (interactive OTP, progress logging, error handling)

### DIFF
--- a/scripts/publish-all.mjs
+++ b/scripts/publish-all.mjs
@@ -138,10 +138,18 @@ const promptOtp = () =>
       input: process.stdin,
       output: process.stderr,
     });
-    rl.question('Enter OTP code: ', (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
+    const ask = () => {
+      rl.question('Enter OTP code: ', (answer) => {
+        const trimmed = answer.trim();
+        if (!trimmed) {
+          ask();
+          return;
+        }
+        rl.close();
+        resolve(trimmed);
+      });
+    };
+    ask();
   });
 
 const packAndPublish = async () => {
@@ -234,4 +242,7 @@ const main = async () => {
   console.log('Release publish complete.');
 };
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/publish-all.mjs
+++ b/scripts/publish-all.mjs
@@ -136,7 +136,7 @@ const promptOtp = () =>
   new Promise((resolve) => {
     const rl = createInterface({
       input: process.stdin,
-      output: process.stderr,
+      output: process.stdout,
     });
     const ask = () => {
       rl.question('Enter OTP code: ', (answer) => {
@@ -158,7 +158,9 @@ const packAndPublish = async () => {
   try {
     // Phase 1: pack all packages
     const tarballs = [];
-    for (const pkg of packages) {
+    for (let i = 0; i < packages.length; i++) {
+      const pkg = packages[i];
+      console.log(`Packing ${pkg.name} (${i + 1}/${packages.length})...`);
       const packOutput = runCapture('pnpm', [
         '-C',
         pkg.dir,
@@ -173,7 +175,11 @@ const packAndPublish = async () => {
     const otp = dryRun ? null : await promptOtp();
 
     // Phase 3: publish all packages
-    for (const tarball of tarballs) {
+    for (let i = 0; i < tarballs.length; i++) {
+      const tarball = tarballs[i];
+      console.log(
+        `Publishing ${packages[i].name} (${i + 1}/${packages.length})...`,
+      );
       const publishArgs = ['publish', tarball];
       if (distTag) {
         publishArgs.push('--tag', distTag);


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Improve the release/publish workflow by prompting for OTP interactively right before publishing, adding clearer progress output, and strengthening error handling for the publish script.

## Changes

- Replace `--otp` CLI argument usage with an interactive OTP prompt during the publish phase
- Add basic OTP validation (re-prompt on empty input)
- Log packing/publishing progress (current package out of total)
- Ensure failures are surfaced properly by catching errors and exiting with a non-zero code

## Breaking Changes

- [x] None
- If any, describe migration steps:
  - N/A

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #