### PR TITLE
feat(pdf-parser): replace in-memory JSON processing with jq for improved memory efficiency

### DIFF
--- a/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
@@ -2,25 +2,30 @@ import type { LoggerMethods } from '@heripo/logger';
 import type { DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { copyFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { copyFileSync, existsSync, rmSync } from 'node:fs';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
+import { runJqFileJson } from '../utils/jq';
 import { PDFConverter } from './pdf-converter';
 
 vi.mock('node:fs', () => ({
   copyFileSync: vi.fn(),
   existsSync: vi.fn(),
-  readFileSync: vi.fn(),
   rmSync: vi.fn(),
   createWriteStream: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
   join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('../utils/jq', () => ({
+  runJqFileToFile: vi.fn(),
+  runJqFileJson: vi.fn(),
 }));
 
 vi.mock('../samplers/ocr-strategy-sampler', () => ({
@@ -110,10 +115,8 @@ describe('PDFConverter.convertWithStrategy', () => {
       return mockTextExtractorInstance as any;
     });
 
-    // Default: readFileSync returns a doc with 1 page for wrappedCallback
-    vi.mocked(readFileSync).mockReturnValue(
-      Buffer.from(JSON.stringify({ pages: { '1': { page_no: 1 } } })),
-    );
+    // Default: runJqFileJson returns page count of 1 for wrappedCallback
+    vi.mocked(runJqFileJson).mockResolvedValue(1);
   });
 
   describe('strategy determination', () => {
@@ -1090,13 +1093,7 @@ describe('PDFConverter.convertWithStrategy', () => {
       pageTexts.set(1, 'extracted text page 1');
       mockTextExtractorInstance.extractText.mockResolvedValue(pageTexts);
 
-      vi.mocked(readFileSync).mockReturnValue(
-        Buffer.from(
-          JSON.stringify({
-            pages: { '1': { page_no: 1 }, '2': { page_no: 2 } },
-          }),
-        ),
-      );
+      vi.mocked(runJqFileJson).mockResolvedValue(2);
 
       const convertSpy = vi
         .spyOn(converter, 'convert')
@@ -1166,9 +1163,7 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('proceeds without pageTexts when result.json read fails', async () => {
-      vi.mocked(readFileSync).mockImplementation(() => {
-        throw new Error('ENOENT');
-      });
+      vi.mocked(runJqFileJson).mockRejectedValue(new Error('ENOENT'));
 
       const convertSpy = vi
         .spyOn(converter, 'convert')

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -3,8 +3,8 @@ import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
 import type { Readable } from 'node:stream';
 
 import { omit } from 'es-toolkit';
-import { createWriteStream, existsSync, readFileSync, rmSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { createWriteStream, existsSync, rmSync } from 'node:fs';
+import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -13,6 +13,7 @@ import { PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { ImagePdfConverter } from './image-pdf-converter';
 import { PDFConverter } from './pdf-converter';
@@ -31,13 +32,14 @@ vi.mock('../utils/local-file-server', () => ({
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
-  readFileSync: vi.fn(),
+  copyFileSync: vi.fn(),
   rmSync: vi.fn(),
   createWriteStream: vi.fn(),
 }));
 
 vi.mock('node:fs/promises', () => ({
   writeFile: vi.fn(),
+  rename: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
@@ -56,6 +58,11 @@ vi.mock('../processors/image-extractor', () => ({
 
 vi.mock('../processors/page-renderer', () => ({
   PageRenderer: vi.fn(),
+}));
+
+vi.mock('../utils/jq', () => ({
+  runJqFileToFile: vi.fn(),
+  runJqFileJson: vi.fn(),
 }));
 
 describe('PDFConverter', () => {
@@ -1210,9 +1217,8 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
-      );
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1338,9 +1344,8 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
-      );
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1375,14 +1380,8 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-
-      const mockDoc = {
-        pages: {
-          '1': { page_no: 1, image: { uri: '', mimetype: '', dpi: 0 } },
-          '2': { page_no: 2, image: { uri: '', mimetype: '', dpi: 0 } },
-        },
-      };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       const mockRenderPages = vi
         .fn()
@@ -1404,10 +1403,13 @@ describe('PDFConverter', () => {
         '/test/cwd/output/report-render',
       );
 
-      expect(writeFile).toHaveBeenCalledWith(
-        '/test/cwd/output/report-render/result.json',
-        expect.stringContaining('"pages/page_0.png"'),
+      const resultPath = '/test/cwd/output/report-render/result.json';
+      expect(runJqFileToFile).toHaveBeenCalledWith(
+        expect.stringContaining('.pages |= with_entries('),
+        resultPath,
+        resultPath + '.tmp',
       );
+      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
 
       expect(logger.info).toHaveBeenCalledWith(
         '[PDFConverter] Rendered 2 page images',
@@ -1463,15 +1465,8 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-
-      const mockDoc = {
-        pages: {
-          '1': { page_no: 1, image: { uri: '', mimetype: '', dpi: 0 } },
-          '2': { page_no: 2, image: { uri: '', mimetype: '', dpi: 0 } },
-          '3': { page_no: 3, image: { uri: '', mimetype: '', dpi: 0 } },
-        },
-      };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       vi.mocked(PageRenderer).mockImplementation(function () {
         return {
@@ -1489,20 +1484,13 @@ describe('PDFConverter', () => {
         {},
       );
 
-      const writeCall = vi
-        .mocked(writeFile)
-        .mock.calls.find(
-          (call) =>
-            typeof call[0] === 'string' && call[0].includes('result.json'),
-        );
-      expect(writeCall).toBeDefined();
-
-      const savedDoc = JSON.parse(writeCall![1] as string);
-      expect(savedDoc.pages['1'].image.uri).toBe('pages/page_0.png');
-      expect(savedDoc.pages['1'].image.mimetype).toBe('image/png');
-      expect(savedDoc.pages['1'].image.dpi).toBe(300);
-      expect(savedDoc.pages['2'].image.uri).toBe('pages/page_1.png');
-      expect(savedDoc.pages['3'].image.uri).toBe('pages/page_2.png');
+      const resultPath = '/test/cwd/output/report-uris/result.json';
+      expect(runJqFileToFile).toHaveBeenCalledWith(
+        expect.stringContaining('< 3'),
+        resultPath,
+        resultPath + '.tmp',
+      );
+      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
     });
 
     test('should skip pages with page_no exceeding rendered page count', async () => {
@@ -1521,16 +1509,8 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-
-      // Page 3 has page_no=3 but only 2 pages were rendered
-      const mockDoc = {
-        pages: {
-          '1': { page_no: 1, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
-          '2': { page_no: 2, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
-          '3': { page_no: 3, image: { uri: 'old', mimetype: 'old', dpi: 0 } },
-        },
-      };
-      vi.mocked(readFileSync).mockReturnValue(JSON.stringify(mockDoc));
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       vi.mocked(PageRenderer).mockImplementation(function () {
         return {
@@ -1548,21 +1528,14 @@ describe('PDFConverter', () => {
         {},
       );
 
-      const writeCall = vi
-        .mocked(writeFile)
-        .mock.calls.find(
-          (call) =>
-            typeof call[0] === 'string' && call[0].includes('result.json'),
-        );
-      expect(writeCall).toBeDefined();
-
-      const savedDoc = JSON.parse(writeCall![1] as string);
-      // Pages 1-2 should be updated
-      expect(savedDoc.pages['1'].image.uri).toBe('pages/page_0.png');
-      expect(savedDoc.pages['2'].image.uri).toBe('pages/page_1.png');
-      // Page 3 should remain unchanged (exceeds rendered count)
-      expect(savedDoc.pages['3'].image.uri).toBe('old');
-      expect(savedDoc.pages['3'].image.mimetype).toBe('old');
+      // The jq program uses pageCount (2) so pages with page_no > 2 are skipped
+      const resultPath = '/test/cwd/output/report-skip-excess/result.json';
+      expect(runJqFileToFile).toHaveBeenCalledWith(
+        expect.stringContaining('< 2'),
+        resultPath,
+        resultPath + '.tmp',
+      );
+      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
     });
   });
 
@@ -1575,9 +1548,8 @@ describe('PDFConverter', () => {
         fileStream: {} as Readable,
       });
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(readFileSync).mockReturnValue(
-        JSON.stringify({ pages: { '1': { page_no: 1, image: {} } } }),
-      );
+      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
 
       await converter.convert(
         'http://test.com/doc.pdf',

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -9,14 +9,8 @@ import type {
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
 import { omit } from 'es-toolkit';
-import {
-  copyFileSync,
-  createWriteStream,
-  existsSync,
-  readFileSync,
-  rmSync,
-} from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { copyFileSync, createWriteStream, existsSync, rmSync } from 'node:fs';
+import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
@@ -27,6 +21,7 @@ import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
+import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { ImagePdfConverter } from './image-pdf-converter';
 
@@ -316,8 +311,11 @@ export class PDFConverter {
       let pageTexts: Map<number, string> | undefined;
       try {
         const resultPath = join(outputDir, 'result.json');
-        const doc = JSON.parse(readFileSync(resultPath, 'utf-8'));
-        const totalPages = Object.keys(doc.pages).length;
+        // Use jq to extract only page count — avoids loading full JSON into memory
+        const totalPages = await runJqFileJson<number>(
+          '.pages | length',
+          resultPath,
+        );
         const textExtractor = new PdfTextExtractor(this.logger);
         pageTexts = await textExtractor.extractText(pdfPath, totalPages);
       } catch {
@@ -804,6 +802,7 @@ export class PDFConverter {
 
   /**
    * Render page images from the source PDF using ImageMagick and update result.json.
+   * Uses jq to update the JSON file without loading it into Node.js memory.
    * Replaces Docling's generate_page_images which fails on large PDFs
    * due to memory limits when embedding all page images as base64.
    */
@@ -826,21 +825,21 @@ export class PDFConverter {
     const renderer = new PageRenderer(this.logger);
     const renderResult = await renderer.renderPages(pdfPath, outputDir);
 
-    // Update result.json with page image URIs
+    // Update result.json with page image URIs using jq to avoid loading large JSON
     const resultPath = join(outputDir, 'result.json');
-    const doc = JSON.parse(readFileSync(resultPath, 'utf-8'));
+    const tmpPath = resultPath + '.tmp';
+    const jqProgram = `
+      .pages |= with_entries(
+        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
+          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
+          .value.image.mimetype = "image/png" |
+          .value.image.dpi = 300
+        else . end
+      )
+    `;
+    await runJqFileToFile(jqProgram, resultPath, tmpPath);
+    await rename(tmpPath, resultPath);
 
-    for (const page of Object.values(doc.pages) as any[]) {
-      const pageNo = page.page_no as number;
-      const fileIndex = pageNo - 1;
-      if (fileIndex >= 0 && fileIndex < renderResult.pageCount) {
-        page.image.uri = `pages/page_${fileIndex}.png`;
-        page.image.mimetype = 'image/png';
-        page.image.dpi = 300;
-      }
-    }
-
-    await writeFile(resultPath, JSON.stringify(doc, null, 2));
     this.logger.info(
       `[PDFConverter] Rendered ${renderResult.pageCount} page images`,
     );

--- a/packages/pdf-parser/src/processors/image-extractor.test.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.test.ts
@@ -2,17 +2,20 @@ import type { LoggerMethods } from '@heripo/logger';
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { Transform } from 'node:stream';
+import * as streamPromises from 'node:stream/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import * as yauzl from 'yauzl';
 
 import {
-  jqExtractBase64PngStrings,
-  jqReplaceBase64WithPaths,
+  jqExtractBase64PngStringsStreaming,
+  jqReplaceBase64WithPathsToFile,
 } from '../utils/jq';
 import { ImageExtractor } from './image-extractor';
 
 vi.mock('node:fs');
 vi.mock('node:path');
+vi.mock('node:stream/promises');
 vi.mock('yauzl');
 vi.mock('../utils/jq');
 
@@ -50,19 +53,12 @@ describe('ImageExtractor', () => {
         'test.html',
       ] as any);
 
-      vi.mocked(fs.readFileSync).mockReturnValue(
-        '<html><img src="data:image/png;base64,iVBORw0KGgo="/></html>',
-      );
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockResolvedValue(2);
 
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([
-        'data:image/png;base64,abc123',
-        'data:image/png;base64,def456',
-      ]);
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
 
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 2,
-      });
+      // Mock extractImagesFromHtmlStream via pipeline
+      vi.mocked(streamPromises.pipeline).mockResolvedValue(undefined);
 
       await ImageExtractor.extractAndSaveDocumentsFromZip(
         mockLogger,
@@ -77,13 +73,17 @@ describe('ImageExtractor', () => {
         expect.any(Function),
       );
       expect(fs.mkdirSync).toHaveBeenCalled();
-      expect(fs.writeFileSync).toHaveBeenCalled();
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.stringContaining('Extracting ZIP file'),
       );
 
-      // Verify JSON images use 'images' directory and 'pic' prefix
-      expect(jqReplaceBase64WithPaths).toHaveBeenCalledWith(
+      // Verify jq streaming functions called with correct args
+      expect(jqExtractBase64PngStringsStreaming).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Function),
+      );
+      expect(jqReplaceBase64WithPathsToFile).toHaveBeenCalledWith(
+        expect.any(String),
         expect.any(String),
         'images',
         'pic',
@@ -109,14 +109,9 @@ describe('ImageExtractor', () => {
         'test.html',
       ] as any);
 
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 0,
-      });
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockResolvedValue(0);
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
+      vi.mocked(streamPromises.pipeline).mockResolvedValue(undefined);
 
       await ImageExtractor.extractAndSaveDocumentsFromZip(
         mockLogger,
@@ -293,14 +288,9 @@ describe('ImageExtractor', () => {
         'test.HTML',
       ] as any);
 
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 0,
-      });
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockResolvedValue(0);
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
+      vi.mocked(streamPromises.pipeline).mockResolvedValue(undefined);
 
       await ImageExtractor.extractAndSaveDocumentsFromZip(
         mockLogger,
@@ -309,7 +299,7 @@ describe('ImageExtractor', () => {
         outputDir,
       );
 
-      expect(fs.readFileSync).toHaveBeenCalled();
+      expect(jqExtractBase64PngStringsStreaming).toHaveBeenCalled();
     });
 
     test('should handle jq extraction failure and rethrow', async () => {
@@ -327,9 +317,7 @@ describe('ImageExtractor', () => {
         'test.html',
       ] as any);
 
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(jqExtractBase64PngStrings).mockRejectedValue(
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockRejectedValue(
         new Error('jq extraction failed'),
       );
 
@@ -348,7 +336,7 @@ describe('ImageExtractor', () => {
       );
     });
 
-    test('should handle HTML image extraction with multiple images', async () => {
+    test('should invoke extractBase64ImageToFile via streaming callback', async () => {
       const zipPath = '/test/input.zip';
       const extractDir = '/test/extract';
       const outputDir = '/test/output';
@@ -363,148 +351,17 @@ describe('ImageExtractor', () => {
         'test.html',
       ] as any);
 
-      vi.mocked(fs.readFileSync).mockReturnValue(
-        '<html><img src="data:image/png;base64,abc123"/><img src="data:image/png;base64,def456"/></html>',
+      // Capture the onImage callback and invoke it with test data
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockImplementation(
+        async (_filePath, onImage) => {
+          onImage('data:image/png;base64,abc123', 0);
+          onImage('def456', 1);
+          return 2;
+        },
       );
 
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 0,
-      });
-
-      await ImageExtractor.extractAndSaveDocumentsFromZip(
-        mockLogger,
-        zipPath,
-        extractDir,
-        outputDir,
-      );
-
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('.html'),
-        expect.stringContaining('images/image_'),
-        'utf-8',
-      );
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.stringContaining('Extracted 2 images from HTML'),
-      );
-    });
-
-    test('should handle HTML image extraction failure gracefully', async () => {
-      const zipPath = '/test/input.zip';
-      const extractDir = '/test/extract';
-      const outputDir = '/test/output';
-
-      setupSuccessfulZipExtraction([
-        { fileName: 'test.json', isDirectory: false },
-        { fileName: 'test.html', isDirectory: false },
-      ]);
-
-      vi.mocked(fs.readdirSync).mockReturnValue([
-        'test.json',
-        'test.html',
-      ] as any);
-
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 0,
-      });
-
-      let htmlWriteAttempted = false;
-      vi.mocked(fs.writeFileSync).mockImplementation((filepath) => {
-        if (filepath.toString().includes('.html') && !htmlWriteAttempted) {
-          htmlWriteAttempted = true;
-          throw new Error('HTML write failed');
-        }
-      });
-
-      await ImageExtractor.extractAndSaveDocumentsFromZip(
-        mockLogger,
-        zipPath,
-        extractDir,
-        outputDir,
-      );
-
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to extract images from HTML'),
-        expect.any(Error),
-      );
-    });
-
-    test('should handle output directory removal failure gracefully', async () => {
-      const zipPath = '/test/input.zip';
-      const extractDir = '/test/extract';
-      const outputDir = '/test/output';
-
-      setupSuccessfulZipExtraction([
-        { fileName: 'test.json', isDirectory: false },
-        { fileName: 'test.html', isDirectory: false },
-      ]);
-
-      vi.mocked(fs.readdirSync).mockReturnValue([
-        'test.json',
-        'test.html',
-      ] as any);
-
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(fs.existsSync).mockReturnValue(true);
-
-      vi.mocked(fs.rmSync).mockImplementation(() => {
-        throw new Error('Permission denied');
-      });
-
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 0,
-      });
-
-      await ImageExtractor.extractAndSaveDocumentsFromZip(
-        mockLogger,
-        zipPath,
-        extractDir,
-        outputDir,
-      );
-
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to clear output directory'),
-        expect.any(Error),
-      );
-    });
-
-    test('should handle base64 images with and without prefix', async () => {
-      const zipPath = '/test/input.zip';
-      const extractDir = '/test/extract';
-      const outputDir = '/test/output';
-
-      setupSuccessfulZipExtraction([
-        { fileName: 'test.json', isDirectory: false },
-        { fileName: 'test.html', isDirectory: false },
-      ]);
-
-      vi.mocked(fs.readdirSync).mockReturnValue([
-        'test.json',
-        'test.html',
-      ] as any);
-
-      vi.mocked(fs.readFileSync).mockReturnValue('<html></html>');
-
-      vi.mocked(jqExtractBase64PngStrings).mockResolvedValue([
-        'data:image/png;base64,abc123',
-        'def456',
-      ]);
-
-      vi.mocked(jqReplaceBase64WithPaths).mockResolvedValue({
-        data: { pages: [] },
-        count: 2,
-      });
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
+      vi.mocked(streamPromises.pipeline).mockResolvedValue(undefined);
 
       const bufferFromSpy = vi.spyOn(Buffer, 'from');
 
@@ -529,6 +386,90 @@ describe('ImageExtractor', () => {
       );
     });
 
+    test('should handle output directory removal failure gracefully', async () => {
+      const zipPath = '/test/input.zip';
+      const extractDir = '/test/extract';
+      const outputDir = '/test/output';
+
+      setupSuccessfulZipExtraction([
+        { fileName: 'test.json', isDirectory: false },
+        { fileName: 'test.html', isDirectory: false },
+      ]);
+
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'test.json',
+        'test.html',
+      ] as any);
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      vi.mocked(fs.rmSync).mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockResolvedValue(0);
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
+      vi.mocked(streamPromises.pipeline).mockResolvedValue(undefined);
+
+      await ImageExtractor.extractAndSaveDocumentsFromZip(
+        mockLogger,
+        zipPath,
+        extractDir,
+        outputDir,
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to clear output directory'),
+        expect.any(Error),
+      );
+    });
+
+    test('should fallback to streaming copy when HTML extraction fails', async () => {
+      const zipPath = '/test/input.zip';
+      const extractDir = '/test/extract';
+      const outputDir = '/test/output';
+
+      setupSuccessfulZipExtraction([
+        { fileName: 'test.json', isDirectory: false },
+        { fileName: 'test.html', isDirectory: false },
+      ]);
+
+      vi.mocked(fs.readdirSync).mockReturnValue([
+        'test.json',
+        'test.html',
+      ] as any);
+
+      vi.mocked(jqExtractBase64PngStringsStreaming).mockResolvedValue(0);
+      vi.mocked(jqReplaceBase64WithPathsToFile).mockResolvedValue(undefined);
+
+      // First call to pipeline (for extractImagesFromHtmlStream) throws error
+      // Second call (for fallback streaming copy) succeeds
+      let pipelineCallCount = 0;
+      vi.mocked(streamPromises.pipeline).mockImplementation(async () => {
+        pipelineCallCount++;
+        if (pipelineCallCount === 1) {
+          throw new Error('HTML stream processing failed');
+        }
+      });
+
+      await ImageExtractor.extractAndSaveDocumentsFromZip(
+        mockLogger,
+        zipPath,
+        extractDir,
+        outputDir,
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to extract images from HTML, copying original',
+        ),
+        expect.any(Error),
+      );
+      // Verify fallback used streaming copy (createReadStream + createWriteStream + pipeline)
+      expect(fs.createReadStream).toHaveBeenCalled();
+      expect(fs.createWriteStream).toHaveBeenCalled();
+    });
+
     test('should handle zipfile error event', async () => {
       const zipPath = '/test/input.zip';
       const extractDir = '/test/extract';
@@ -544,6 +485,230 @@ describe('ImageExtractor', () => {
           outputDir,
         ),
       ).rejects.toThrow('Zipfile error');
+    });
+  });
+
+  describe('extractImagesFromHtmlStream', () => {
+    test('should extract base64 images and replace with file paths', async () => {
+      // Use real pipeline for streaming test
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const htmlInput =
+        '<html><img src="data:image/png;base64,iVBOR"/><img src="data:image/png;base64,AAAA"/></html>';
+
+      // Mock createReadStream to return a readable stream with our test data
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+      vi.mocked(fs.createReadStream).mockReturnValue(
+        Readable.from([htmlInput]) as any,
+      );
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(2);
+      const output = chunks.join('');
+      expect(output).toContain('src="images/image_0.png"');
+      expect(output).toContain('src="images/image_1.png"');
+      expect(output).not.toContain('data:image/png;base64');
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/images/image_0.png',
+        expect.any(Buffer),
+      );
+    });
+
+    test('should handle data split across chunk boundaries', async () => {
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+
+      // Split the marker across two chunks
+      vi.mocked(fs.createReadStream).mockReturnValue(
+        Readable.from([
+          '<img src="data:image/png;base',
+          '64,AAAA" />rest',
+        ]) as any,
+      );
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(1);
+      const output = chunks.join('');
+      expect(output).toContain('src="images/image_0.png"');
+      expect(output).toContain('rest');
+    });
+
+    test('should handle closing quote split across chunks', async () => {
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+
+      // First chunk has the marker and base64 data start but no closing quote
+      // Second chunk has more base64 data with the closing quote
+      vi.mocked(fs.createReadStream).mockReturnValue(
+        Readable.from([
+          '<img src="data:image/png;base64,AAAA',
+          'BBBB" />done',
+        ]) as any,
+      );
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(1);
+      const output = chunks.join('');
+      expect(output).toContain('src="images/image_0.png"');
+      expect(output).toContain('done');
+    });
+
+    test('should pass through HTML without images unchanged', async () => {
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+
+      vi.mocked(fs.createReadStream).mockReturnValue(
+        Readable.from(['<html><body>Hello</body></html>']) as any,
+      );
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(0);
+      const output = chunks.join('');
+      expect(output).toContain('Hello');
+    });
+
+    test('should handle very short chunks without pushing empty result', async () => {
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+
+      // Send data as individual characters — each chunk is shorter than the marker length,
+      // so safeEnd=0 and result='' (covers result.length > 0 false branch)
+      vi.mocked(fs.createReadStream).mockReturnValue(
+        Readable.from(['a', 'b', 'c']) as any,
+      );
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(0);
+      const output = chunks.join('');
+      expect(output).toBe('abc');
+    });
+
+    test('should handle empty input with nothing to flush', async () => {
+      vi.mocked(streamPromises.pipeline).mockRestore();
+      const { pipeline: realPipeline } = await vi.importActual<
+        typeof streamPromises
+      >('node:stream/promises');
+      vi.mocked(streamPromises.pipeline).mockImplementation(realPipeline);
+
+      const { Readable } = (await vi.importActual('node:stream')) as any;
+
+      // Empty input — no data passed to transform, flush is called with empty pending
+      // (covers pending.length > 0 false branch in flush)
+      vi.mocked(fs.createReadStream).mockReturnValue(Readable.from([]) as any);
+
+      const chunks: string[] = [];
+      const mockWs = new Transform({
+        transform(chunk, _enc, cb) {
+          chunks.push(chunk.toString());
+          cb();
+        },
+      });
+      vi.mocked(fs.createWriteStream).mockReturnValue(mockWs as any);
+
+      const count = await ImageExtractor.extractImagesFromHtmlStream(
+        '/input.html',
+        '/output.html',
+        '/images',
+      );
+
+      expect(count).toBe(0);
+      expect(chunks.join('')).toBe('');
     });
   });
 });

--- a/packages/pdf-parser/src/processors/image-extractor.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.ts
@@ -1,21 +1,22 @@
 import type { LoggerMethods } from '@heripo/logger';
-import type { DoclingDocument } from '@heripo/model';
 
 import {
+  createReadStream,
   createWriteStream,
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
 import { extname, join } from 'node:path';
+import { Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import * as yauzl from 'yauzl';
 
 import {
-  jqExtractBase64PngStrings,
-  jqReplaceBase64WithPaths,
+  jqExtractBase64PngStringsStreaming,
+  jqReplaceBase64WithPathsToFile,
 } from '../utils/jq';
 
 /**
@@ -81,38 +82,6 @@ export class ImageExtractor {
   }
 
   /**
-   * Extract base64 images from JSON file using jq (for large files)
-   * Returns array of base64 data strings
-   */
-  private static async extractBase64ImagesFromJsonWithJq(
-    jsonPath: string,
-  ): Promise<string[]> {
-    return jqExtractBase64PngStrings(jsonPath);
-  }
-
-  /**
-   * Replace base64 images with file paths in JSON using jq (for large files)
-   * Uses reduce to maintain counter state while walking the JSON
-   */
-  private static async replaceBase64ImagesInJsonWithJq(
-    jsonPath: string,
-    outputPath: string,
-    dirName: string,
-    prefix: string,
-  ): Promise<number> {
-    const { data, count } = (await jqReplaceBase64WithPaths(
-      jsonPath,
-      dirName,
-      prefix,
-    )) as { data: DoclingDocument; count: number };
-
-    // Write transformed JSON to output file
-    writeFileSync(outputPath, JSON.stringify(data, null, 2), 'utf-8');
-
-    return count;
-  }
-
-  /**
    * Extract a base64-encoded image to a file and return the relative path
    */
   private static extractBase64ImageToFile(
@@ -138,8 +107,89 @@ export class ImageExtractor {
   }
 
   /**
-   * Save JSON and HTML documents with base64 images extracted to separate files
-   * Uses jq for JSON processing to handle large files
+   * Extract base64 images from HTML using streaming.
+   * Reads HTML file as a stream, extracts base64 images from src attributes,
+   * saves them as PNG files, and replaces with file paths in the output HTML.
+   * Returns the number of images extracted.
+   */
+  static async extractImagesFromHtmlStream(
+    htmlInputPath: string,
+    htmlOutputPath: string,
+    imagesDir: string,
+  ): Promise<number> {
+    let imageIndex = 0;
+    let pending = '';
+    const MARKER = 'src="data:image/png;base64,';
+
+    const transform = new Transform({
+      decodeStrings: false,
+      encoding: 'utf-8',
+      transform(chunk: string, _encoding, callback) {
+        pending += chunk;
+        let result = '';
+
+        while (true) {
+          const markerIdx = pending.indexOf(MARKER);
+
+          if (markerIdx === -1) {
+            // Keep a tail that could be a partial marker match
+            const safeEnd = Math.max(0, pending.length - MARKER.length);
+            result += pending.slice(0, safeEnd);
+            pending = pending.slice(safeEnd);
+            break;
+          }
+
+          // Flush everything before the marker
+          result += pending.slice(0, markerIdx);
+
+          // Find the closing quote after base64 data
+          const dataStart = markerIdx + MARKER.length;
+          const quoteIdx = pending.indexOf('"', dataStart);
+
+          if (quoteIdx === -1) {
+            // Closing quote not in buffer yet — keep everything from marker onward
+            pending = pending.slice(markerIdx);
+            break;
+          }
+
+          // Extract base64 content and save as image file
+          const base64Content = pending.slice(dataStart, quoteIdx);
+          const filename = `image_${imageIndex}.png`;
+          const filepath = join(imagesDir, filename);
+          const buf = Buffer.from(base64Content, 'base64');
+          writeFileSync(filepath, buf);
+
+          const relativePath = `images/${filename}`;
+          result += `src="${relativePath}"`;
+          imageIndex++;
+
+          pending = pending.slice(quoteIdx + 1);
+        }
+
+        if (result.length > 0) {
+          this.push(result);
+        }
+        callback();
+      },
+      flush(callback) {
+        if (pending.length > 0) {
+          this.push(pending);
+        }
+        callback();
+      },
+    });
+
+    const rs = createReadStream(htmlInputPath, { encoding: 'utf-8' });
+    const ws = createWriteStream(htmlOutputPath, { encoding: 'utf-8' });
+
+    await pipeline(rs, transform, ws);
+
+    return imageIndex;
+  }
+
+  /**
+   * Save JSON and HTML documents with base64 images extracted to separate files.
+   * Uses jq for JSON processing and streaming for HTML to handle large files.
    *
    * This method:
    * 1. Extracts base64-encoded images from JSON and HTML content
@@ -152,7 +202,7 @@ export class ImageExtractor {
     outputDir: string,
     filename: string,
     jsonSourcePath: string,
-    htmlContent: string,
+    htmlSourcePath: string,
   ): Promise<void> {
     // Clear output directory completely at the start, then recreate it
     try {
@@ -167,7 +217,7 @@ export class ImageExtractor {
     // Get filename without extension
     const baseName = filename.replace(extname(filename), '');
 
-    // Save JSON with extracted images (using jq for large files)
+    // Save JSON with extracted images (using jq streaming for large files)
     const jsonPath = join(outputDir, `${baseName}.json`);
     try {
       // Create images directory for picture images from JSON
@@ -176,36 +226,34 @@ export class ImageExtractor {
         mkdirSync(imagesDir, { recursive: true });
       }
 
-      // Step 1: Extract base64 images using jq (doesn't load full JSON into memory)
-      const base64Images =
-        await ImageExtractor.extractBase64ImagesFromJsonWithJq(jsonSourcePath);
-
-      // Step 2: Save each picture image to file
-      base64Images.forEach((base64Data, index) => {
-        ImageExtractor.extractBase64ImageToFile(
-          base64Data,
-          imagesDir,
-          index,
-          'pic',
-          'images',
-        );
-      });
-
-      logger.info(
-        `[PDFConverter] Extracted ${base64Images.length} picture images from JSON to ${imagesDir}`,
+      // Step 1: Extract base64 images using streaming jq (one at a time, no accumulation)
+      const imageCount = await jqExtractBase64PngStringsStreaming(
+        jsonSourcePath,
+        (base64Data, index) => {
+          ImageExtractor.extractBase64ImageToFile(
+            base64Data,
+            imagesDir,
+            index,
+            'pic',
+            'images',
+          );
+        },
       );
 
-      // Step 3: Replace base64 images with file paths using jq
-      const replacedCount =
-        await ImageExtractor.replaceBase64ImagesInJsonWithJq(
-          jsonSourcePath,
-          jsonPath,
-          'images',
-          'pic',
-        );
+      logger.info(
+        `[PDFConverter] Extracted ${imageCount} picture images from JSON to ${imagesDir}`,
+      );
+
+      // Step 2: Replace base64 images with file paths using jq, pipe directly to file
+      await jqReplaceBase64WithPathsToFile(
+        jsonSourcePath,
+        jsonPath,
+        'images',
+        'pic',
+      );
 
       logger.info(
-        `[PDFConverter] Replaced ${replacedCount} base64 images with file paths`,
+        `[PDFConverter] Replaced ${imageCount} base64 images with file paths`,
       );
     } catch (e) {
       logger.warn(
@@ -216,7 +264,7 @@ export class ImageExtractor {
     }
     logger.info('[PDFConverter] Saved JSON:', jsonPath);
 
-    // Save HTML with extracted images
+    // Save HTML with extracted images using streaming
     const htmlPath = join(outputDir, `${baseName}.html`);
     try {
       // Create images directory for HTML images
@@ -225,49 +273,39 @@ export class ImageExtractor {
         mkdirSync(imagesDir, { recursive: true });
       }
 
-      // Extract base64 images from HTML src attributes, save them as PNG files, and replace with file paths
-      let imageIndex = 0;
-      const transformedHtml = htmlContent.replace(
-        /src="data:image\/png;base64,([^"]+)"/g,
-        (_, base64Content) => {
-          const filename = `image_${imageIndex}.png`;
-          const filepath = join(imagesDir, filename);
-
-          // Convert base64 to buffer and write to file
-          const buffer = Buffer.from(base64Content, 'base64');
-          writeFileSync(filepath, buffer);
-
-          const relativePath = `images/${filename}`;
-          imageIndex += 1;
-
-          return `src="${relativePath}"`;
-        },
+      const htmlImageCount = await ImageExtractor.extractImagesFromHtmlStream(
+        htmlSourcePath,
+        htmlPath,
+        imagesDir,
       );
 
       logger.info(
-        `[PDFConverter] Extracted ${imageIndex} images from HTML to ${imagesDir}`,
+        `[PDFConverter] Extracted ${htmlImageCount} images from HTML to ${imagesDir}`,
       );
-      writeFileSync(htmlPath, transformedHtml, 'utf-8');
     } catch (e) {
       logger.warn(
-        '[PDFConverter] Failed to extract images from HTML, writing original. Error:',
+        '[PDFConverter] Failed to extract images from HTML, copying original. Error:',
         e,
       );
-      writeFileSync(htmlPath, htmlContent, 'utf-8');
+      // Fallback: copy original HTML using streaming
+      const rs = createReadStream(htmlSourcePath);
+      const ws = createWriteStream(htmlPath);
+      await pipeline(rs, ws);
     }
     logger.info('[PDFConverter] Saved HTML:', htmlPath);
   }
 
   /**
    * Extract documents from ZIP and save with extracted images
-   * Uses jq for JSON processing to handle large files without loading into Node.js memory
+   * Uses jq for JSON processing and streaming for HTML to handle large files
+   * without loading into Node.js memory
    *
    * Complete workflow:
    * 1. Extract ZIP file to temporary directory
    * 2. Find JSON and HTML files from extracted files
-   * 3. Use jq to extract base64 images from JSON and save as separate files
-   * 4. Use jq to replace base64 with file paths in JSON
-   * 5. Process HTML with regex to extract and replace images
+   * 3. Use jq to stream-extract base64 images from JSON and save as separate files
+   * 4. Use jq to replace base64 with file paths in JSON (piped to file)
+   * 5. Process HTML with streaming Transform to extract and replace images
    * 6. Save transformed documents to output directory (as result.json and result.html)
    */
   static async extractAndSaveDocumentsFromZip(
@@ -295,18 +333,15 @@ export class ImageExtractor {
     const jsonPath = join(extractDir, jsonFile);
     const htmlPath = join(extractDir, htmlFile);
 
-    // Read HTML content (HTML is typically smaller, safe to read into memory)
-    const htmlContent = readFileSync(htmlPath, 'utf-8');
-
     // Save converted files to output directory with extracted images
-    // JSON is processed with jq to avoid loading large files into memory
+    // Both JSON and HTML are processed with streaming to avoid loading large files into memory
     logger.info('[PDFConverter] Saving converted files to output...');
     await ImageExtractor.saveDocumentsWithExtractedImages(
       logger,
       outputDir,
       'result',
       jsonPath,
-      htmlContent,
+      htmlPath,
     );
 
     logger.info('[PDFConverter] Files saved to:', outputDir);

--- a/packages/pdf-parser/src/utils/jq.test.ts
+++ b/packages/pdf-parser/src/utils/jq.test.ts
@@ -45,6 +45,7 @@ describe('jq utils', () => {
       on: ReturnType<typeof vi.fn>;
     };
     on: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
     exitCode: number | null;
   };
   let stdoutHandlers: Map<string, (chunk: string) => void>;
@@ -72,6 +73,7 @@ describe('jq utils', () => {
       on: vi.fn((event: string, handler: (arg: any) => void) => {
         childHandlers.set(event, handler);
       }),
+      kill: vi.fn(),
       exitCode: null,
     };
 
@@ -260,15 +262,14 @@ describe('jq utils', () => {
   });
 
   describe('runJqFileToFile', () => {
-    test('should pipe jq stdout to output file', async () => {
+    test('should pipe jq stdout to output file when both pipeline and close complete', async () => {
       const mockWs = {} as Writable;
       vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
       vi.mocked(pipeline).mockResolvedValue(undefined);
 
       const promise = runJqFileToFile('.data', '/input.json', '/output.json');
 
-      // Simulate jq exiting successfully
-      mockChild.exitCode = 0;
+      // Both pipeline (resolved via mock) and close must fire
       childHandlers.get('close')?.(0);
 
       await promise;
@@ -280,6 +281,46 @@ describe('jq utils', () => {
       );
       expect(createWriteStream).toHaveBeenCalledWith('/output.json');
       expect(pipeline).toHaveBeenCalledWith(mockChild.stdout, mockWs);
+    });
+
+    test('should resolve when close fires before pipeline completes', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+
+      // Pipeline resolves asynchronously after close
+      let resolvePipeline!: () => void;
+      vi.mocked(pipeline).mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolvePipeline = resolve;
+          }),
+      );
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // close fires first
+      childHandlers.get('close')?.(0);
+      // then pipeline completes
+      resolvePipeline();
+
+      await promise;
+    });
+
+    test('should resolve when pipeline completes before close fires', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      // pipeline resolves immediately (before close)
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // Allow pipeline microtask to resolve first
+      await vi.waitFor(() => {
+        // close fires after pipeline is done
+        childHandlers.get('close')?.(0);
+      });
+
+      await promise;
     });
 
     test('should reject when jq exits with non-zero code', async () => {
@@ -301,6 +342,18 @@ describe('jq utils', () => {
       );
     });
 
+    test('should reject when jq exits with non-zero code without stderr', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow('jq exited with code 1. ');
+    });
+
     test('should reject when spawn emits error', async () => {
       const mockWs = { destroy: vi.fn() } as unknown as Writable;
       vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
@@ -311,6 +364,7 @@ describe('jq utils', () => {
       childHandlers.get('error')?.(new Error('spawn ENOENT'));
 
       await expect(promise).rejects.toThrow('spawn ENOENT');
+      expect((mockWs as any).destroy).toHaveBeenCalled();
     });
 
     test('should reject when pipeline fails', async () => {
@@ -323,66 +377,60 @@ describe('jq utils', () => {
       await expect(promise).rejects.toThrow('pipe error');
     });
 
-    test('should resolve via pipeline when exitCode is already 0', async () => {
+    test('should use null exit code as 1', async () => {
       const mockWs = {} as Writable;
       vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
-
-      // Simulate jq already exited before pipeline resolves
-      mockChild.exitCode = 0;
       vi.mocked(pipeline).mockResolvedValue(undefined);
 
       const promise = runJqFileToFile('.data', '/input.json', '/output.json');
 
-      // The close handler also fires
-      childHandlers.get('close')?.(0);
-
-      await promise;
-    });
-
-    test('should reject via pipeline when exitCode is non-zero', async () => {
-      const mockWs = {} as Writable;
-      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
-
-      mockChild.exitCode = 1;
-      stderrHandlers.get('data')?.('error msg');
-      vi.mocked(pipeline).mockResolvedValue(undefined);
-
-      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
-
-      childHandlers.get('close')?.(1);
+      childHandlers.get('close')?.(null);
 
       await expect(promise).rejects.toThrow('jq exited with code 1');
     });
 
-    test('should reject via pipeline when exitCode is non-zero without stderr', async () => {
-      const mockWs = {} as Writable;
+    test('should not reject twice when both error and pipeline rejection fire', async () => {
+      const mockWs = { destroy: vi.fn() } as unknown as Writable;
       vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
-
-      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(pipeline).mockRejectedValue(new Error('pipe error'));
 
       const promise = runJqFileToFile('.data', '/input.json', '/output.json');
 
-      // Set exitCode after handlers are registered, no stderr data sent
-      mockChild.exitCode = 1;
+      // error handler fires synchronously before pipeline microtask
+      childHandlers.get('error')?.(new Error('spawn ENOENT'));
 
-      await expect(promise).rejects.toThrow('jq exited with code 1. ');
+      // First rejection wins (error event), pipeline rejection is ignored
+      await expect(promise).rejects.toThrow('spawn ENOENT');
     });
 
-    test('should reject via pipeline with stderr when exitCode is non-zero', async () => {
+    test('should ignore close event after error has already settled', async () => {
+      const mockWs = { destroy: vi.fn() } as unknown as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockImplementation(() => new Promise(() => {}));
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // error settles first
+      childHandlers.get('error')?.(new Error('spawn ENOENT'));
+      // close fires after — trySettle should bail out via settled guard
+      childHandlers.get('close')?.(0);
+
+      await expect(promise).rejects.toThrow('spawn ENOENT');
+    });
+
+    test('should ignore error event after already settled via trySettle', async () => {
       const mockWs = {} as Writable;
       vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
-
       vi.mocked(pipeline).mockResolvedValue(undefined);
 
       const promise = runJqFileToFile('.data', '/input.json', '/output.json');
 
-      // Send stderr data and set exitCode AFTER handlers are registered
-      stderrHandlers.get('data')?.('pipeline stderr');
-      mockChild.exitCode = 2;
+      // Both pipeline (resolved) and close fire — settles via trySettle
+      childHandlers.get('close')?.(0);
+      await promise;
 
-      await expect(promise).rejects.toThrow(
-        'jq exited with code 2. Stderr: pipeline stderr',
-      );
+      // error fires after already settled — should be ignored
+      childHandlers.get('error')?.(new Error('late error'));
     });
   });
 
@@ -481,6 +529,72 @@ describe('jq utils', () => {
       childHandlers.get('error')?.(new Error('spawn failed'));
 
       await expect(promise).rejects.toThrow('spawn failed');
+    });
+
+    test('should reject and kill child when onLine throws during data event', async () => {
+      const callbackErr = new Error('disk write failed');
+      const promise = runJqFileLines('.[]', '/input.json', () => {
+        throw callbackErr;
+      });
+
+      stdoutHandlers.get('data')?.('line1\n');
+
+      await expect(promise).rejects.toThrow('disk write failed');
+      expect(mockChild.kill).toHaveBeenCalled();
+    });
+
+    test('should reject and kill child when onLine throws during close buffer flush', async () => {
+      const callbackErr = new Error('callback error on close');
+      const promise = runJqFileLines('.[]', '/input.json', () => {
+        throw callbackErr;
+      });
+
+      // No newline, so data stays in buffer until close
+      stdoutHandlers.get('data')?.('remaining');
+      childHandlers.get('close')?.(0);
+
+      await expect(promise).rejects.toThrow('callback error on close');
+      expect(mockChild.kill).toHaveBeenCalled();
+    });
+
+    test('should stop processing lines after callback error', async () => {
+      let callCount = 0;
+      const promise = runJqFileLines('.[]', '/input.json', () => {
+        callCount++;
+        if (callCount === 2) {
+          throw new Error('fail on second');
+        }
+      });
+
+      stdoutHandlers.get('data')?.('line1\nline2\nline3\n');
+
+      await expect(promise).rejects.toThrow('fail on second');
+      expect(callCount).toBe(2);
+    });
+
+    test('should not reject from error event after callback error', async () => {
+      const callbackErr = new Error('callback error');
+      const promise = runJqFileLines('.[]', '/input.json', () => {
+        throw callbackErr;
+      });
+
+      stdoutHandlers.get('data')?.('line1\n');
+      // error event fires after callback already rejected
+      childHandlers.get('error')?.(new Error('spawn error'));
+
+      await expect(promise).rejects.toThrow('callback error');
+    });
+
+    test('should ignore close event after callback error in data handler', async () => {
+      const promise = runJqFileLines('.[]', '/input.json', () => {
+        throw new Error('callback fail');
+      });
+
+      stdoutHandlers.get('data')?.('line1\n');
+      // close fires after callback already rejected — should be ignored
+      childHandlers.get('close')?.(0);
+
+      await expect(promise).rejects.toThrow('callback fail');
     });
   });
 

--- a/packages/pdf-parser/src/utils/jq.test.ts
+++ b/packages/pdf-parser/src/utils/jq.test.ts
@@ -1,17 +1,36 @@
 import type { ChildProcess } from 'node:child_process';
-import type { Readable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 
 import { spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   jqExtractBase64PngStrings,
+  jqExtractBase64PngStringsStreaming,
   jqReplaceBase64WithPaths,
+  jqReplaceBase64WithPathsToFile,
   runJqFileJson,
+  runJqFileLines,
+  runJqFileToFile,
 } from './jq';
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  rename: vi.fn(),
+}));
+
+vi.mock('node:stream/promises', () => ({
+  pipeline: vi.fn(),
 }));
 
 describe('jq utils', () => {
@@ -19,12 +38,14 @@ describe('jq utils', () => {
     stdout: {
       setEncoding: ReturnType<typeof vi.fn>;
       on: ReturnType<typeof vi.fn>;
+      pipe?: ReturnType<typeof vi.fn>;
     };
     stderr: {
       setEncoding: ReturnType<typeof vi.fn>;
       on: ReturnType<typeof vi.fn>;
     };
     on: ReturnType<typeof vi.fn>;
+    exitCode: number | null;
   };
   let stdoutHandlers: Map<string, (chunk: string) => void>;
   let stderrHandlers: Map<string, (chunk: string) => void>;
@@ -38,19 +59,20 @@ describe('jq utils', () => {
     mockChild = {
       stdout: {
         setEncoding: vi.fn(),
-        on: vi.fn((event, handler) => {
+        on: vi.fn((event: string, handler: (chunk: string) => void) => {
           stdoutHandlers.set(event, handler);
         }),
       },
       stderr: {
         setEncoding: vi.fn(),
-        on: vi.fn((event, handler) => {
+        on: vi.fn((event: string, handler: (chunk: string) => void) => {
           stderrHandlers.set(event, handler);
         }),
       },
-      on: vi.fn((event, handler) => {
+      on: vi.fn((event: string, handler: (arg: any) => void) => {
         childHandlers.set(event, handler);
       }),
+      exitCode: null,
     };
 
     vi.mocked(spawn).mockReturnValue(
@@ -237,6 +259,231 @@ describe('jq utils', () => {
     });
   });
 
+  describe('runJqFileToFile', () => {
+    test('should pipe jq stdout to output file', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // Simulate jq exiting successfully
+      mockChild.exitCode = 0;
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(spawn).toHaveBeenCalledWith(
+        'jq',
+        ['.data', '/input.json'],
+        expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+      );
+      expect(createWriteStream).toHaveBeenCalledWith('/output.json');
+      expect(pipeline).toHaveBeenCalledWith(mockChild.stdout, mockWs);
+    });
+
+    test('should reject when jq exits with non-zero code', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile(
+        '.invalid',
+        '/input.json',
+        '/output.json',
+      );
+
+      stderrHandlers.get('data')?.('jq error\n');
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow(
+        'jq exited with code 1. Stderr: jq error\n',
+      );
+    });
+
+    test('should reject when spawn emits error', async () => {
+      const mockWs = { destroy: vi.fn() } as unknown as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockImplementation(() => new Promise(() => {}));
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      childHandlers.get('error')?.(new Error('spawn ENOENT'));
+
+      await expect(promise).rejects.toThrow('spawn ENOENT');
+    });
+
+    test('should reject when pipeline fails', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockRejectedValue(new Error('pipe error'));
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      await expect(promise).rejects.toThrow('pipe error');
+    });
+
+    test('should resolve via pipeline when exitCode is already 0', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+
+      // Simulate jq already exited before pipeline resolves
+      mockChild.exitCode = 0;
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // The close handler also fires
+      childHandlers.get('close')?.(0);
+
+      await promise;
+    });
+
+    test('should reject via pipeline when exitCode is non-zero', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+
+      mockChild.exitCode = 1;
+      stderrHandlers.get('data')?.('error msg');
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow('jq exited with code 1');
+    });
+
+    test('should reject via pipeline when exitCode is non-zero without stderr', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // Set exitCode after handlers are registered, no stderr data sent
+      mockChild.exitCode = 1;
+
+      await expect(promise).rejects.toThrow('jq exited with code 1. ');
+    });
+
+    test('should reject via pipeline with stderr when exitCode is non-zero', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = runJqFileToFile('.data', '/input.json', '/output.json');
+
+      // Send stderr data and set exitCode AFTER handlers are registered
+      stderrHandlers.get('data')?.('pipeline stderr');
+      mockChild.exitCode = 2;
+
+      await expect(promise).rejects.toThrow(
+        'jq exited with code 2. Stderr: pipeline stderr',
+      );
+    });
+  });
+
+  describe('runJqFileLines', () => {
+    test('should process each line via onLine callback', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      stdoutHandlers.get('data')?.('line1\nline2\nline3\n');
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(lines).toEqual(['line1', 'line2', 'line3']);
+      expect(spawn).toHaveBeenCalledWith(
+        'jq',
+        ['-r', '.[]', '/input.json'],
+        expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+      );
+    });
+
+    test('should handle data arriving across chunk boundaries', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      stdoutHandlers.get('data')?.('par');
+      stdoutHandlers.get('data')?.('tial_line\nsecond');
+      stdoutHandlers.get('data')?.('_line\n');
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(lines).toEqual(['partial_line', 'second_line']);
+    });
+
+    test('should process remaining buffer on close', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      stdoutHandlers.get('data')?.('no_trailing_newline');
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(lines).toEqual(['no_trailing_newline']);
+    });
+
+    test('should skip empty lines', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      stdoutHandlers.get('data')?.('a\n\nb\n');
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(lines).toEqual(['a', 'b']);
+    });
+
+    test('should reject when jq exits with non-zero code', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      stderrHandlers.get('data')?.('parse error');
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow(
+        'jq exited with code 1. Stderr: parse error',
+      );
+    });
+
+    test('should reject when jq exits with non-zero code without stderr', async () => {
+      const lines: string[] = [];
+      const promise = runJqFileLines('.[]', '/input.json', (line) => {
+        lines.push(line);
+      });
+
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow('jq exited with code 1. ');
+    });
+
+    test('should reject when spawn emits error', async () => {
+      const promise = runJqFileLines('.[]', '/input.json', vi.fn());
+
+      childHandlers.get('error')?.(new Error('spawn failed'));
+
+      await expect(promise).rejects.toThrow('spawn failed');
+    });
+  });
+
   describe('jqExtractBase64PngStrings', () => {
     test('should extract base64 PNG strings from JSON file', async () => {
       const promise = jqExtractBase64PngStrings('/path/to/file.json');
@@ -268,6 +515,57 @@ describe('jq utils', () => {
       const jqProgram = vi.mocked(spawn).mock.calls[0][1][1];
       expect(jqProgram).toContain('select(type == "string"');
       expect(jqProgram).toContain('startswith("data:image/png;base64")');
+    });
+  });
+
+  describe('jqExtractBase64PngStringsStreaming', () => {
+    test('should stream each base64 image to onImage callback with index', async () => {
+      const images: Array<{ data: string; index: number }> = [];
+      const promise = jqExtractBase64PngStringsStreaming(
+        '/path/to/file.json',
+        (data, index) => {
+          images.push({ data, index });
+        },
+      );
+
+      const stdoutHandler = stdoutHandlers.get('data');
+      const closeHandler = childHandlers.get('close');
+
+      stdoutHandler?.('data:image/png;base64,abc123\n');
+      stdoutHandler?.('data:image/png;base64,def456\n');
+      closeHandler?.(0);
+
+      const count = await promise;
+
+      expect(count).toBe(2);
+      expect(images).toEqual([
+        { data: 'data:image/png;base64,abc123', index: 0 },
+        { data: 'data:image/png;base64,def456', index: 1 },
+      ]);
+
+      // Should use -r flag for raw output
+      expect(spawn).toHaveBeenCalledWith(
+        'jq',
+        expect.arrayContaining(['-r', expect.any(String)]),
+        expect.any(Object),
+      );
+    });
+
+    test('should return 0 when no images found', async () => {
+      const images: Array<{ data: string; index: number }> = [];
+      const promise = jqExtractBase64PngStringsStreaming(
+        '/path/to/file.json',
+        (data, index) => {
+          images.push({ data, index });
+        },
+      );
+
+      childHandlers.get('close')?.(0);
+
+      const count = await promise;
+
+      expect(count).toBe(0);
+      expect(images).toEqual([]);
     });
   });
 
@@ -305,6 +603,53 @@ describe('jq utils', () => {
       expect(jqProgram).toContain('reduce paths');
       expect(jqProgram).toContain('images/img_');
       expect(jqProgram).toContain('.counter');
+    });
+  });
+
+  describe('jqReplaceBase64WithPathsToFile', () => {
+    test('should pipe jq output to temp file and rename to target', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+      vi.mocked(rename).mockResolvedValue(undefined);
+
+      const promise = jqReplaceBase64WithPathsToFile(
+        '/input.json',
+        '/output.json',
+        'images',
+        'pic',
+      );
+
+      mockChild.exitCode = 0;
+      childHandlers.get('close')?.(0);
+
+      await promise;
+
+      expect(createWriteStream).toHaveBeenCalledWith('/output.json.tmp');
+      expect(rename).toHaveBeenCalledWith('/output.json.tmp', '/output.json');
+
+      const jqProgram = vi.mocked(spawn).mock.calls[0][1][0];
+      expect(jqProgram).toContain('reduce paths');
+      expect(jqProgram).toContain('images/pic_');
+      expect(jqProgram).toContain('.data');
+    });
+
+    test('should reject when jq fails', async () => {
+      const mockWs = {} as Writable;
+      vi.mocked(createWriteStream).mockReturnValue(mockWs as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const promise = jqReplaceBase64WithPathsToFile(
+        '/input.json',
+        '/output.json',
+        'images',
+        'pic',
+      );
+
+      stderrHandlers.get('data')?.('error');
+      childHandlers.get('close')?.(1);
+
+      await expect(promise).rejects.toThrow('jq exited with code 1');
     });
   });
 });

--- a/packages/pdf-parser/src/utils/jq.ts
+++ b/packages/pdf-parser/src/utils/jq.ts
@@ -93,6 +93,10 @@ export function runJqFileToFile(
     });
 
     let stderr = '';
+    let exitCode: number | null = null;
+    let pipelineDone = false;
+    let settled = false;
+
     child.stderr.setEncoding('utf-8');
     child.stderr.on('data', (chunk: string) => {
       stderr += chunk;
@@ -100,38 +104,42 @@ export function runJqFileToFile(
 
     const ws = createWriteStream(outputPath);
 
+    function trySettle() {
+      if (settled) return;
+      if (!pipelineDone || exitCode === null) return;
+      settled = true;
+      if (exitCode !== 0) {
+        reject(
+          new Error(
+            `jq exited with code ${exitCode}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+          ),
+        );
+      } else {
+        resolve();
+      }
+    }
+
     child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
       ws.destroy();
       reject(err);
     });
 
     pipeline(child.stdout, ws)
       .then(() => {
-        // Wait for jq to exit after pipeline completes
-        if (child.exitCode !== null) {
-          if (child.exitCode !== 0) {
-            reject(
-              new Error(
-                `jq exited with code ${child.exitCode}. ${stderr ? 'Stderr: ' + stderr : ''}`,
-              ),
-            );
-          } else {
-            resolve();
-          }
-        }
+        pipelineDone = true;
+        trySettle();
       })
-      .catch(reject);
+      .catch((err) => {
+        if (settled) return;
+        settled = true;
+        reject(err);
+      });
 
     child.on('close', (code) => {
-      if (code !== 0) {
-        reject(
-          new Error(
-            `jq exited with code ${code}. ${stderr ? 'Stderr: ' + stderr : ''}`,
-          ),
-        );
-      } else {
-        resolve();
-      }
+      exitCode = code ?? 1;
+      trySettle();
     });
   });
 }
@@ -156,9 +164,21 @@ export function runJqFileLines(
 
     let stderr = '';
     let buffer = '';
+    let callbackError = false;
 
     child.stdout.setEncoding('utf-8');
     child.stderr.setEncoding('utf-8');
+
+    function safeOnLine(line: string): void {
+      if (callbackError) return;
+      try {
+        onLine(line);
+      } catch (err) {
+        callbackError = true;
+        child.kill();
+        reject(err);
+      }
+    }
 
     child.stdout.on('data', (chunk: string) => {
       buffer += chunk;
@@ -167,7 +187,7 @@ export function runJqFileLines(
         const line = buffer.slice(0, newlineIdx);
         buffer = buffer.slice(newlineIdx + 1);
         if (line.length > 0) {
-          onLine(line);
+          safeOnLine(line);
         }
       }
     });
@@ -177,14 +197,16 @@ export function runJqFileLines(
     });
 
     child.on('error', (err) => {
-      reject(err);
+      if (!callbackError) reject(err);
     });
 
     child.on('close', (code) => {
+      if (callbackError) return;
       // Process any remaining data in buffer
       if (buffer.length > 0) {
-        onLine(buffer);
+        safeOnLine(buffer);
       }
+      if (callbackError) return;
 
       if (code !== 0) {
         reject(

--- a/packages/pdf-parser/src/utils/jq.ts
+++ b/packages/pdf-parser/src/utils/jq.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
 
 /**
  * Resolve jq executable path from environment or default to 'jq' in PATH.
@@ -72,6 +75,131 @@ export function runJqFileJson<T = unknown>(
 }
 
 /**
+ * Run a jq program against a JSON file and pipe output directly to a file.
+ * Avoids loading jq output into Node.js memory.
+ */
+export function runJqFileToFile(
+  program: string,
+  inputPath: string,
+  outputPath: string,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const jqPath = getJqPath();
+    const args = [program, inputPath];
+
+    const child = spawn(jqPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stderr = '';
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    const ws = createWriteStream(outputPath);
+
+    child.on('error', (err) => {
+      ws.destroy();
+      reject(err);
+    });
+
+    pipeline(child.stdout, ws)
+      .then(() => {
+        // Wait for jq to exit after pipeline completes
+        if (child.exitCode !== null) {
+          if (child.exitCode !== 0) {
+            reject(
+              new Error(
+                `jq exited with code ${child.exitCode}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+              ),
+            );
+          } else {
+            resolve();
+          }
+        }
+      })
+      .catch(reject);
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `jq exited with code ${code}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+          ),
+        );
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Run a jq program with -r (raw output) and process stdout line by line.
+ * Each line is passed to the onLine callback immediately, avoiding memory accumulation.
+ */
+export function runJqFileLines(
+  program: string,
+  filePath: string,
+  onLine: (line: string) => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const jqPath = getJqPath();
+    const args = ['-r', program, filePath];
+
+    const child = spawn(jqPath, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    let stderr = '';
+    let buffer = '';
+
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+
+    child.stdout.on('data', (chunk: string) => {
+      buffer += chunk;
+      let newlineIdx: number;
+      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newlineIdx);
+        buffer = buffer.slice(newlineIdx + 1);
+        if (line.length > 0) {
+          onLine(line);
+        }
+      }
+    });
+
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on('error', (err) => {
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      // Process any remaining data in buffer
+      if (buffer.length > 0) {
+        onLine(buffer);
+      }
+
+      if (code !== 0) {
+        reject(
+          new Error(
+            `jq exited with code ${code}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+          ),
+        );
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
  * Convenience: extract all base64 PNG data-URI strings from a JSON file.
  */
 export function jqExtractBase64PngStrings(filePath: string): Promise<string[]> {
@@ -82,6 +210,27 @@ export function jqExtractBase64PngStrings(filePath: string): Promise<string[]> {
       ]
     `;
   return runJqFileJson<string[]>(program, filePath);
+}
+
+/**
+ * Streaming extraction of base64 PNG data-URI strings from a JSON file.
+ * Each image is passed to the onImage callback immediately instead of accumulating all in memory.
+ * Returns the total count of images found.
+ */
+export async function jqExtractBase64PngStringsStreaming(
+  filePath: string,
+  onImage: (base64Data: string, index: number) => void,
+): Promise<number> {
+  let index = 0;
+  await runJqFileLines(
+    '.. | select(type == "string" and startswith("data:image/png;base64"))',
+    filePath,
+    (line) => {
+      onImage(line, index);
+      index++;
+    },
+  );
+  return index;
 }
 
 /**
@@ -102,4 +251,28 @@ export function jqReplaceBase64WithPaths(
       ) | {data: .data, count: .counter}
     `;
   return runJqFileJson<{ data: unknown; count: number }>(program, filePath);
+}
+
+/**
+ * Replace base64 PNG data-URIs with file paths and pipe result directly to an output file.
+ * Avoids loading the entire transformed JSON into Node.js memory.
+ * Uses a temporary file and atomic rename to avoid corrupting the output.
+ */
+export async function jqReplaceBase64WithPathsToFile(
+  inputPath: string,
+  outputPath: string,
+  dirName: string,
+  prefix: string,
+): Promise<void> {
+  const program = `
+      reduce paths(type == "string" and startswith("data:image/png;base64")) as $p (
+        {data: ., counter: 0};
+        .counter as $idx |
+        .data |= setpath($p; "${dirName}/${prefix}_\\($idx).png") |
+        .counter += 1
+      ) | .data
+    `;
+  const tmpPath = outputPath + '.tmp';
+  await runJqFileToFile(program, inputPath, tmpPath);
+  await rename(tmpPath, outputPath);
 }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Refactor `PDFConverter` and `ImageExtractor` to use `jq`-based JSON processing instead of in-memory manipulation, significantly reducing memory usage when handling large PDF files.

## Changes

- Replace in-memory JSON manipulation in `PDFConverter` with `jq`-based updates for large file handling
- Add `extractImagesFromHtmlStream` to `ImageExtractor` for streaming-based HTML image processing
- Expand `jq` utility module with new helper functions for JSON manipulation
- Update mocks, tests, and error handling for consistency with the new streaming approach

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
