### PR TITLE
feat(pdf-parser): add BCP 47 language normalization and frequency-based language aggregation

### DIFF
--- a/packages/model/src/bcp47-language-tag.ts
+++ b/packages/model/src/bcp47-language-tag.ts
@@ -1,0 +1,196 @@
+/**
+ * BCP 47 language tags supported by Docling OCR engines.
+ * Covers major languages encountered in archaeological report processing.
+ */
+export const BCP47_LANGUAGE_TAGS = [
+  'af-ZA',
+  'am-ET',
+  'ar-SA',
+  'as-IN',
+  'az-AZ',
+  'be-BY',
+  'bg-BG',
+  'bn-IN',
+  'bs-BA',
+  'ca-ES',
+  'cs-CZ',
+  'cy-GB',
+  'da-DK',
+  'de-DE',
+  'el-GR',
+  'en-US',
+  'es-ES',
+  'et-EE',
+  'eu-ES',
+  'fa-IR',
+  'fi-FI',
+  'fr-FR',
+  'ga-IE',
+  'gl-ES',
+  'gu-IN',
+  'he-IL',
+  'hi-IN',
+  'hr-HR',
+  'hu-HU',
+  'hy-AM',
+  'id-ID',
+  'is-IS',
+  'it-IT',
+  'ja-JP',
+  'ka-GE',
+  'kk-KZ',
+  'km-KH',
+  'kn-IN',
+  'ko-KR',
+  'lo-LA',
+  'lt-LT',
+  'lv-LV',
+  'mk-MK',
+  'ml-IN',
+  'mn-MN',
+  'mr-IN',
+  'ms-MY',
+  'my-MM',
+  'ne-NP',
+  'nl-NL',
+  'no-NO',
+  'or-IN',
+  'pa-IN',
+  'pl-PL',
+  'pt-BR',
+  'pt-PT',
+  'ro-RO',
+  'ru-RU',
+  'si-LK',
+  'sk-SK',
+  'sl-SI',
+  'sq-AL',
+  'sr-RS',
+  'sv-SE',
+  'sw-KE',
+  'ta-IN',
+  'te-IN',
+  'th-TH',
+  'tr-TR',
+  'uk-UA',
+  'ur-PK',
+  'uz-UZ',
+  'vi-VN',
+  'zh-CN',
+  'zh-Hant',
+  'zh-TW',
+] as const;
+
+/** Union type of all supported BCP 47 language tags */
+export type Bcp47LanguageTag = (typeof BCP47_LANGUAGE_TAGS)[number];
+
+/** Set for O(1) lookup of valid BCP 47 tags */
+export const BCP47_LANGUAGE_TAG_SET: ReadonlySet<string> = new Set(
+  BCP47_LANGUAGE_TAGS,
+);
+
+/** Check whether a string is a valid BCP 47 language tag */
+export function isValidBcp47Tag(tag: string): tag is Bcp47LanguageTag {
+  return BCP47_LANGUAGE_TAG_SET.has(tag);
+}
+
+/**
+ * Maps bare language codes to their default BCP 47 tag.
+ * Used when VLM returns only a language code without a region subtag.
+ */
+const DEFAULT_REGION_MAP: Record<string, Bcp47LanguageTag> = {
+  af: 'af-ZA',
+  am: 'am-ET',
+  ar: 'ar-SA',
+  as: 'as-IN',
+  az: 'az-AZ',
+  be: 'be-BY',
+  bg: 'bg-BG',
+  bn: 'bn-IN',
+  bs: 'bs-BA',
+  ca: 'ca-ES',
+  cs: 'cs-CZ',
+  cy: 'cy-GB',
+  da: 'da-DK',
+  de: 'de-DE',
+  el: 'el-GR',
+  en: 'en-US',
+  es: 'es-ES',
+  et: 'et-EE',
+  eu: 'eu-ES',
+  fa: 'fa-IR',
+  fi: 'fi-FI',
+  fr: 'fr-FR',
+  ga: 'ga-IE',
+  gl: 'gl-ES',
+  gu: 'gu-IN',
+  he: 'he-IL',
+  hi: 'hi-IN',
+  hr: 'hr-HR',
+  hu: 'hu-HU',
+  hy: 'hy-AM',
+  id: 'id-ID',
+  is: 'is-IS',
+  it: 'it-IT',
+  ja: 'ja-JP',
+  ka: 'ka-GE',
+  kk: 'kk-KZ',
+  km: 'km-KH',
+  kn: 'kn-IN',
+  ko: 'ko-KR',
+  lo: 'lo-LA',
+  lt: 'lt-LT',
+  lv: 'lv-LV',
+  mk: 'mk-MK',
+  ml: 'ml-IN',
+  mn: 'mn-MN',
+  mr: 'mr-IN',
+  ms: 'ms-MY',
+  my: 'my-MM',
+  ne: 'ne-NP',
+  nl: 'nl-NL',
+  no: 'no-NO',
+  or: 'or-IN',
+  pa: 'pa-IN',
+  pl: 'pl-PL',
+  pt: 'pt-BR',
+  ro: 'ro-RO',
+  ru: 'ru-RU',
+  si: 'si-LK',
+  sk: 'sk-SK',
+  sl: 'sl-SI',
+  sq: 'sq-AL',
+  sr: 'sr-RS',
+  sv: 'sv-SE',
+  sw: 'sw-KE',
+  ta: 'ta-IN',
+  te: 'te-IN',
+  th: 'th-TH',
+  tr: 'tr-TR',
+  uk: 'uk-UA',
+  ur: 'ur-PK',
+  uz: 'uz-UZ',
+  vi: 'vi-VN',
+  zh: 'zh-CN',
+};
+
+/**
+ * Normalize a language string to a valid BCP 47 tag.
+ *
+ * - If the input is already a valid full tag (e.g. "en-US"), return it as-is.
+ * - If it is a bare language code (e.g. "en", "ko"), map it to the default region.
+ * - Otherwise return null (e.g. "und", "unknown", empty string).
+ */
+export function normalizeToBcp47(tag: string): Bcp47LanguageTag | null {
+  if (isValidBcp47Tag(tag)) {
+    return tag;
+  }
+
+  const lower = tag.toLowerCase();
+  const mapped = DEFAULT_REGION_MAP[lower];
+  if (mapped) {
+    return mapped;
+  }
+
+  return null;
+}

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,3 +1,10 @@
+export type * from './bcp47-language-tag';
+export {
+  BCP47_LANGUAGE_TAGS,
+  BCP47_LANGUAGE_TAG_SET,
+  isValidBcp47Tag,
+  normalizeToBcp47,
+} from './bcp47-language-tag';
 export type * from './docling-document';
 export type * from './processed-document';
 export type * from './token-usage-report';

--- a/packages/model/src/ocr-strategy.ts
+++ b/packages/model/src/ocr-strategy.ts
@@ -1,3 +1,5 @@
+import type { Bcp47LanguageTag } from './bcp47-language-tag';
+
 /**
  * Result of the OCR strategy sampling phase.
  * Determines whether to use ocrmac (standard Docling pipeline)
@@ -10,8 +12,8 @@ export interface OcrStrategy {
   /** OCR language weights for ocrmac (e.g., ['ko-KR', 'en-US'] or ['zh-Hant', 'ko-KR']) */
   ocrLanguages?: string[];
 
-  /** BCP 47 language tags detected during sampling (e.g., ['ko-KR', 'en-US']) */
-  detectedLanguages?: string[];
+  /** BCP 47 language tags detected during sampling, ordered by frequency (e.g., ['ko-KR', 'en-US']) */
+  detectedLanguages?: Bcp47LanguageTag[];
 
   /** Human-readable explanation of the decision */
   reason: string;

--- a/packages/pdf-parser/src/samplers/ocr-strategy-sampler.test.ts
+++ b/packages/pdf-parser/src/samplers/ocr-strategy-sampler.test.ts
@@ -776,7 +776,105 @@ describe('OcrStrategySampler', () => {
       expect(result.detectedLanguages).toEqual(['en-US']);
     });
 
-    test('uses last sampled page languages when no Korean-Hanja mix', async () => {
+    test('aggregates languages by frequency across all sampled pages', async () => {
+      mockPageRenderer = createMockPageRenderer(20);
+      sampler = new OcrStrategySampler(
+        mockLogger,
+        mockPageRenderer as any,
+        mockTextExtractor as any,
+      );
+
+      // 14 pages return ko-KR, 1 page returns en-US
+      for (let i = 0; i < 14; i++) {
+        mockCallVision.mockResolvedValueOnce(
+          createMockKoreanHanjaMixResult(false, ['ko-KR']),
+        );
+      }
+      mockCallVision.mockResolvedValueOnce(
+        createMockKoreanHanjaMixResult(false, ['en-US']),
+      );
+
+      const result = await sampler.sample(
+        '/tmp/test.pdf',
+        '/tmp/output',
+        mockModel,
+      );
+
+      // ko-KR should come first (14 occurrences vs 1 for en-US)
+      expect(result.detectedLanguages).toEqual(['ko-KR', 'en-US']);
+    });
+
+    test('filters out invalid language tags like und', async () => {
+      mockPageRenderer = createMockPageRenderer(3);
+      sampler = new OcrStrategySampler(
+        mockLogger,
+        mockPageRenderer as any,
+        mockTextExtractor as any,
+      );
+
+      mockCallVision
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['en-US']))
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['en-US']))
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['und']));
+
+      const result = await sampler.sample(
+        '/tmp/test.pdf',
+        '/tmp/output',
+        mockModel,
+      );
+
+      // und should be filtered out, only en-US remains
+      expect(result.detectedLanguages).toEqual(['en-US']);
+    });
+
+    test('normalizes bare language codes to BCP 47 tags', async () => {
+      mockPageRenderer = createMockPageRenderer(3);
+      sampler = new OcrStrategySampler(
+        mockLogger,
+        mockPageRenderer as any,
+        mockTextExtractor as any,
+      );
+
+      mockCallVision
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['en']))
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko']))
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['en']));
+
+      const result = await sampler.sample(
+        '/tmp/test.pdf',
+        '/tmp/output',
+        mockModel,
+      );
+
+      // en → en-US (2 times), ko → ko-KR (1 time)
+      expect(result.detectedLanguages).toEqual(['en-US', 'ko-KR']);
+    });
+
+    test('returns undefined detectedLanguages when all pages return invalid tags', async () => {
+      mockPageRenderer = createMockPageRenderer(3);
+      sampler = new OcrStrategySampler(
+        mockLogger,
+        mockPageRenderer as any,
+        mockTextExtractor as any,
+      );
+
+      mockCallVision
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['und']))
+        .mockResolvedValueOnce(
+          createMockKoreanHanjaMixResult(false, ['unknown']),
+        )
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['und']));
+
+      const result = await sampler.sample(
+        '/tmp/test.pdf',
+        '/tmp/output',
+        mockModel,
+      );
+
+      expect(result.detectedLanguages).toBeUndefined();
+    });
+
+    test('aggregates languages on early exit (Korean-Hanja mix detected)', async () => {
       mockPageRenderer = createMockPageRenderer(20);
       sampler = new OcrStrategySampler(
         mockLogger,
@@ -785,23 +883,10 @@ describe('OcrStrategySampler', () => {
       );
 
       mockCallVision
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
-        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(false, ['ko-KR']))
         .mockResolvedValueOnce(
-          createMockKoreanHanjaMixResult(false, ['en-US']),
-        );
+          createMockKoreanHanjaMixResult(false, ['ko-KR', 'en-US']),
+        )
+        .mockResolvedValueOnce(createMockKoreanHanjaMixResult(true, ['ko-KR']));
 
       const result = await sampler.sample(
         '/tmp/test.pdf',
@@ -809,7 +894,9 @@ describe('OcrStrategySampler', () => {
         mockModel,
       );
 
-      expect(result.detectedLanguages).toEqual(['en-US']);
+      expect(result.method).toBe('vlm');
+      // ko-KR appears on both pages (2 times), en-US on first page (1 time)
+      expect(result.detectedLanguages).toEqual(['ko-KR', 'en-US']);
     });
 
     test('detectedLanguages is undefined when no pages found', async () => {

--- a/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
+++ b/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
@@ -1,10 +1,11 @@
 import type { LoggerMethods } from '@heripo/logger';
-import type { OcrStrategy } from '@heripo/model';
+import type { Bcp47LanguageTag, OcrStrategy } from '@heripo/model';
 import type { LLMTokenUsageAggregator } from '@heripo/shared';
 import type { LanguageModel } from 'ai';
 
 import type { PageRenderer } from '../processors/page-renderer';
 
+import { normalizeToBcp47 } from '@heripo/model';
 import { LLMCaller } from '@heripo/shared';
 import { readFileSync } from 'node:fs';
 import { z } from 'zod/v4';
@@ -151,7 +152,7 @@ export class OcrStrategySampler {
 
     // Step 4: Check each sample page for Korean-Hanja mix (early exit on detection)
     let sampledCount = 0;
-    let detectedLanguages: string[] | undefined;
+    const languageFrequency = new Map<Bcp47LanguageTag, number>();
     for (const idx of sampleIndices) {
       sampledCount++;
       const pageFile = renderResult.pageFiles[idx];
@@ -162,12 +163,15 @@ export class OcrStrategySampler {
         options,
       );
 
-      detectedLanguages = pageAnalysis.detectedLanguages;
+      for (const lang of pageAnalysis.detectedLanguages) {
+        languageFrequency.set(lang, (languageFrequency.get(lang) ?? 0) + 1);
+      }
 
       if (pageAnalysis.hasKoreanHanjaMix) {
         this.logger.info(
           `[OcrStrategySampler] Korean-Hanja mix detected on page ${idx + 1} → VLM strategy`,
         );
+        const detectedLanguages = this.aggregateLanguages(languageFrequency);
         return {
           method: 'vlm',
           detectedLanguages,
@@ -182,6 +186,7 @@ export class OcrStrategySampler {
     this.logger.info(
       '[OcrStrategySampler] No Korean-Hanja mix detected → ocrmac strategy',
     );
+    const detectedLanguages = this.aggregateLanguages(languageFrequency);
     return {
       method: 'ocrmac',
       detectedLanguages,
@@ -307,15 +312,19 @@ export class OcrStrategySampler {
 
   /**
    * Analyze a single sample page for Korean-Hanja mixed script and primary language.
+   * Normalizes raw VLM language responses to valid BCP 47 tags, filtering out invalid ones.
    *
-   * @returns Object with Korean-Hanja detection result and detected languages
+   * @returns Object with Korean-Hanja detection result and normalized detected languages
    */
   private async analyzeSamplePage(
     pageFile: string,
     pageNo: number,
     model: LanguageModel,
     options?: OcrStrategySamplerOptions,
-  ): Promise<{ hasKoreanHanjaMix: boolean; detectedLanguages: string[] }> {
+  ): Promise<{
+    hasKoreanHanjaMix: boolean;
+    detectedLanguages: Bcp47LanguageTag[];
+  }> {
     this.logger.debug(
       `[OcrStrategySampler] Analyzing page ${pageNo} for Korean-Hanja mix and language...`,
     );
@@ -356,13 +365,31 @@ export class OcrStrategySampler {
       detectedLanguages: string[];
     };
 
+    const normalizedLanguages = output.detectedLanguages
+      .map(normalizeToBcp47)
+      .filter((tag): tag is Bcp47LanguageTag => tag !== null);
+
     this.logger.debug(
-      `[OcrStrategySampler] Page ${pageNo}: hasKoreanHanjaMix=${output.hasKoreanHanjaMix}, detectedLanguages=${output.detectedLanguages.join(',')}`,
+      `[OcrStrategySampler] Page ${pageNo}: hasKoreanHanjaMix=${output.hasKoreanHanjaMix}, detectedLanguages=${normalizedLanguages.join(',')}`,
     );
 
     return {
       hasKoreanHanjaMix: output.hasKoreanHanjaMix,
-      detectedLanguages: output.detectedLanguages,
+      detectedLanguages: normalizedLanguages,
     };
+  }
+
+  /**
+   * Aggregate language frequency map into a sorted array.
+   * Returns languages sorted by frequency (descending), or undefined if empty.
+   */
+  private aggregateLanguages(
+    frequencyMap: Map<Bcp47LanguageTag, number>,
+  ): Bcp47LanguageTag[] | undefined {
+    if (frequencyMap.size === 0) return undefined;
+
+    return [...frequencyMap.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([lang]) => lang);
   }
 }


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [x] `@heripo/model`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Enhance OCR sampling reliability by normalizing VLM-detected language tags to valid BCP 47 format and aggregating language detections by frequency across all sampled pages instead of using only the last page's result.

## Changes

- Add `bcp47-language-tag.ts` in `@heripo/model` with a comprehensive list of supported BCP 47 tags, validation, and normalization utilities (`isValidBcp47Tag`, `normalizeToBcp47`)
- Export BCP 47 types and functions from `@heripo/model` public API
- Update `OcrStrategy.detectedLanguages` type from `string[]` to `Bcp47LanguageTag[]`
- Normalize raw VLM language responses in `analyzeSamplePage`, filtering out invalid tags (e.g., `und`, `unknown`)
- Replace last-page-wins language detection with frequency-based aggregation across all sampled pages using `aggregateLanguages`
- Ensure language aggregation works correctly on early exit (Korean-Hanja mix detected)
- Add/update tests for: frequency aggregation, invalid tag filtering, bare code normalization, all-invalid fallback, and early exit aggregation

## Breaking Changes

- [ ] None
- If any, describe migration steps:

The `OcrStrategy.detectedLanguages` type changed from `string[]` to `Bcp47LanguageTag[]`. This is a stricter type but remains compatible at runtime since all values were already BCP 47 strings.

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
