### PR TITLE
feat(pdf-parser): standardize DPI constants and add progress logging to page renderer

### DIFF
--- a/packages/pdf-parser/src/config/constants.ts
+++ b/packages/pdf-parser/src/config/constants.ts
@@ -54,13 +54,23 @@ export const DOCLING_ENVIRONMENT = {
 } as const;
 
 /**
+ * Configuration constants for page rendering DPI
+ */
+export const PAGE_RENDERING = {
+  /** Default rendering DPI for VLM text recognition quality */
+  DEFAULT_DPI: 200,
+  /** Low-resolution DPI for OCR strategy sampling */
+  SAMPLE_DPI: 150,
+} as const;
+
+/**
  * Configuration constants for ImagePdfConverter
  */
 export const IMAGE_PDF_CONVERTER = {
   /**
    * ImageMagick density option (DPI) for PDF to image conversion
    */
-  DENSITY: 300,
+  DENSITY: PAGE_RENDERING.DEFAULT_DPI,
 
   /**
    * ImageMagick quality option (1-100)

--- a/packages/pdf-parser/src/core/image-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/image-pdf-converter.test.ts
@@ -64,7 +64,7 @@ describe('ImagePdfConverter', () => {
       // Verify magick call
       expect(sharedMock.spawnAsync).toHaveBeenNthCalledWith(2, 'magick', [
         '-density',
-        '300',
+        '200',
         join('/tmp', `report-123-${fixedTimestamp}-input.pdf`),
         '-quality',
         '100',

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -1490,6 +1490,11 @@ describe('PDFConverter', () => {
         resultPath,
         resultPath + '.tmp',
       );
+      expect(runJqFileToFile).toHaveBeenCalledWith(
+        expect.stringContaining('.value.image.dpi = 200'),
+        resultPath,
+        resultPath + '.tmp',
+      );
       expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
     });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -14,7 +14,7 @@ import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
-import { PDF_CONVERTER } from '../config/constants';
+import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
@@ -833,7 +833,7 @@ export class PDFConverter {
         if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
           .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
           .value.image.mimetype = "image/png" |
-          .value.image.dpi = 300
+          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
         else . end
       )
     `;

--- a/packages/pdf-parser/src/processors/docling-document-assembler.test.ts
+++ b/packages/pdf-parser/src/processors/docling-document-assembler.test.ts
@@ -478,7 +478,7 @@ describe('DoclingDocumentAssembler', () => {
       expect(doc.pages['1'].page_no).toBe(1);
       expect(doc.pages['1'].size).toEqual({ width: 1190, height: 1684 });
       expect(doc.pages['1'].image.mimetype).toBe('image/png');
-      expect(doc.pages['1'].image.dpi).toBe(300);
+      expect(doc.pages['1'].image.dpi).toBe(200);
       expect(doc.pages['1'].image.uri).toBe(''); // Filled by VlmDocumentBuilder
       expect(doc.pages['2'].page_no).toBe(2);
     });
@@ -508,13 +508,13 @@ describe('DoclingDocumentAssembler', () => {
       expect(doc.pages['1'].image.dpi).toBe(150);
     });
 
-    test('defaults to DPI 300 when not provided in metadata', () => {
+    test('defaults to DPI 200 when not provided in metadata', () => {
       const pageResults: VlmPageResult[] = [{ pageNo: 1, elements: [] }];
       const metadata = createMetadata(1);
 
       const doc = assembler.assemble(pageResults, metadata);
 
-      expect(doc.pages['1'].image.dpi).toBe(300);
+      expect(doc.pages['1'].image.dpi).toBe(200);
     });
   });
 

--- a/packages/pdf-parser/src/processors/docling-document-assembler.ts
+++ b/packages/pdf-parser/src/processors/docling-document-assembler.ts
@@ -16,6 +16,8 @@ import type {
   VlmPageResult,
 } from '../types/vlm-page-result';
 
+import { PAGE_RENDERING } from '../config/constants.js';
+
 /** Metadata for document assembly */
 export interface AssemblerMetadata {
   /** Document name (e.g., filename without extension) */
@@ -24,7 +26,7 @@ export interface AssemblerMetadata {
   filename: string;
   /** Page dimensions in pixels (width x height at render DPI) */
   pageDimensions: Map<number, { width: number; height: number }>;
-  /** DPI used for page rendering (default: 300) */
+  /** DPI used for page rendering (default: 200) */
   dpi?: number;
 }
 
@@ -131,7 +133,7 @@ export class DoclingDocumentAssembler {
       label: 'unspecified',
     };
 
-    const dpi = metadata.dpi ?? 300;
+    const dpi = metadata.dpi ?? PAGE_RENDERING.DEFAULT_DPI;
     const pages = this.buildPages(sortedPages, metadata.pageDimensions, dpi);
 
     return {

--- a/packages/pdf-parser/src/processors/page-renderer.test.ts
+++ b/packages/pdf-parser/src/processors/page-renderer.test.ts
@@ -30,8 +30,10 @@ describe('PageRenderer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
     renderer = new PageRenderer(mockLogger);
     mockExistsSync.mockReturnValue(false);
+    // Default: pdfinfo returns empty (page count unknown), magick succeeds
     mockSpawnAsync.mockResolvedValue({ code: 0, stdout: '', stderr: '' });
   });
 
@@ -63,7 +65,7 @@ describe('PageRenderer', () => {
 
       expect(mockSpawnAsync).toHaveBeenCalledWith('magick', [
         '-density',
-        '300',
+        '200',
         '/tmp/input.pdf',
         '-background',
         'white',
@@ -180,17 +182,240 @@ describe('PageRenderer', () => {
       );
     });
 
-    test('logs rendering start and completion', async () => {
+    test('logs rendering start and completion when page count is unknown', async () => {
       mockReaddirSync.mockReturnValue(['page_0.png', 'page_1.png']);
 
       await renderer.renderPages('/tmp/input.pdf', '/tmp/output');
 
       expect(mockLogger.info).toHaveBeenCalledWith(
-        '[PageRenderer] Rendering PDF at 300 DPI...',
+        '[PageRenderer] Rendering PDF at 200 DPI...',
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
         '[PageRenderer] Rendered 2 pages to /tmp/output/pages',
       );
+    });
+  });
+
+  describe('page count detection', () => {
+    test('calls pdfinfo to get page count before rendering', async () => {
+      mockReaddirSync.mockReturnValue([]);
+
+      await renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      expect(mockSpawnAsync).toHaveBeenCalledWith('pdfinfo', [
+        '/tmp/input.pdf',
+      ]);
+    });
+
+    test('logs page count when pdfinfo returns valid count', async () => {
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({
+            code: 0,
+            stdout: 'Pages:          244',
+            stderr: '',
+          });
+        }
+        return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+      });
+      mockReaddirSync.mockReturnValue([]);
+
+      await renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[PageRenderer] Rendering 244 pages at 200 DPI...',
+      );
+    });
+
+    test('falls back to generic log when pdfinfo fails', async () => {
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({
+            code: 1,
+            stdout: '',
+            stderr: 'pdfinfo not found',
+          });
+        }
+        return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+      });
+      mockReaddirSync.mockReturnValue([]);
+
+      await renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[PageRenderer] Rendering PDF at 200 DPI...',
+      );
+    });
+
+    test('falls back to generic log when pdfinfo throws', async () => {
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.reject(new Error('spawn ENOENT'));
+        }
+        return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+      });
+      mockReaddirSync.mockReturnValue([]);
+
+      await renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[PageRenderer] Rendering PDF at 200 DPI...',
+      );
+    });
+  });
+
+  describe('progress logging', () => {
+    test('logs rendering progress during magick execution', async () => {
+      vi.useFakeTimers();
+
+      let readdirCallCount = 0;
+      mockReaddirSync.mockImplementation(() => {
+        readdirCallCount++;
+        // 1st call (progress poll at 2s): 1 file rendered
+        if (readdirCallCount === 1) return ['page_0.png'];
+        // 2nd call (progress poll at 4s): 2 files rendered
+        if (readdirCallCount === 2) return ['page_0.png', 'page_1.png'];
+        // 3rd+ call (final listing after render): all 3 files
+        return ['page_0.png', 'page_1.png', 'page_2.png'];
+      });
+
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({
+            code: 0,
+            stdout: 'Pages:          3',
+            stderr: '',
+          });
+        }
+        // magick takes 5 seconds
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ code: 0, stdout: '', stderr: '' }), 5000);
+        });
+      });
+
+      const promise = renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      // First progress poll at 2s
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[PageRenderer] Rendering pages: 1/3',
+      );
+
+      // Second progress poll at 4s
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[PageRenderer] Rendering pages: 2/3',
+      );
+
+      // magick completes at 5s
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
+    });
+
+    test('skips duplicate progress logs when count has not changed', async () => {
+      vi.useFakeTimers();
+
+      // Always return same count during progress polls
+      mockReaddirSync.mockReturnValue(['page_0.png']);
+
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({
+            code: 0,
+            stdout: 'Pages:          5',
+            stderr: '',
+          });
+        }
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ code: 0, stdout: '', stderr: '' }), 5000);
+        });
+      });
+
+      const promise = renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      // Two polls, same file count
+      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      // Should only log "1/5" once (deduplication)
+      const progressCalls = mockLogger.info.mock.calls.filter(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('Rendering pages:'),
+      );
+      expect(progressCalls).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
+    });
+
+    test('cleans up progress interval when magick fails', async () => {
+      vi.useFakeTimers();
+
+      mockReaddirSync.mockReturnValue([]);
+
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({
+            code: 0,
+            stdout: 'Pages:          5',
+            stderr: '',
+          });
+        }
+        return new Promise((resolve) => {
+          setTimeout(
+            () => resolve({ code: 1, stdout: '', stderr: 'render error' }),
+            3000,
+          );
+        });
+      });
+
+      const promise = renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+      // Attach a no-op catch to prevent PromiseRejectionHandledWarning
+      // (the rejection is still asserted below via rejects.toThrow)
+      promise.catch(() => {});
+
+      await vi.advanceTimersByTimeAsync(3000);
+      await expect(promise).rejects.toThrow(
+        '[PageRenderer] Failed to render PDF pages: render error',
+      );
+
+      // Verify no more interval callbacks after error (interval was cleared)
+      mockLogger.info.mockClear();
+      await vi.advanceTimersByTimeAsync(4000);
+      const progressCalls = mockLogger.info.mock.calls.filter(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('Rendering pages:'),
+      );
+      expect(progressCalls).toHaveLength(0);
+    });
+
+    test('does not start progress interval when page count is unknown', async () => {
+      vi.useFakeTimers();
+
+      mockReaddirSync.mockReturnValue([]);
+
+      mockSpawnAsync.mockImplementation((cmd: string) => {
+        if (cmd === 'pdfinfo') {
+          return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+        }
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ code: 0, stdout: '', stderr: '' }), 3000);
+        });
+      });
+
+      const promise = renderer.renderPages('/tmp/input.pdf', '/tmp/output');
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      // No progress log when page count is 0
+      const progressCalls = mockLogger.info.mock.calls.filter(
+        (args: string[]) =>
+          typeof args[0] === 'string' && args[0].includes('Rendering pages:'),
+      );
+      expect(progressCalls).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await promise;
     });
   });
 });

--- a/packages/pdf-parser/src/processors/page-renderer.ts
+++ b/packages/pdf-parser/src/processors/page-renderer.ts
@@ -4,8 +4,10 @@ import { spawnAsync } from '@heripo/shared';
 import { existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** Default rendering DPI for VLM text recognition quality */
-const DEFAULT_DPI = 300;
+import { PAGE_RENDERING } from '../config/constants.js';
+
+/** Interval for progress polling in milliseconds */
+const PROGRESS_POLL_INTERVAL_MS = 2000;
 
 /** Result of page rendering */
 export interface PageRenderResult {
@@ -19,7 +21,7 @@ export interface PageRenderResult {
 
 /** Options for page rendering */
 export interface PageRendererOptions {
-  /** DPI for rendered images (default: 300) */
+  /** DPI for rendered images (default: 200) */
   dpi?: number;
 }
 
@@ -46,34 +48,69 @@ export class PageRenderer {
     outputDir: string,
     options?: PageRendererOptions,
   ): Promise<PageRenderResult> {
-    const dpi = options?.dpi ?? DEFAULT_DPI;
+    const dpi = options?.dpi ?? PAGE_RENDERING.DEFAULT_DPI;
     const pagesDir = join(outputDir, 'pages');
 
     if (!existsSync(pagesDir)) {
       mkdirSync(pagesDir, { recursive: true });
     }
 
-    this.logger.info(`[PageRenderer] Rendering PDF at ${dpi} DPI...`);
+    const totalPages = await this.getPageCount(pdfPath);
+
+    if (totalPages > 0) {
+      this.logger.info(
+        `[PageRenderer] Rendering ${totalPages} pages at ${dpi} DPI...`,
+      );
+    } else {
+      this.logger.info(`[PageRenderer] Rendering PDF at ${dpi} DPI...`);
+    }
 
     const outputPattern = join(pagesDir, 'page_%d.png');
 
-    const result = await spawnAsync('magick', [
-      '-density',
-      dpi.toString(),
-      pdfPath,
-      '-background',
-      'white',
-      '-alpha',
-      'remove',
-      '-alpha',
-      'off',
-      outputPattern,
-    ]);
+    // Poll output directory for progress during rendering
+    let progressInterval: ReturnType<typeof setInterval> | null = null;
+    if (totalPages > 0) {
+      let lastLoggedCount = 0;
+      progressInterval = setInterval(() => {
+        try {
+          const rendered = readdirSync(pagesDir).filter(
+            (f) => f.startsWith('page_') && f.endsWith('.png'),
+          ).length;
+          if (rendered > 0 && rendered !== lastLoggedCount) {
+            lastLoggedCount = rendered;
+            this.logger.info(
+              `[PageRenderer] Rendering pages: ${rendered}/${totalPages}`,
+            );
+          }
+        } catch {
+          /* ignore read errors during rendering */
+        }
+      }, PROGRESS_POLL_INTERVAL_MS);
+    }
 
-    if (result.code !== 0) {
-      throw new Error(
-        `[PageRenderer] Failed to render PDF pages: ${result.stderr || 'Unknown error'}`,
-      );
+    try {
+      const result = await spawnAsync('magick', [
+        '-density',
+        dpi.toString(),
+        pdfPath,
+        '-background',
+        'white',
+        '-alpha',
+        'remove',
+        '-alpha',
+        'off',
+        outputPattern,
+      ]);
+
+      if (result.code !== 0) {
+        throw new Error(
+          `[PageRenderer] Failed to render PDF pages: ${result.stderr || 'Unknown error'}`,
+        );
+      }
+    } finally {
+      if (progressInterval) {
+        clearInterval(progressInterval);
+      }
     }
 
     const pageFiles = readdirSync(pagesDir)
@@ -94,5 +131,20 @@ export class PageRenderer {
       pagesDir,
       pageFiles,
     };
+  }
+
+  /**
+   * Get total page count using pdfinfo.
+   * Returns 0 on failure (progress logging will be skipped).
+   */
+  private async getPageCount(pdfPath: string): Promise<number> {
+    try {
+      const result = await spawnAsync('pdfinfo', [pdfPath]);
+      if (result.code !== 0) return 0;
+      const match = result.stdout.match(/^Pages:\s+(\d+)/m);
+      return match ? parseInt(match[1], 10) : 0;
+    } catch {
+      return 0;
+    }
   }
 }

--- a/packages/pdf-parser/src/processors/vlm-document-builder.test.ts
+++ b/packages/pdf-parser/src/processors/vlm-document-builder.test.ts
@@ -23,7 +23,7 @@ function createTestDoc(
       size: { width: 1000, height: 1400 },
       image: {
         mimetype: 'image/png',
-        dpi: 300,
+        dpi: 200,
         size: { width: 1000, height: 1400 },
         uri: '', // Empty, to be filled by builder
       },
@@ -262,7 +262,7 @@ describe('VlmDocumentBuilder', () => {
       expect(page.page_no).toBe(1);
       expect(page.size).toEqual({ width: 1000, height: 1400 });
       expect(page.image.mimetype).toBe('image/png');
-      expect(page.image.dpi).toBe(300);
+      expect(page.image.dpi).toBe(200);
       expect(page.image.size).toEqual({ width: 1000, height: 1400 });
       expect(page.image.uri).toBe('pages/page_0.png');
     });

--- a/packages/pdf-parser/src/processors/vlm-text-corrector.test.ts
+++ b/packages/pdf-parser/src/processors/vlm-text-corrector.test.ts
@@ -166,7 +166,7 @@ function createTestDoc(
         size: { width: 595, height: 842 },
         image: {
           mimetype: 'image/png',
-          dpi: 300,
+          dpi: 200,
           size: { width: 2480, height: 3508 },
           uri: 'pages/page_0.png',
         },
@@ -686,7 +686,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_0.png',
             },
@@ -696,7 +696,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_1.png',
             },
@@ -706,7 +706,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_2.png',
             },
@@ -754,7 +754,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_0.png',
             },
@@ -764,7 +764,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_1.png',
             },
@@ -814,7 +814,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_0.png',
             },
@@ -824,7 +824,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_1.png',
             },
@@ -834,7 +834,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_2.png',
             },
@@ -844,7 +844,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_3.png',
             },
@@ -854,7 +854,7 @@ describe('VlmTextCorrector', () => {
             size: { width: 595, height: 842 },
             image: {
               mimetype: 'image/png',
-              dpi: 300,
+              dpi: 200,
               size: { width: 2480, height: 3508 },
               uri: 'pages/page_4.png',
             },
@@ -1045,7 +1045,7 @@ describe('VlmTextCorrector', () => {
         size: { width: 595, height: 842 },
         image: {
           mimetype: 'image/png',
-          dpi: 300,
+          dpi: 200,
           size: { width: 2480, height: 3508 },
           uri: 'pages/page_1.png',
         },
@@ -1122,7 +1122,7 @@ describe('VlmTextCorrector', () => {
         size: { width: 595, height: 842 },
         image: {
           mimetype: 'image/png',
-          dpi: 300,
+          dpi: 200,
           size: { width: 2480, height: 3508 },
           uri: 'pages/page_1.png',
         },
@@ -1181,7 +1181,7 @@ describe('VlmTextCorrector', () => {
         size: { width: 595, height: 842 },
         image: {
           mimetype: 'image/png',
-          dpi: 300,
+          dpi: 200,
           size: { width: 2480, height: 3508 },
           uri: 'pages/page_1.png',
         },
@@ -2112,7 +2112,7 @@ describe('VlmTextCorrector', () => {
         size: { width: 595, height: 842 },
         image: {
           mimetype: 'image/png',
-          dpi: 300,
+          dpi: 200,
           size: { width: 2480, height: 3508 },
           uri: 'pages/page_1.png',
         },

--- a/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
+++ b/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
@@ -10,10 +10,8 @@ import { LLMCaller } from '@heripo/shared';
 import { readFileSync } from 'node:fs';
 import { z } from 'zod/v4';
 
+import { PAGE_RENDERING } from '../config/constants.js';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
-
-/** DPI for sampling pages */
-const SAMPLE_DPI = 150;
 
 /** Ratio of pages to trim from front and back (covers, TOC, appendices) */
 const EDGE_TRIM_RATIO = 0.1;
@@ -127,7 +125,7 @@ export class OcrStrategySampler {
     const renderResult = await this.pageRenderer.renderPages(
       pdfPath,
       outputDir,
-      { dpi: SAMPLE_DPI },
+      { dpi: PAGE_RENDERING.SAMPLE_DPI },
     );
 
     if (renderResult.pageCount === 0) {


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Centralize DPI configuration into shared constants (`DEFAULT_DPI: 200`, `SAMPLE_DPI: 150`) and add progress logging to `PageRenderer` for better visibility during long-running PDF rendering tasks.

## Changes

- Define `PAGE_RENDERING.DEFAULT_DPI` (200) and `PAGE_RENDERING.SAMPLE_DPI` (150) in `config/constants.ts`
- Replace all hardcoded DPI values (300) with the centralized `PAGE_RENDERING.DEFAULT_DPI` constant
- Lower default rendering DPI from 300 to 200 for improved performance
- Add `pdfinfo`-based page count detection before rendering
- Add interval-based progress polling that logs `Rendering pages: X/Y` during magick execution
- Ensure progress interval is properly cleaned up on both success and failure
- Update and extend tests to cover page count detection, progress logging, deduplication, and error handling

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
