### PR TITLE
feat(pdf-parser): upgrade docling-sdk to v2 with download fallback logic

### DIFF
--- a/packages/pdf-parser/package.json
+++ b/packages/pdf-parser/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@heripo/model": "workspace:*",
     "ai": "catalog:",
-    "docling-sdk": "^1.3.6",
+    "docling-sdk": "^2.0.4",
     "es-toolkit": "catalog:",
     "yauzl": "^3.2.0",
     "zod": "catalog:"

--- a/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
@@ -64,6 +64,7 @@ describe('PDFConverter.convertWithStrategy', () => {
     client = {
       convertSourceAsync: vi.fn(),
       getTaskResultFile: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
     } as unknown as DoclingAPIClient;
 
     converter = new PDFConverter(logger, client);

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -4,6 +4,7 @@ import type { Readable } from 'node:stream';
 
 import { omit } from 'es-toolkit';
 import { createWriteStream, existsSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -31,6 +32,10 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
   rmSync: vi.fn(),
   createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
@@ -745,7 +750,7 @@ describe('PDFConverter', () => {
   });
 
   describe('downloadResult', () => {
-    test('should download result file successfully', async () => {
+    test('should download via stream when fileStream is present', async () => {
       const mockTask = createMockTask();
       const mockFileStream = {} as Readable;
       const writeStream = { write: vi.fn(), end: vi.fn() };
@@ -778,32 +783,37 @@ describe('PDFConverter', () => {
       expect(pipeline).toHaveBeenCalledWith(mockFileStream, writeStream);
     });
 
-    test('should throw error when success is false', async () => {
+    test('should download via writeFile when data is present', async () => {
       const mockTask = createMockTask();
+      const mockData = new Uint8Array([1, 2, 3]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
       vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: false,
-      } as any);
+        success: true,
+        data: mockData,
+      });
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
 
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Failed to get ZIP file result');
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(writeFile).toHaveBeenCalledWith('/test/cwd/result.zip', mockData);
+      expect(createWriteStream).not.toHaveBeenCalled();
+      expect(pipeline).not.toHaveBeenCalled();
     });
 
-    test('should throw error when fileStream is missing', async () => {
+    test('should throw error when neither fileStream nor data is present', async () => {
       const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
       vi.mocked(client.getTaskResultFile).mockResolvedValue({
         success: true,
-        fileStream: undefined,
       } as any);
 
       await expect(

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -68,6 +68,7 @@ describe('PDFConverter', () => {
     client = {
       convertSourceAsync: vi.fn(),
       getTaskResultFile: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
     } as unknown as DoclingAPIClient;
 
     converter = new PDFConverter(logger, client);
@@ -808,13 +809,60 @@ describe('PDFConverter', () => {
       expect(pipeline).not.toHaveBeenCalled();
     });
 
-    test('should throw error when neither fileStream nor data is present', async () => {
+    test('should fallback to direct fetch when neither fileStream nor data is present', async () => {
+      const mockTask = createMockTask();
+      const mockZipData = new Uint8Array([80, 75, 3, 4]);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(client.getTaskResultFile).mockResolvedValue({
+        success: false,
+      } as any);
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(mockZipData.buffer),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report-fallback',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'http://localhost:5001/v1/result/task-123',
+        { headers: { Accept: 'application/zip' } },
+      );
+      expect(writeFile).toHaveBeenCalledWith(
+        '/test/cwd/result.zip',
+        expect.any(Uint8Array),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFConverter] SDK file result unavailable, falling back to direct download...',
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    test('should throw error when direct fetch fallback fails', async () => {
       const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
       vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
+        success: false,
       } as any);
+
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+      vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         converter.convert(
@@ -824,7 +872,9 @@ describe('PDFConverter', () => {
           false,
           {},
         ),
-      ).rejects.toThrow('Failed to get ZIP file result');
+      ).rejects.toThrow('Failed to download ZIP file: 404 Not Found');
+
+      vi.unstubAllGlobals();
     });
   });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -16,6 +16,7 @@ import {
   readFileSync,
   rmSync,
 } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
@@ -749,15 +750,19 @@ export class PDFConverter {
 
     const zipResult = await this.client.getTaskResultFile(taskId);
 
-    if (!zipResult.success || !zipResult.fileStream) {
+    const zipPath = join(process.cwd(), 'result.zip');
+    this.logger.info('[PDFConverter] Saving ZIP file to:', zipPath);
+
+    if (zipResult.fileStream) {
+      // Stream-based download (v1.x behavior)
+      const writeStream = createWriteStream(zipPath);
+      await pipeline(zipResult.fileStream, writeStream);
+    } else if (zipResult.data) {
+      // Buffer-based download (v2.x behavior)
+      await writeFile(zipPath, zipResult.data);
+    } else {
       throw new Error('Failed to get ZIP file result');
     }
-
-    const zipPath = join(process.cwd(), 'result.zip');
-
-    this.logger.info('[PDFConverter] Saving ZIP file to:', zipPath);
-    const writeStream = createWriteStream(zipPath);
-    await pipeline(zipResult.fileStream, writeStream);
   }
 
   private async processConvertedFiles(

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -754,15 +754,33 @@ export class PDFConverter {
     this.logger.info('[PDFConverter] Saving ZIP file to:', zipPath);
 
     if (zipResult.fileStream) {
-      // Stream-based download (v1.x behavior)
       const writeStream = createWriteStream(zipPath);
       await pipeline(zipResult.fileStream, writeStream);
-    } else if (zipResult.data) {
-      // Buffer-based download (v2.x behavior)
-      await writeFile(zipPath, zipResult.data);
-    } else {
-      throw new Error('Failed to get ZIP file result');
+      return;
     }
+
+    if (zipResult.data) {
+      await writeFile(zipPath, zipResult.data);
+      return;
+    }
+
+    // Fallback: direct HTTP download when SDK stream/data unavailable
+    this.logger.warn(
+      '[PDFConverter] SDK file result unavailable, falling back to direct download...',
+    );
+    const baseUrl = this.client.getConfig().baseUrl;
+    const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
+      headers: { Accept: 'application/zip' },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download ZIP file: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    await writeFile(zipPath, buffer);
   }
 
   private async processConvertedFiles(

--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -641,8 +641,9 @@ describe('PDFParser', () => {
       killSpy.mockResolvedValue(undefined);
 
       // First call fails with ECONNREFUSED, second succeeds
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertMock
         .mockRejectedValueOnce(econnRefusedError)
         .mockResolvedValueOnce('OK');
@@ -684,8 +685,9 @@ describe('PDFParser', () => {
       });
       doclingClient.health.mockResolvedValueOnce();
 
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertMock.mockRejectedValueOnce(econnRefusedError);
 
       const logger = makeLogger();
@@ -697,7 +699,7 @@ describe('PDFParser', () => {
         parser.parse('http://file.pdf', 'report-1', onComplete, false, {
           num_threads: 4,
         }),
-      ).rejects.toThrow('Connection refused');
+      ).rejects.toThrow('ECONNREFUSED');
 
       expect(logger.warn).not.toHaveBeenCalled();
     });
@@ -714,8 +716,9 @@ describe('PDFParser', () => {
       killSpy.mockResolvedValue(undefined);
 
       // Both calls fail with ECONNREFUSED
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertMock
         .mockRejectedValueOnce(econnRefusedError)
         .mockRejectedValueOnce(econnRefusedError);
@@ -738,7 +741,7 @@ describe('PDFParser', () => {
         parser.parse('http://file.pdf', 'report-1', onComplete, false, {
           num_threads: 4,
         }),
-      ).rejects.toThrow('Connection refused');
+      ).rejects.toThrow('ECONNREFUSED');
 
       expect(logger.warn).toHaveBeenCalledWith(
         '[PDFParser] Connection refused, attempting server recovery...',
@@ -794,6 +797,48 @@ describe('PDFParser', () => {
       ).rejects.toBe('string error');
 
       expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('parse recovers from ECONNREFUSED in error cause chain (ofetch style)', async () => {
+      vi.mocked(platform).mockReturnValue('darwin');
+      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
+        if (cmd.startsWith('sw_vers')) return '12.6.0';
+        if (cmd.startsWith('which jq')) return '';
+        return '';
+      });
+      doclingClient.health.mockResolvedValue(undefined);
+      const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
+      killSpy.mockResolvedValue(undefined);
+
+      // ofetch-style error: ECONNREFUSED in cause, not in main message
+      const causeError = new Error('connect ECONNREFUSED 127.0.0.1:5001');
+      const fetchError = new Error('fetch failed', { cause: causeError });
+      convertMock.mockRejectedValueOnce(fetchError).mockResolvedValueOnce('OK');
+
+      const startServerMock = vi.fn().mockResolvedValue(undefined);
+      (DoclingEnvironment as any).mockImplementation(function () {
+        return {
+          setup: envMocks.setupMock,
+          startServer: startServerMock,
+        };
+      });
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const result = await parser.parse(
+        'http://file.pdf',
+        'report-1',
+        vi.fn(),
+        false,
+        { num_threads: 4 },
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFParser] Connection refused, attempting server recovery...',
+      );
+      expect(result).toBe('OK');
     });
 
     test('parse throws immediately when abortSignal is already aborted', async () => {
@@ -965,8 +1010,9 @@ describe('PDFParser', () => {
       killSpy.mockResolvedValue(undefined);
 
       // First call fails with ECONNREFUSED, second succeeds
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertWithStrategyMock
         .mockRejectedValueOnce(econnRefusedError)
         .mockResolvedValueOnce({
@@ -1014,8 +1060,9 @@ describe('PDFParser', () => {
       });
       doclingClient.health.mockResolvedValueOnce();
 
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertWithStrategyMock.mockRejectedValueOnce(econnRefusedError);
 
       const logger = makeLogger();
@@ -1026,7 +1073,7 @@ describe('PDFParser', () => {
         parser.parse('http://file.pdf', 'report-1', vi.fn(), false, {
           forcedMethod: 'ocrmac',
         }),
-      ).rejects.toThrow('Connection refused');
+      ).rejects.toThrow('ECONNREFUSED');
 
       expect(logger.warn).not.toHaveBeenCalled();
     });
@@ -1076,8 +1123,9 @@ describe('PDFParser', () => {
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
-      const econnRefusedError = new Error('Connection refused');
-      (econnRefusedError as any).code = 'ECONNREFUSED';
+      const econnRefusedError = new Error(
+        'connect ECONNREFUSED 127.0.0.1:5001',
+      );
       convertWithStrategyMock
         .mockRejectedValueOnce(econnRefusedError)
         .mockRejectedValueOnce(econnRefusedError);
@@ -1098,7 +1146,7 @@ describe('PDFParser', () => {
         parser.parse('http://file.pdf', 'report-1', vi.fn(), false, {
           forcedMethod: 'ocrmac',
         }),
-      ).rejects.toThrow('Connection refused');
+      ).rejects.toThrow('ECONNREFUSED');
     });
 
     test('strategy flow passes enableImagePdfFallback=true for local server', async () => {

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -236,8 +236,16 @@ export class PDFParser {
    */
   private isConnectionRefusedError(error: unknown): boolean {
     if (error instanceof Error) {
-      const errorStr = JSON.stringify(error);
-      return errorStr.includes('ECONNREFUSED');
+      // Check message and cause chain for ECONNREFUSED
+      if (error.message.includes('ECONNREFUSED')) {
+        return true;
+      }
+      if (
+        error.cause instanceof Error &&
+        error.cause.message.includes('ECONNREFUSED')
+      ) {
+        return true;
+      }
     }
     return false;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: 'catalog:'
         version: 6.0.105(zod@4.3.6)
       docling-sdk:
-        specifier: ^1.3.6
-        version: 1.3.6(typescript@5.9.3)
+        specifier: ^2.0.4
+        version: 2.0.4(typescript@5.9.3)
       es-toolkit:
         specifier: 'catalog:'
         version: 1.44.0
@@ -2639,6 +2639,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -2646,13 +2649,22 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  docling-sdk@1.3.6:
-    resolution: {integrity: sha512-LcuWYh9VR0gecIC84z+kBDnrJcE+hXiJBO9iSO30froU0k5uynGcKIx2Hxz2k0uecf1JKcB5gQ8D35Gl2Wmo8w==}
+  docling-sdk@2.0.4:
+    resolution: {integrity: sha512-nQ4IWQCRSEIBAbhHTwY/oA4/6cBOhNvCnQfppffL+pGU4cK/8kcoN6J6QMLlfbep3pRv2HO4JAgkjjc0FXGF8g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@huggingface/transformers': '>=3.0.0'
+      onnxruntime-web: '>=1.18.0'
       typescript: '>=4.9.0'
+      unpdf: '>=0.12.0'
     peerDependenciesMeta:
+      '@huggingface/transformers':
+        optional: true
+      onnxruntime-web:
+        optional: true
       typescript:
+        optional: true
+      unpdf:
         optional: true
 
   eastasianwidth@0.2.0:
@@ -3081,6 +3093,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
@@ -3123,6 +3138,9 @@ packages:
     resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
     engines: {node: '>=6.0.0'}
 
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -3136,6 +3154,9 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5727,17 +5748,21 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  destr@2.0.5: {}
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
-  docling-sdk@1.3.6(typescript@5.9.3):
+  docling-sdk@2.0.4(typescript@5.9.3):
     dependencies:
-      archiver: 7.0.1
-      ws: 8.18.3
+      mitt: 3.0.1
+      ofetch: 1.5.1
       zod: 4.3.6
     optionalDependencies:
+      archiver: 7.0.1
       typescript: 5.9.3
+      ws: 8.18.3
     transitivePeerDependencies:
       - bare-abort-controller
       - bufferutil
@@ -6188,6 +6213,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -6234,6 +6261,8 @@ snapshots:
 
   node-cron@4.2.1: {}
 
+  node-fetch-native@1.6.7: {}
+
   node-releases@2.0.27: {}
 
   normalize-path@3.0.0: {}
@@ -6241,6 +6270,12 @@ snapshots:
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.1
 
   optionator@0.9.4:
     dependencies:
@@ -6868,7 +6903,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
-  ws@8.18.3: {}
+  ws@8.18.3:
+    optional: true
 
   yauzl@3.2.0:
     dependencies:


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Upgrade `docling-sdk` from v1.x to v2.0.4 and adapt `PDFConverter` to handle breaking changes in the SDK's file download API. Add a multi-tier fallback strategy for ZIP file downloads to improve resilience when the SDK response format varies.

## Changes

- Upgrade `docling-sdk` dependency to `^2.0.4`
- Support both stream-based (v1.x) and buffer-based (v2.x) ZIP file downloads in `PDFConverter.downloadResult`
- Add direct HTTP fetch fallback when SDK `getTaskResultFile` returns neither `fileStream` nor `data`
- Detect `ECONNREFUSED` errors from error message text instead of `error.code` to align with `ofetch` error format
- Handle nested `ECONNREFUSED` errors in the cause chain (ofetch-style wrapped errors)
- Update all related tests and mocks to reflect the new behavior

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

N/A