### PR TITLE
feat(pdf-parser): add poppler as required dependency for PDF text extraction and page counting

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -155,6 +155,7 @@ heripo-engine/
 - **pnpm** >= 9.0.0
 - **Python** 3.9 - 3.12 (⚠️ Python 3.13+는 지원하지 않음)
 - **jq** (JSON 처리 도구)
+- **poppler** (PDF 텍스트 추출 도구)
 
 ```bash
 # Python 3.11 설치 (권장)
@@ -162,6 +163,9 @@ brew install python@3.11
 
 # jq 설치
 brew install jq
+
+# poppler 설치
+brew install poppler
 
 # Node.js 및 pnpm 설치
 brew install node

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ For detailed architecture explanation, see [docs/architecture.md](./docs/archite
 - **pnpm** >= 9.0.0
 - **Python** 3.9 - 3.12 (⚠️ Python 3.13+ is not supported)
 - **jq** (JSON processing tool)
+- **poppler** (PDF text extraction tools)
 
 ```bash
 # Install Python 3.11 (recommended)
@@ -162,6 +163,9 @@ brew install python@3.11
 
 # Install jq
 brew install jq
+
+# Install poppler
+brew install poppler
 
 # Install Node.js and pnpm
 brew install node

--- a/packages/pdf-parser/README.ko.md
+++ b/packages/pdf-parser/README.ko.md
@@ -72,7 +72,7 @@ python3.11 --version
 
 #### 4. poppler (PDF 텍스트 추출)
 
-OCR 전략 시스템의 텍스트 레이어 사전 검사(`pdftotext`)에 필요합니다.
+PDF 페이지 수 확인(`pdfinfo`)과 텍스트 레이어 추출(`pdftotext`)에 필요하며, OCR 전략 시스템의 텍스트 레이어 사전 검사에 사용됩니다.
 
 ```bash
 brew install poppler
@@ -281,12 +281,12 @@ const outputPath = await pdfParser.parse(
 
 `@heripo/pdf-parser`는 다음 시스템 레벨 의존성이 필요합니다:
 
-| 의존성  | 필수 버전  | 설치 방법                  | 용도                                      |
-| ------- | ---------- | -------------------------- | ----------------------------------------- |
-| Python  | 3.9 - 3.12 | `brew install python@3.11` | Docling SDK 실행 환경                     |
-| poppler | Any        | `brew install poppler`     | OCR 전략용 텍스트 레이어 추출 (pdftotext) |
-| jq      | Any        | `brew install jq`          | JSON 처리 (변환 결과 파싱)                |
-| lsof    | Any        | macOS 기본 설치됨          | docling-serve 포트 관리                   |
+| 의존성  | 필수 버전  | 설치 방법                  | 용도                                                           |
+| ------- | ---------- | -------------------------- | -------------------------------------------------------------- |
+| Python  | 3.9 - 3.12 | `brew install python@3.11` | Docling SDK 실행 환경                                          |
+| poppler | Any        | `brew install poppler`     | PDF 페이지 수 확인 (pdfinfo) 및 텍스트 레이어 추출 (pdftotext) |
+| jq      | Any        | `brew install jq`          | JSON 처리 (변환 결과 파싱)                                     |
+| lsof    | Any        | macOS 기본 설치됨          | docling-serve 포트 관리                                        |
 
 > ⚠️ **Python 3.13+는 지원하지 않습니다.** Docling SDK의 일부 의존성이 Python 3.13과 호환되지 않습니다.
 
@@ -409,6 +409,16 @@ const pdfParser = new PDFParser({
 
 ```bash
 brew install jq
+```
+
+### poppler를 찾을 수 없음
+
+**증상**: `poppler is not installed. Please install poppler using: brew install poppler`
+
+**해결**:
+
+```bash
+brew install poppler
 ```
 
 ### 포트 충돌

--- a/packages/pdf-parser/README.md
+++ b/packages/pdf-parser/README.md
@@ -72,7 +72,7 @@ python3.11 --version
 
 #### 4. poppler (PDF text extraction)
 
-Required for the OCR strategy system's text layer pre-check (`pdftotext`).
+Required for PDF page counting (`pdfinfo`) and text layer extraction (`pdftotext`), used by the OCR strategy system's text layer pre-check.
 
 ```bash
 brew install poppler
@@ -281,12 +281,12 @@ Archaeological excavation report PDFs have the following characteristics:
 
 `@heripo/pdf-parser` requires the following system-level dependencies:
 
-| Dependency | Required Version | Installation               | Purpose                                            |
-| ---------- | ---------------- | -------------------------- | -------------------------------------------------- |
-| Python     | 3.9 - 3.12       | `brew install python@3.11` | Docling SDK runtime                                |
-| poppler    | Any              | `brew install poppler`     | Text layer extraction for OCR strategy (pdftotext) |
-| jq         | Any              | `brew install jq`          | JSON processing (conversion result parsing)        |
-| lsof       | Any              | Included with macOS        | docling-serve port management                      |
+| Dependency | Required Version | Installation               | Purpose                                                           |
+| ---------- | ---------------- | -------------------------- | ----------------------------------------------------------------- |
+| Python     | 3.9 - 3.12       | `brew install python@3.11` | Docling SDK runtime                                               |
+| poppler    | Any              | `brew install poppler`     | PDF page counting (pdfinfo) and text layer extraction (pdftotext) |
+| jq         | Any              | `brew install jq`          | JSON processing (conversion result parsing)                       |
+| lsof       | Any              | Included with macOS        | docling-serve port management                                     |
 
 > ⚠️ **Python 3.13+ is not supported.** Some Docling SDK dependencies are not compatible with Python 3.13.
 
@@ -409,6 +409,16 @@ const pdfParser = new PDFParser({
 
 ```bash
 brew install jq
+```
+
+### poppler Not Found
+
+**Symptom**: `poppler is not installed. Please install poppler using: brew install poppler`
+
+**Solution**:
+
+```bash
+brew install poppler
 ```
 
 ### Port Conflict

--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -192,6 +192,20 @@ describe('PDFParser', () => {
     );
   });
 
+  test('throws when poppler is not installed', async () => {
+    vi.mocked(platform).mockReturnValue('darwin');
+    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
+      if (cmd.startsWith('which jq')) return '';
+      if (cmd.startsWith('which pdftotext')) throw new Error('not found');
+      return '';
+    });
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
+    await expect(parser.init()).rejects.toThrow(
+      'poppler is not installed. Please install poppler using: brew install poppler',
+    );
+  });
+
   test('throws when macOS version is below 10.15', async () => {
     vi.mocked(platform).mockReturnValue('darwin');
     vi.mocked(execSync as any).mockImplementation((cmd: string) => {

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -44,6 +44,8 @@ type Options = {
  *   - Install specific version: `pyenv install 3.12.0 && pyenv global 3.12.0`
  * - `jq` - JSON processor
  *   - Install: `brew install jq`
+ * - `poppler` - PDF text extraction tools (pdftotext, pdfinfo)
+ *   - Install: `brew install poppler`
  * - `lsof` - List open files (usually pre-installed on macOS)
  *
  * ## Initialization Process
@@ -119,6 +121,7 @@ export class PDFParser {
 
     this.checkOperatingSystem();
     this.checkJqInstalled();
+    this.checkPopplerInstalled();
     this.checkMacOSVersion();
 
     // Check ImageMagick/Ghostscript only for local server mode with fallback enabled
@@ -181,6 +184,16 @@ export class PDFParser {
     } catch {
       throw new Error(
         'jq is not installed. Please install jq using: brew install jq',
+      );
+    }
+  }
+
+  private checkPopplerInstalled(): void {
+    try {
+      execSync('which pdftotext', { stdio: 'ignore' });
+    } catch {
+      throw new Error(
+        'poppler is not installed. Please install poppler using: brew install poppler',
       );
     }
   }


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [x] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Add `poppler` (providing `pdftotext` and `pdfinfo`) as a required system dependency for `@heripo/pdf-parser`. This enables PDF page count verification via `pdfinfo` in addition to the existing text layer extraction via `pdftotext`.

## Changes

- Add `checkPopplerInstalled()` validation in `PDFParser.init()` that checks for `pdftotext` availability
- Update root `README.md` and `README.ko.md` to list poppler as a prerequisite with install instructions
- Update `packages/pdf-parser/README.md` and `README.ko.md`:
  - Revise poppler description to include both `pdfinfo` (page counting) and `pdftotext` (text extraction)
  - Update the system dependencies table with expanded purpose description
  - Add "poppler Not Found" troubleshooting section
- Add JSDoc entry for poppler in `PDFParser` class documentation
- Add test case for poppler-not-installed error scenario

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

N/A
