### PR TITLE
feat(pdf-parser): add ImageMagick-based page image rendering and enhance JSON image extraction

### DIFF
--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -3,7 +3,7 @@ import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
 import type { Readable } from 'node:stream';
 
 import { omit } from 'es-toolkit';
-import { createWriteStream, existsSync, rmSync } from 'node:fs';
+import { createWriteStream, existsSync, readFileSync, rmSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
+import { PageRenderer } from '../processors/page-renderer';
 import { LocalFileServer } from '../utils/local-file-server';
 import { ImagePdfConverter } from './image-pdf-converter';
 import { PDFConverter } from './pdf-converter';
@@ -30,6 +31,7 @@ vi.mock('../utils/local-file-server', () => ({
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
+  readFileSync: vi.fn(),
   rmSync: vi.fn(),
   createWriteStream: vi.fn(),
 }));
@@ -50,6 +52,10 @@ vi.mock('../processors/image-extractor', () => ({
   ImageExtractor: {
     extractAndSaveDocumentsFromZip: vi.fn(),
   },
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
 }));
 
 describe('PDFConverter', () => {
@@ -98,6 +104,15 @@ describe('PDFConverter', () => {
       return {
         convert: vi.fn().mockResolvedValue('/tmp/image.pdf'),
         cleanup: vi.fn(),
+      } as any;
+    });
+
+    // Mock PageRenderer (used by renderPageImages)
+    vi.mocked(PageRenderer).mockImplementation(function () {
+      return {
+        renderPages: vi
+          .fn()
+          .mockResolvedValue({ pageCount: 3, pagesDir: '', pageFiles: [] }),
       } as any;
     });
   });
@@ -149,6 +164,7 @@ describe('PDFConverter', () => {
             framework: 'livetext',
           },
           generate_picture_images: true,
+          generate_page_images: false,
           images_scale: 2.0,
           force_ocr: true,
           accelerator_options: {
@@ -189,6 +205,7 @@ describe('PDFConverter', () => {
           framework: 'livetext',
         },
         generate_picture_images: true,
+        generate_page_images: false,
         images_scale: 2.0,
         force_ocr: true,
         accelerator_options: {
@@ -1193,6 +1210,9 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
+      );
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1318,6 +1338,9 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
+      );
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1335,6 +1358,214 @@ describe('PDFConverter', () => {
     });
   });
 
+  describe('renderPageImages', () => {
+    test('should render page images and update result.json for file:// URLs', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+      const writeStream = { write: vi.fn(), end: vi.fn() };
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(client.getTaskResultFile).mockResolvedValue({
+        success: true,
+        fileStream: {} as Readable,
+      });
+      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const mockDoc = {
+        pages: {
+          '1': { page_no: 1, image: { uri: '', mimetype: '', dpi: 0 } },
+          '2': { page_no: 2, image: { uri: '', mimetype: '', dpi: 0 } },
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+
+      const mockRenderPages = vi
+        .fn()
+        .mockResolvedValue({ pageCount: 2, pagesDir: '', pageFiles: [] });
+      vi.mocked(PageRenderer).mockImplementation(function () {
+        return { renderPages: mockRenderPages } as any;
+      });
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report-render',
+        onComplete,
+        false,
+        {},
+      );
+
+      expect(mockRenderPages).toHaveBeenCalledWith(
+        '/test/doc.pdf',
+        '/test/cwd/output/report-render',
+      );
+
+      expect(writeFile).toHaveBeenCalledWith(
+        '/test/cwd/output/report-render/result.json',
+        expect.stringContaining('"pages/page_0.png"'),
+      );
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Rendered 2 page images',
+      );
+    });
+
+    test('should skip rendering and log warning for http:// URLs', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+      const writeStream = { write: vi.fn(), end: vi.fn() };
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(client.getTaskResultFile).mockResolvedValue({
+        success: true,
+        fileStream: {} as Readable,
+      });
+      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      vi.mocked(PageRenderer).mockClear();
+
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report-skip-render',
+        onComplete,
+        false,
+        {},
+      );
+
+      expect(PageRenderer).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
+      );
+    });
+
+    test('should update page image URIs with correct indices', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+      const writeStream = { write: vi.fn(), end: vi.fn() };
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(client.getTaskResultFile).mockResolvedValue({
+        success: true,
+        fileStream: {} as Readable,
+      });
+      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      const mockDoc = {
+        pages: {
+          '1': { page_no: 1, image: { uri: '', mimetype: '', dpi: 0 } },
+          '2': { page_no: 2, image: { uri: '', mimetype: '', dpi: 0 } },
+          '3': { page_no: 3, image: { uri: '', mimetype: '', dpi: 0 } },
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+
+      vi.mocked(PageRenderer).mockImplementation(function () {
+        return {
+          renderPages: vi
+            .fn()
+            .mockResolvedValue({ pageCount: 3, pagesDir: '', pageFiles: [] }),
+        } as any;
+      });
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report-uris',
+        onComplete,
+        false,
+        {},
+      );
+
+      const writeCall = vi
+        .mocked(writeFile)
+        .mock.calls.find(
+          (call) =>
+            typeof call[0] === 'string' && call[0].includes('result.json'),
+        );
+      expect(writeCall).toBeDefined();
+
+      const savedDoc = JSON.parse(writeCall![1] as string);
+      expect(savedDoc.pages['1'].image.uri).toBe('pages/page_0.png');
+      expect(savedDoc.pages['1'].image.mimetype).toBe('image/png');
+      expect(savedDoc.pages['1'].image.dpi).toBe(300);
+      expect(savedDoc.pages['2'].image.uri).toBe('pages/page_1.png');
+      expect(savedDoc.pages['3'].image.uri).toBe('pages/page_2.png');
+    });
+
+    test('should skip pages with page_no exceeding rendered page count', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+      const writeStream = { write: vi.fn(), end: vi.fn() };
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(client.getTaskResultFile).mockResolvedValue({
+        success: true,
+        fileStream: {} as Readable,
+      });
+      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      // Page 3 has page_no=3 but only 2 pages were rendered
+      const mockDoc = {
+        pages: {
+          '1': { page_no: 1, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
+          '2': { page_no: 2, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
+          '3': { page_no: 3, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
+        },
+      };
+      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+
+      vi.mocked(PageRenderer).mockImplementation(function () {
+        return {
+          renderPages: vi
+            .fn()
+            .mockResolvedValue({ pageCount: 2, pagesDir: '', pageFiles: [] }),
+        } as any;
+      });
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report-skip-excess',
+        onComplete,
+        false,
+        {},
+      );
+
+      const writeCall = vi
+        .mocked(writeFile)
+        .mock.calls.find(
+          (call) =>
+            typeof call[0] === 'string' && call[0].includes('result.json'),
+        );
+      expect(writeCall).toBeDefined();
+
+      const savedDoc = JSON.parse(writeCall![1] as string);
+      // Pages 1-2 should be updated
+      expect(savedDoc.pages['1'].image.uri).toBe('pages/page_0.png');
+      expect(savedDoc.pages['2'].image.uri).toBe('pages/page_1.png');
+      // Page 3 should remain unchanged (exceeds rendered count)
+      expect(savedDoc.pages['3'].image.uri).toBe('old');
+      expect(savedDoc.pages['3'].image.mimetype).toBe('old');
+    });
+  });
+
   describe('forceImagePdf', () => {
     test('should convert via image PDF when forceImagePdf is true', async () => {
       const mockTask = createMockTask();
@@ -1344,6 +1575,9 @@ describe('PDFConverter', () => {
         fileStream: {} as Readable,
       });
       vi.mocked(existsSync).mockReturnValue(false);
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
+      );
 
       await converter.convert(
         'http://test.com/doc.pdf',

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -49,6 +49,7 @@ export type PDFConvertOptions = Omit<
   | 'accelerator_options'
   | 'ocr_options'
   | 'generate_picture_images'
+  | 'generate_page_images'
   | 'images_scale'
   | 'force_ocr'
   | 'pipeline'
@@ -530,6 +531,9 @@ export class PDFConverter {
     try {
       await this.processConvertedFiles(zipPath, extractDir, outputDir);
 
+      // Render page images using ImageMagick (replaces Docling's page image generation)
+      await this.renderPageImages(url, outputDir);
+
       // Check abort before callback
       if (abortSignal?.aborted) {
         this.logger.info('[PDFConverter] Conversion aborted before callback');
@@ -596,6 +600,7 @@ export class PDFConverter {
         framework: 'livetext',
       },
       generate_picture_images: true,
+      generate_page_images: false, // Page images are rendered by PageRenderer (ImageMagick) after conversion
       images_scale: 2.0,
       /**
        * While disabling this option yields the most accurate text extraction for readable PDFs,
@@ -794,6 +799,50 @@ export class PDFConverter {
       zipPath,
       extractDir,
       outputDir,
+    );
+  }
+
+  /**
+   * Render page images from the source PDF using ImageMagick and update result.json.
+   * Replaces Docling's generate_page_images which fails on large PDFs
+   * due to memory limits when embedding all page images as base64.
+   */
+  private async renderPageImages(
+    url: string,
+    outputDir: string,
+  ): Promise<void> {
+    if (!url.startsWith('file://')) {
+      this.logger.warn(
+        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
+      );
+      return;
+    }
+
+    const pdfPath = url.slice(7);
+    this.logger.info(
+      '[PDFConverter] Rendering page images with ImageMagick...',
+    );
+
+    const renderer = new PageRenderer(this.logger);
+    const renderResult = await renderer.renderPages(pdfPath, outputDir);
+
+    // Update result.json with page image URIs
+    const resultPath = join(outputDir, 'result.json');
+    const doc = JSON.parse(readFileSync(resultPath, 'utf-8'));
+
+    for (const page of Object.values(doc.pages) as any[]) {
+      const pageNo = page.page_no as number;
+      const fileIndex = pageNo - 1;
+      if (fileIndex >= 0 && fileIndex < renderResult.pageCount) {
+        page.image.uri = `pages/page_${fileIndex}.png`;
+        page.image.mimetype = 'image/png';
+        page.image.dpi = 300;
+      }
+    }
+
+    await writeFile(resultPath, JSON.stringify(doc, null, 2));
+    this.logger.info(
+      `[PDFConverter] Rendered ${renderResult.pageCount} page images`,
     );
   }
 }

--- a/packages/pdf-parser/src/processors/image-extractor.test.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.test.ts
@@ -81,6 +81,16 @@ describe('ImageExtractor', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('Extracting ZIP file'),
       );
+
+      // Verify JSON images use 'images' directory and 'pic' prefix
+      expect(jqReplaceBase64WithPaths).toHaveBeenCalledWith(
+        expect.any(String),
+        'images',
+        'pic',
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining('picture images from JSON'),
+      );
     });
 
     test('should handle directory entries in zip', async () => {
@@ -507,6 +517,16 @@ describe('ImageExtractor', () => {
 
       expect(bufferFromSpy).toHaveBeenCalledWith('abc123', 'base64');
       expect(bufferFromSpy).toHaveBeenCalledWith('def456', 'base64');
+
+      // Verify images are saved to 'images' dir with 'pic' prefix
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_0.png'),
+        expect.any(Buffer),
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_1.png'),
+        expect.any(Buffer),
+      );
     });
 
     test('should handle zipfile error event', async () => {

--- a/packages/pdf-parser/src/processors/image-extractor.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.ts
@@ -170,29 +170,29 @@ export class ImageExtractor {
     // Save JSON with extracted images (using jq for large files)
     const jsonPath = join(outputDir, `${baseName}.json`);
     try {
-      // Create pages directory for JSON images
-      const pagesDir = join(outputDir, 'pages');
-      if (!existsSync(pagesDir)) {
-        mkdirSync(pagesDir, { recursive: true });
+      // Create images directory for picture images from JSON
+      const imagesDir = join(outputDir, 'images');
+      if (!existsSync(imagesDir)) {
+        mkdirSync(imagesDir, { recursive: true });
       }
 
       // Step 1: Extract base64 images using jq (doesn't load full JSON into memory)
       const base64Images =
         await ImageExtractor.extractBase64ImagesFromJsonWithJq(jsonSourcePath);
 
-      // Step 2: Save each image to file
+      // Step 2: Save each picture image to file
       base64Images.forEach((base64Data, index) => {
         ImageExtractor.extractBase64ImageToFile(
           base64Data,
-          pagesDir,
+          imagesDir,
           index,
-          'page',
-          'pages',
+          'pic',
+          'images',
         );
       });
 
       logger.info(
-        `[PDFConverter] Extracted ${base64Images.length} images from JSON to ${pagesDir}`,
+        `[PDFConverter] Extracted ${base64Images.length} picture images from JSON to ${imagesDir}`,
       );
 
       // Step 3: Replace base64 images with file paths using jq
@@ -200,8 +200,8 @@ export class ImageExtractor {
         await ImageExtractor.replaceBase64ImagesInJsonWithJq(
           jsonSourcePath,
           jsonPath,
-          'pages',
-          'page',
+          'images',
+          'pic',
         );
 
       logger.info(


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Replace Docling's built-in `generate_page_images` with an ImageMagick-based `PageRenderer` to avoid memory issues on large PDFs caused by base64-embedded page images. Also reorganize JSON-extracted picture images into a dedicated `images/` directory with a `pic` prefix to distinguish them from page images.

## Changes

- Add `renderPageImages` private method to `PDFConverter` that renders page images via `PageRenderer` (ImageMagick) for local `file://` URLs and updates `result.json` with page image URIs
- Disable Docling's `generate_page_images` option (`false`) since page images are now rendered externally after conversion
- Update `ImageExtractor` to save JSON-extracted picture images in `images/` directory with `pic` prefix (previously used `pages/` directory with `page` prefix)
- Add comprehensive tests for page image rendering, URI updates, excess page skipping, and non-local URL handling
- Add test assertions for the new image directory and prefix in `ImageExtractor`

## Breaking Changes

- [x] None
- If any, describe migration steps:

Output directory structure changed:
- Page images: now rendered by ImageMagick into `pages/page_N.png` (referenced in `result.json`)
- Picture images from JSON: moved from `pages/page_N.png` to `images/pic_N.png`

Consumers relying on the previous `pages/` directory for picture images need to update their paths to `images/pic_N.png`.

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
