### PR TITLE
fix(demo-web): redirect empty chapters to nearest content-filled sibling or descendant

### DIFF
--- a/apps/demo-web/src/features/result/components/chapter-content-card.tsx
+++ b/apps/demo-web/src/features/result/components/chapter-content-card.tsx
@@ -16,6 +16,7 @@ import {
   createImageLookupMap,
   createTableLookupMap,
   findChapterById,
+  findContentRedirectTarget,
 } from '~/features/result/utils/chapter-lookup';
 import {
   filterFootnoteIdsByPage,
@@ -75,6 +76,17 @@ export function ChapterContentCard({
     [chapters, selectedChapterId],
   );
 
+  // When the selected chapter is empty, resolve content from
+  // the first sibling/descendant with content on the same page (alias).
+  const contentChapter = useMemo(
+    () =>
+      selectedChapterId
+        ? (findContentRedirectTarget(chapters, selectedChapterId) ??
+          selectedChapter)
+        : selectedChapter,
+    [chapters, selectedChapterId, selectedChapter],
+  );
+
   const imageMap = useMemo(() => createImageLookupMap(images), [images]);
   const tableMap = useMemo(() => createTableLookupMap(tables), [tables]);
   const footnoteMap = useMemo(
@@ -82,41 +94,41 @@ export function ChapterContentCard({
     [footnotes],
   );
 
-  // Filter content by current page
+  // Filter content by current page (uses contentChapter which may alias to a sibling)
   const pageTextBlocks = useMemo(
     () =>
-      selectedChapter
-        ? filterTextBlocksByPage(selectedChapter.textBlocks, currentPage)
+      contentChapter
+        ? filterTextBlocksByPage(contentChapter.textBlocks, currentPage)
         : [],
-    [selectedChapter, currentPage],
+    [contentChapter, currentPage],
   );
 
   const pageImageIds = useMemo(
     () =>
-      selectedChapter
-        ? filterImageIdsByPage(selectedChapter.imageIds, imageMap, currentPage)
+      contentChapter
+        ? filterImageIdsByPage(contentChapter.imageIds, imageMap, currentPage)
         : [],
-    [selectedChapter, imageMap, currentPage],
+    [contentChapter, imageMap, currentPage],
   );
 
   const pageTableIds = useMemo(
     () =>
-      selectedChapter
-        ? filterTableIdsByPage(selectedChapter.tableIds, tableMap, currentPage)
+      contentChapter
+        ? filterTableIdsByPage(contentChapter.tableIds, tableMap, currentPage)
         : [],
-    [selectedChapter, tableMap, currentPage],
+    [contentChapter, tableMap, currentPage],
   );
 
   const pageFootnoteIds = useMemo(
     () =>
-      selectedChapter
+      contentChapter
         ? filterFootnoteIdsByPage(
-            selectedChapter.footnoteIds,
+            contentChapter.footnoteIds,
             footnoteMap,
             currentPage,
           )
         : [],
-    [selectedChapter, footnoteMap, currentPage],
+    [contentChapter, footnoteMap, currentPage],
   );
 
   const isPageEmpty =

--- a/apps/demo-web/src/features/result/hooks/use-page-navigation.ts
+++ b/apps/demo-web/src/features/result/hooks/use-page-navigation.ts
@@ -10,7 +10,10 @@ import type {
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useMemo } from 'react';
 
-import { findChapterById } from '../utils/chapter-lookup';
+import {
+  findChapterById,
+  findContentRedirectTarget,
+} from '../utils/chapter-lookup';
 import {
   findChapterForPage,
   getAllPdfPages,
@@ -79,7 +82,19 @@ export function usePageNavigation({
     if (currentChapterId) {
       const chapter = findChapterById(chapters, currentChapterId);
       if (chapter) {
-        const chapterPages = getChapterPdfPages(chapter);
+        let chapterPages = getChapterPdfPages(chapter);
+
+        // Empty chapter: use content redirect target's pages
+        if (chapterPages.length === 0) {
+          const redirectTarget = findContentRedirectTarget(
+            chapters,
+            currentChapterId,
+          );
+          if (redirectTarget) {
+            chapterPages = getChapterPdfPages(redirectTarget);
+          }
+        }
+
         if (chapterPages.length > 0) {
           return chapterPages[0];
         }

--- a/apps/demo-web/src/features/result/hooks/use-selected-chapter.ts
+++ b/apps/demo-web/src/features/result/hooks/use-selected-chapter.ts
@@ -5,7 +5,10 @@ import type { Chapter } from '@heripo/model';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback } from 'react';
 
-import { findChapterById } from '../utils/chapter-lookup';
+import {
+  findChapterById,
+  findContentRedirectTarget,
+} from '../utils/chapter-lookup';
 import { getChapterPdfPages } from '../utils/page-navigation-utils';
 
 const CHAPTER_PARAM_KEY = 'chapterId';
@@ -44,7 +47,16 @@ export function useSelectedChapter(
         if (chapters) {
           const chapter = findChapterById(chapters, id);
           if (chapter) {
-            const chapterPages = getChapterPdfPages(chapter);
+            let chapterPages = getChapterPdfPages(chapter);
+
+            // Empty chapter: use content redirect target's pages
+            if (chapterPages.length === 0) {
+              const redirectTarget = findContentRedirectTarget(chapters, id);
+              if (redirectTarget) {
+                chapterPages = getChapterPdfPages(redirectTarget);
+              }
+            }
+
             if (chapterPages.length > 0) {
               params.set(PAGE_PARAM_KEY, String(chapterPages[0]));
             } else {

--- a/apps/demo-web/src/features/result/utils/chapter-lookup.ts
+++ b/apps/demo-web/src/features/result/utils/chapter-lookup.ts
@@ -68,6 +68,87 @@ export function isChapterEmpty(chapter: Chapter): boolean {
 }
 
 /**
+ * Finds a chapter by ID and returns it along with its sibling list.
+ */
+function findChapterWithSiblings(
+  chapters: Chapter[],
+  id: string,
+): { chapter: Chapter; siblings: Chapter[] } | null {
+  for (const chapter of chapters) {
+    if (chapter.id === id) return { chapter, siblings: chapters };
+
+    if (chapter.children?.length) {
+      const found = findChapterWithSiblings(chapter.children, id);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Depth-first search for the first chapter with content on the target page.
+ */
+function findContentOnSamePage(
+  chapters: Chapter[],
+  targetPage: number,
+): Chapter | null {
+  for (const chapter of chapters) {
+    if (chapter.pageNo !== targetPage) continue;
+
+    if (!isChapterEmpty(chapter)) return chapter;
+
+    if (chapter.children?.length) {
+      const found = findContentOnSamePage(chapter.children, targetPage);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * For an empty chapter, finds the first chapter with content on the same page.
+ * Searches descendants first, then next siblings (and their descendants).
+ * Returns null if the chapter has content or no redirect target is found.
+ */
+export function findContentRedirectTarget(
+  chapters: Chapter[],
+  chapterId: string,
+): Chapter | null {
+  const context = findChapterWithSiblings(chapters, chapterId);
+  if (!context) return null;
+
+  const { chapter, siblings } = context;
+
+  if (!isChapterEmpty(chapter)) return null;
+
+  const targetPage = chapter.pageNo;
+
+  // Search descendants
+  if (chapter.children?.length) {
+    const descendant = findContentOnSamePage(chapter.children, targetPage);
+    if (descendant) return descendant;
+  }
+
+  // Search next siblings and their descendants
+  const index = siblings.indexOf(chapter);
+  for (let i = index + 1; i < siblings.length; i++) {
+    const sibling = siblings[i]!;
+    if (sibling.pageNo !== targetPage) continue;
+
+    if (!isChapterEmpty(sibling)) return sibling;
+
+    if (sibling.children?.length) {
+      const descendant = findContentOnSamePage(sibling.children, targetPage);
+      if (descendant) return descendant;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Resolves image IDs to actual items using a lookup map.
  * Filters out any IDs that don't exist in the map.
  */


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Empty chapters (those with no text blocks, images, tables, or footnotes) previously rendered blank content when selected in the TOC. This PR adds a content redirect mechanism that resolves the nearest sibling or descendant chapter with actual content on the same page, so users always see meaningful content.

## Changes

- Add `findContentRedirectTarget` utility in `chapter-lookup.ts` that searches descendants first, then next siblings (and their descendants) on the same page
- Add helper functions `findChapterWithSiblings` and `findContentOnSamePage` for recursive chapter tree traversal
- Update `chapter-content-card` to resolve a `contentChapter` alias when the selected chapter is empty, using it for text blocks, images, tables, and footnotes filtering
- Update `use-page-navigation` hook to fall back to the redirect target's pages when navigating to an empty chapter
- Update `use-selected-chapter` hook to resolve the redirect target's page when selecting an empty chapter via TOC

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
