### PR TITLE
feat(pdf-parser): add chunked PDF conversion for improved scalability

### DIFF
--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -269,6 +269,7 @@ export async function runTaskWorker(
 
     // Build PDF convert options with new strategy fields
     const pdfConvertOptions: PDFConvertOptions = {
+      chunkedConversion: true,
       num_threads: options.threadCount,
       forceImagePdf: options.forceImagePdf,
       ...(options.strategySamplerModel

--- a/packages/pdf-parser/src/config/constants.ts
+++ b/packages/pdf-parser/src/config/constants.ts
@@ -66,6 +66,19 @@ export const PAGE_RENDERING = {
 /**
  * Configuration constants for ImagePdfConverter
  */
+/**
+ * Configuration constants for chunked PDF conversion
+ */
+export const CHUNKED_CONVERSION = {
+  /** Number of pages per chunk */
+  DEFAULT_CHUNK_SIZE: 10,
+  /** Maximum retry attempts per failed chunk */
+  DEFAULT_MAX_RETRIES: 2,
+} as const;
+
+/**
+ * Configuration constants for ImagePdfConverter
+ */
 export const IMAGE_PDF_CONVERTER = {
   /**
    * ImageMagick density option (DPI) for PDF to image conversion

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -324,8 +324,11 @@ describe('ChunkedPDFConverter', () => {
         expect.objectContaining({ page_range: [21, 25] }),
       );
 
-      // Merger called with 3 documents
-      expect(mockMergerInstance.merge).toHaveBeenCalledWith([doc1, doc2, doc3]);
+      // Merger called with 3 documents and picFileOffsets
+      expect(mockMergerInstance.merge).toHaveBeenCalledWith(
+        [doc1, doc2, doc3],
+        [0, 0, 0],
+      );
 
       // onComplete callback called
       expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/report-1');
@@ -1035,6 +1038,129 @@ describe('ChunkedPDFConverter', () => {
           mockBuildOptions,
         ),
       ).rejects.toThrow('Failed to detect page count from PDF');
+    });
+
+    test('throws on non-positive chunkSize', () => {
+      const zeroChunkConverter = new ChunkedPDFConverter(logger, client, {
+        chunkSize: 0,
+        maxRetries: 0,
+      });
+      expect(() => zeroChunkConverter.calculateChunks(10)).toThrow(
+        'chunkSize must be positive',
+      );
+
+      const negativeChunkConverter = new ChunkedPDFConverter(logger, client, {
+        chunkSize: -5,
+        maxRetries: 0,
+      });
+      expect(() => negativeChunkConverter.calculateChunks(10)).toThrow(
+        'chunkSize must be positive',
+      );
+    });
+
+    test('_chunks directory is cleaned up even when renderPageImages throws', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      mockRendererInstance.renderPages.mockRejectedValue(
+        new Error('ImageMagick crashed'),
+      );
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('ImageMagick crashed');
+
+      // _chunks dir still cleaned up despite error
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunks'),
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    test('_chunks directory is cleaned up even when onComplete throws', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      mockOnComplete.mockRejectedValue(new Error('Callback error'));
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Callback error');
+
+      // _chunks dir still cleaned up despite callback error
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunks'),
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    test('picFileOffsets are passed to merger based on chunk pic_ file counts', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          20\n',
+        stderr: '',
+      });
+
+      // Simulate pic_ files in chunk directories for buildPicFileOffsets
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const p = String(path);
+        return (
+          p.includes('_chunk_0/output/images') ||
+          p.includes('_chunk_1/output/images')
+        );
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        const p = String(path);
+        // buildPicFileOffsets reads chunk dirs
+        if (p.includes('_chunk_0/output/images')) {
+          return ['pic_0.png', 'pic_1.png', 'pic_2.png'] as any;
+        }
+        if (p.includes('_chunk_1/output/images')) {
+          return ['pic_0.png', 'pic_1.png'] as any;
+        }
+        return [] as any;
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // Merger should have been called with picFileOffsets [0, 3]
+      // (chunk 0 has 3 pic files, so chunk 1 offset = 3)
+      expect(mockMergerInstance.merge).toHaveBeenCalledWith(
+        expect.any(Array),
+        [0, 3],
+      );
     });
   });
 });

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -1,0 +1,1040 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingDocument } from '@heripo/model';
+import type { DoclingAPIClient } from 'docling-sdk';
+
+import { spawnAsync } from '@heripo/shared';
+import {
+  copyFileSync,
+  createWriteStream,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { rename } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DoclingDocumentMerger } from '../processors/docling-document-merger';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { LocalFileServer } from '../utils/local-file-server';
+import { ChunkedPDFConverter } from './chunked-pdf-converter';
+
+vi.mock('@heripo/shared', () => ({
+  spawnAsync: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  copyFileSync: vi.fn(),
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  readdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  rename: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('node:stream/promises', () => ({
+  pipeline: vi.fn(),
+}));
+
+vi.mock('../processors/image-extractor', () => ({
+  ImageExtractor: {
+    extractAndSaveDocumentsFromZip: vi.fn(),
+  },
+}));
+
+vi.mock('../processors/docling-document-merger', () => ({
+  DoclingDocumentMerger: vi.fn(),
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
+}));
+
+vi.mock('../utils/jq', () => ({
+  runJqFileJson: vi.fn(),
+  runJqFileToFile: vi.fn(),
+}));
+
+vi.mock('../utils/local-file-server', () => ({
+  LocalFileServer: vi.fn(),
+}));
+
+function makeDoc(overrides: Partial<DoclingDocument> = {}): DoclingDocument {
+  return {
+    schema_name: 'DoclingDocument',
+    version: '1.0',
+    name: 'test',
+    origin: {
+      mimetype: 'application/pdf',
+      binary_hash: 123,
+      filename: 'test.pdf',
+    },
+    body: {
+      self_ref: '#/body',
+      children: [],
+      content_layer: 'body',
+      name: '_root_',
+      label: 'unspecified',
+    },
+    furniture: {
+      self_ref: '#/furniture',
+      children: [],
+      content_layer: 'furniture',
+      name: '_root_',
+      label: 'unspecified',
+    },
+    groups: [],
+    texts: [],
+    pictures: [],
+    tables: [],
+    pages: {},
+    ...overrides,
+  };
+}
+
+describe('ChunkedPDFConverter', () => {
+  let logger: LoggerMethods;
+  let client: DoclingAPIClient;
+  let converter: ChunkedPDFConverter;
+  let mockOnComplete: Mock;
+  let mockBuildOptions: Mock;
+  let mockServerInstance: { start: Mock; stop: Mock };
+  let mockMergerInstance: { merge: Mock };
+  let mockRendererInstance: { renderPages: Mock };
+  let mockTask: { taskId: string; poll: Mock; getResult: Mock };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    mockTask = {
+      taskId: 'task-1',
+      poll: vi.fn().mockResolvedValue({ task_status: 'success' }),
+      getResult: vi.fn(),
+    };
+
+    client = {
+      convertSourceAsync: vi.fn().mockResolvedValue(mockTask),
+      getTaskResultFile: vi
+        .fn()
+        .mockResolvedValue({ data: Buffer.from('zip') }),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
+    } as unknown as DoclingAPIClient;
+
+    converter = new ChunkedPDFConverter(logger, client, {
+      chunkSize: 10,
+      maxRetries: 2,
+    });
+
+    mockOnComplete = vi.fn();
+    mockBuildOptions = vi.fn().mockReturnValue({ to_formats: ['json'] });
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
+
+    // Mock LocalFileServer
+    mockServerInstance = {
+      start: vi.fn().mockResolvedValue('http://127.0.0.1:3000/test.pdf'),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(LocalFileServer).mockImplementation(function () {
+      return mockServerInstance as any;
+    });
+
+    // Mock DoclingDocumentMerger
+    mockMergerInstance = {
+      merge: vi.fn().mockImplementation((docs: DoclingDocument[]) => {
+        if (docs.length === 1) return docs[0];
+        return makeDoc({
+          texts: docs.flatMap((d) => d.texts),
+          pictures: docs.flatMap((d) => d.pictures),
+          tables: docs.flatMap((d) => d.tables),
+          pages: Object.assign({}, ...docs.map((d) => d.pages)),
+        });
+      }),
+    };
+    vi.mocked(DoclingDocumentMerger).mockImplementation(function () {
+      return mockMergerInstance as any;
+    });
+
+    // Mock PageRenderer
+    mockRendererInstance = {
+      renderPages: vi.fn().mockResolvedValue({
+        pageCount: 25,
+        pagesDir: '/test/cwd/output/report/pages',
+        pageFiles: [],
+      }),
+    };
+    vi.mocked(PageRenderer).mockImplementation(function () {
+      return mockRendererInstance as any;
+    });
+
+    // Mock spawnAsync (pdfinfo returning page count)
+    vi.mocked(spawnAsync).mockResolvedValue({
+      code: 0,
+      stdout: 'Pages:          25\n',
+      stderr: '',
+    });
+
+    // Mock runJqFileJson (returns DoclingDocument per chunk)
+    vi.mocked(runJqFileJson).mockResolvedValue(makeDoc());
+
+    // Mock runJqFileToFile
+    vi.mocked(runJqFileToFile).mockResolvedValue(undefined as any);
+
+    // Mock rename
+    vi.mocked(rename).mockResolvedValue(undefined);
+
+    // Mock existsSync: default false
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    // Mock readdirSync: empty by default
+    vi.mocked(readdirSync).mockReturnValue([] as any);
+
+    // Mock readFileSync: empty JSON by default (for cleanupOrphanedPicFiles)
+    vi.mocked(readFileSync).mockReturnValue('{}');
+  });
+
+  describe('calculateChunks', () => {
+    test('divides pages evenly', () => {
+      const chunks = converter.calculateChunks(30);
+      expect(chunks).toEqual([
+        [1, 10],
+        [11, 20],
+        [21, 30],
+      ]);
+    });
+
+    test('handles remainder pages', () => {
+      const chunks = converter.calculateChunks(25);
+      expect(chunks).toEqual([
+        [1, 10],
+        [11, 20],
+        [21, 25],
+      ]);
+    });
+
+    test('handles single chunk', () => {
+      const chunks = converter.calculateChunks(5);
+      expect(chunks).toEqual([[1, 5]]);
+    });
+
+    test('handles exact chunk size', () => {
+      const chunks = converter.calculateChunks(10);
+      expect(chunks).toEqual([[1, 10]]);
+    });
+  });
+
+  describe('convertChunked', () => {
+    test('normal 3-chunk conversion and merge', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          25\n',
+        stderr: '',
+      });
+
+      const doc1 = makeDoc({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: 'a',
+            text: 'a',
+          },
+        ],
+      });
+      const doc2 = makeDoc({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: 'b',
+            text: 'b',
+          },
+        ],
+      });
+      const doc3 = makeDoc({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: 'c',
+            text: 'c',
+          },
+        ],
+      });
+
+      vi.mocked(runJqFileJson)
+        .mockResolvedValueOnce(doc1)
+        .mockResolvedValueOnce(doc2)
+        .mockResolvedValueOnce(doc3);
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // Local file server started and stopped
+      expect(mockServerInstance.start).toHaveBeenCalledWith('/test/input.pdf');
+      expect(mockServerInstance.stop).toHaveBeenCalled();
+
+      // 3 chunks created (25 pages / 10 = 3 chunks)
+      expect(client.convertSourceAsync).toHaveBeenCalledTimes(3);
+
+      // buildConversionOptions called with page_range for each chunk
+      expect(mockBuildOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ page_range: [1, 10] }),
+      );
+      expect(mockBuildOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ page_range: [11, 20] }),
+      );
+      expect(mockBuildOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ page_range: [21, 25] }),
+      );
+
+      // Merger called with 3 documents
+      expect(mockMergerInstance.merge).toHaveBeenCalledWith([doc1, doc2, doc3]);
+
+      // onComplete callback called
+      expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/report-1');
+
+      // Page rendering done
+      expect(mockRendererInstance.renderPages).toHaveBeenCalled();
+    });
+
+    test('fails when page count detection fails', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 1,
+        stdout: '',
+        stderr: 'pdfinfo failed',
+      });
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Failed to detect page count from PDF');
+    });
+
+    test('chunk failure triggers retry and succeeds', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // First call fails, second succeeds
+      vi.mocked(client.convertSourceAsync as Mock)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce(mockTask);
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // Called twice (1 failure + 1 retry success)
+      expect(client.convertSourceAsync).toHaveBeenCalledTimes(2);
+      expect(mockOnComplete).toHaveBeenCalled();
+    });
+
+    test('max retries exceeded causes total failure', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // All attempts fail
+      vi.mocked(client.convertSourceAsync as Mock).mockRejectedValue(
+        new Error('Persistent error'),
+      );
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Persistent error');
+
+      // Original + maxRetries(2) = 3 attempts
+      expect(client.convertSourceAsync).toHaveBeenCalledTimes(3);
+      // Server is always stopped even on failure
+      expect(mockServerInstance.stop).toHaveBeenCalled();
+    });
+
+    test('abort signal stops conversion', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          25\n',
+        stderr: '',
+      });
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+          controller.signal,
+        ),
+      ).rejects.toThrow('aborted');
+
+      // Server always stopped
+      expect(mockServerInstance.stop).toHaveBeenCalled();
+    });
+
+    test('image relocation with global indexing for both pic_ and image_ files', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          20\n',
+        stderr: '',
+      });
+
+      // Simulate images in chunk directories
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const p = String(path);
+        return (
+          p.includes('_chunk_0/output/images') ||
+          p.includes('_chunk_1/output/images')
+        );
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        const p = String(path);
+        if (p.includes('_chunk_0/output/images')) {
+          return [
+            'pic_0.png',
+            'pic_1.png',
+            'image_0.png',
+            'image_1.png',
+          ] as any;
+        }
+        if (p.includes('_chunk_1/output/images')) {
+          return ['pic_0.png', 'image_0.png'] as any;
+        }
+        return [] as any;
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // 3 pic_ + 3 image_ = 6 total copies
+      expect(copyFileSync).toHaveBeenCalledTimes(6);
+
+      // pic_ files with global indexing
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/pic_0.png'),
+        expect.stringContaining('images/pic_0.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/pic_1.png'),
+        expect.stringContaining('images/pic_1.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_1/output/images/pic_0.png'),
+        expect.stringContaining('images/pic_2.png'),
+      );
+
+      // image_ files with global indexing
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/image_0.png'),
+        expect.stringContaining('images/image_0.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/image_1.png'),
+        expect.stringContaining('images/image_1.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_1/output/images/image_0.png'),
+        expect.stringContaining('images/image_2.png'),
+      );
+    });
+
+    test('image_ files are relocated with global indexing when no pic_ files exist', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          20\n',
+        stderr: '',
+      });
+
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const p = String(path);
+        return (
+          p.includes('_chunk_0/output/images') ||
+          p.includes('_chunk_1/output/images')
+        );
+      });
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        const p = String(path);
+        if (p.includes('_chunk_0/output/images')) {
+          return ['image_0.png', 'image_1.png'] as any;
+        }
+        if (p.includes('_chunk_1/output/images')) {
+          return ['image_0.png'] as any;
+        }
+        return [] as any;
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // 3 image_ files only
+      expect(copyFileSync).toHaveBeenCalledTimes(3);
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/image_0.png'),
+        expect.stringContaining('images/image_0.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_0/output/images/image_1.png'),
+        expect.stringContaining('images/image_1.png'),
+      );
+      expect(copyFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunk_1/output/images/image_0.png'),
+        expect.stringContaining('images/image_2.png'),
+      );
+    });
+
+    test('onComplete receives correct outputDir', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'my-report',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/my-report');
+    });
+
+    test('cleanupAfterCallback removes output directory', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // existsSync returns true for cleanup checks
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        true,
+        {},
+        mockBuildOptions,
+      );
+
+      // Both chunks dir and output dir cleaned up
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunks'),
+        expect.objectContaining({ recursive: true }),
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        '/test/cwd/output/report-1',
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    test('merged result.json is written to output directory', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      expect(writeFileSync).toHaveBeenCalledWith(
+        '/test/cwd/output/report-1/result.json',
+        expect.any(String),
+      );
+    });
+
+    test('task poll failure reports error details', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      const failingTask = {
+        taskId: 'task-fail',
+        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
+        getResult: vi.fn().mockResolvedValue({
+          errors: [{ message: 'OCR engine crashed' }],
+        }),
+      };
+
+      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
+        failingTask,
+      );
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('OCR engine crashed');
+    });
+
+    test('task poll failure without errors array falls back to unknown', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      const failingTask = {
+        taskId: 'task-fail',
+        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
+        getResult: vi.fn().mockResolvedValue({ status: 'failure' }),
+      };
+
+      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
+        failingTask,
+      );
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Chunk task failed: unknown');
+    });
+
+    test('task poll failure with getResult error falls back to unknown', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      const failingTask = {
+        taskId: 'task-fail',
+        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
+        getResult: vi.fn().mockRejectedValue(new Error('Network error')),
+      };
+
+      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
+        failingTask,
+      );
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Chunk task failed: unknown');
+    });
+
+    test('task poll timeout throws error', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // Use a very short timeout
+      const shortTimeoutConverter = new ChunkedPDFConverter(
+        logger,
+        client,
+        { chunkSize: 10, maxRetries: 0 },
+        1,
+      );
+
+      const hangingTask = {
+        taskId: 'task-hang',
+        poll: vi.fn().mockResolvedValue({ task_status: 'pending' }),
+        getResult: vi.fn(),
+      };
+
+      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
+        hangingTask,
+      );
+
+      await expect(
+        shortTimeoutConverter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Chunk task timeout');
+    });
+
+    test('downloadResult uses fileStream when available', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      const mockWriteStream = { on: vi.fn() };
+      vi.mocked(createWriteStream).mockReturnValue(mockWriteStream as any);
+      vi.mocked(pipeline).mockResolvedValue(undefined);
+
+      const mockStream = { pipe: vi.fn() };
+      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({
+        fileStream: mockStream,
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      expect(pipeline).toHaveBeenCalled();
+    });
+
+    test('downloadResult uses fetch fallback when no fileStream or data', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:5001/v1/result/task-1',
+        expect.objectContaining({ headers: { Accept: 'application/zip' } }),
+      );
+
+      vi.unstubAllGlobals();
+    });
+
+    test('downloadResult fetch fallback throws on non-ok response', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Failed to download chunk ZIP: 500');
+
+      vi.unstubAllGlobals();
+    });
+
+    test('chunk temp files are cleaned up after successful conversion', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // existsSync returns true for zip and extract cleanup
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // ZIP and extracted dirs are cleaned per chunk
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('result.zip'),
+        expect.objectContaining({ force: true }),
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('extracted'),
+        expect.objectContaining({ recursive: true }),
+      );
+    });
+
+    test('cleanupAfterCallback skips rmSync when outputDir does not exist', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // existsSync returns true for _chunks but false for outputDir
+      vi.mocked(existsSync).mockImplementation((path) => {
+        const p = String(path);
+        return p.includes('_chunks');
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        true,
+        {},
+        mockBuildOptions,
+      );
+
+      // _chunks dir cleaned up
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('_chunks'),
+        expect.objectContaining({ recursive: true }),
+      );
+      // outputDir rmSync NOT called (existsSync returned false)
+      expect(rmSync).not.toHaveBeenCalledWith(
+        '/test/cwd/output/report-1',
+        expect.any(Object),
+      );
+    });
+
+    test('orphaned pic_ files are cleaned up after page rendering', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // result.json has no pic_ references → all pic_ files are orphaned
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          pages: { '0': { image: { uri: 'pages/page_0.png' } } },
+        }),
+      );
+
+      // cleanupOrphanedPicFiles reads the final images dir
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        const p = String(path);
+        if (p === '/test/cwd/output/report-1/images') {
+          return ['pic_0.png', 'pic_1.png', 'pic_2.png'] as any;
+        }
+        return [] as any;
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // All 3 orphaned pic_ files deleted
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_0.png'),
+        expect.objectContaining({ force: true }),
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_1.png'),
+        expect.objectContaining({ force: true }),
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_2.png'),
+        expect.objectContaining({ force: true }),
+      );
+
+      // Logger reports cleanup
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('Cleaned up 3 orphaned pic_ files'),
+      );
+    });
+
+    test('referenced pic_ files are preserved during cleanup', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      // result.json references pic_1.png (actual content image)
+      vi.mocked(readFileSync).mockReturnValue(
+        JSON.stringify({
+          pictures: [{ image: { uri: 'images/pic_1.png' } }],
+          pages: { '0': { image: { uri: 'pages/page_0.png' } } },
+        }),
+      );
+
+      vi.mocked(readdirSync).mockImplementation((path) => {
+        const p = String(path);
+        if (p === '/test/cwd/output/report-1/images') {
+          return ['pic_0.png', 'pic_1.png', 'pic_2.png'] as any;
+        }
+        return [] as any;
+      });
+
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
+
+      // pic_0 and pic_2 deleted (orphaned)
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_0.png'),
+        expect.objectContaining({ force: true }),
+      );
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('images/pic_2.png'),
+        expect.objectContaining({ force: true }),
+      );
+
+      // pic_1 NOT deleted (referenced)
+      const rmSyncCalls = vi.mocked(rmSync).mock.calls;
+      const deletedPic1 = rmSyncCalls.some((call) =>
+        String(call[0]).includes('images/pic_1.png'),
+      );
+      expect(deletedPic1).toBe(false);
+
+      // Logger reports 2 orphaned, 1 kept
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Cleaned up 2 orphaned pic_ files (1 referenced, kept)',
+        ),
+      );
+    });
+
+    test('pdfinfo returning no Pages line yields zero page count', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Title: Test\nCreator: Test\n',
+        stderr: '',
+      });
+
+      await expect(
+        converter.convertChunked(
+          'file:///test/input.pdf',
+          'report-1',
+          mockOnComplete,
+          false,
+          {},
+          mockBuildOptions,
+        ),
+      ).rejects.toThrow('Failed to detect page count from PDF');
+    });
+  });
+});

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -137,7 +137,11 @@ export class ChunkedPDFConverter {
       `[ChunkedPDFConverter] All ${chunks.length} chunks completed, merging...`,
     );
     const merger = new DoclingDocumentMerger();
-    const merged = merger.merge(chunkDocuments);
+    const picFileOffsets = this.buildPicFileOffsets(
+      chunksBaseDir,
+      chunks.length,
+    );
+    const merged = merger.merge(chunkDocuments, picFileOffsets);
 
     this.logger.info(
       `[ChunkedPDFConverter] Merged: ${merged.texts.length} texts, ${merged.pictures.length} pictures, ${merged.tables.length} tables, ${Object.keys(merged.pages).length} pages`,
@@ -155,33 +159,40 @@ export class ChunkedPDFConverter {
     const resultPath = join(outputDir, 'result.json');
     writeFileSync(resultPath, JSON.stringify(merged));
 
-    // Step 7: Render page images (ImageMagick, same as non-chunked)
-    await this.renderPageImages(pdfPath, outputDir);
+    try {
+      // Step 7: Render page images (ImageMagick, same as non-chunked)
+      await this.renderPageImages(pdfPath, outputDir);
 
-    // Step 7.5: Clean up orphaned pic_ files
-    this.cleanupOrphanedPicFiles(resultPath, imagesDir);
+      // Step 7.5: Clean up orphaned pic_ files
+      this.cleanupOrphanedPicFiles(resultPath, imagesDir);
 
-    this.checkAbort(abortSignal);
+      this.checkAbort(abortSignal);
 
-    // Step 8: Execute completion callback
-    this.logger.info('[ChunkedPDFConverter] Executing completion callback...');
-    await onComplete(outputDir);
-
-    // Step 9: Cleanup
-    if (existsSync(chunksBaseDir)) {
-      rmSync(chunksBaseDir, { recursive: true, force: true });
-    }
-
-    if (cleanupAfterCallback) {
+      // Step 8: Execute completion callback
       this.logger.info(
-        '[ChunkedPDFConverter] Cleaning up output directory:',
-        outputDir,
+        '[ChunkedPDFConverter] Executing completion callback...',
       );
-      if (existsSync(outputDir)) {
-        rmSync(outputDir, { recursive: true, force: true });
+      await onComplete(outputDir);
+    } finally {
+      // Step 9: Cleanup (always runs)
+      if (existsSync(chunksBaseDir)) {
+        rmSync(chunksBaseDir, { recursive: true, force: true });
       }
-    } else {
-      this.logger.info('[ChunkedPDFConverter] Output preserved at:', outputDir);
+
+      if (cleanupAfterCallback) {
+        this.logger.info(
+          '[ChunkedPDFConverter] Cleaning up output directory:',
+          outputDir,
+        );
+        if (existsSync(outputDir)) {
+          rmSync(outputDir, { recursive: true, force: true });
+        }
+      } else {
+        this.logger.info(
+          '[ChunkedPDFConverter] Output preserved at:',
+          outputDir,
+        );
+      }
     }
 
     return null;
@@ -288,6 +299,10 @@ export class ChunkedPDFConverter {
 
   /** Calculate page ranges for chunks */
   calculateChunks(totalPages: number): PageRange[] {
+    if (this.config.chunkSize <= 0) {
+      throw new Error('[ChunkedPDFConverter] chunkSize must be positive');
+    }
+
     const ranges: PageRange[] = [];
     for (let start = 1; start <= totalPages; start += this.config.chunkSize) {
       const end = Math.min(start + this.config.chunkSize - 1, totalPages);
@@ -513,6 +528,29 @@ export class ChunkedPDFConverter {
         `[ChunkedPDFConverter] Cleaned up ${removedCount} orphaned pic_ files (${referencedPics.size} referenced, kept)`,
       );
     }
+  }
+
+  /**
+   * Build cumulative pic_ file offsets per chunk for correct URI remapping.
+   * Each offset[i] is the total number of pic_ files in chunks 0..i-1.
+   */
+  private buildPicFileOffsets(
+    chunksBaseDir: string,
+    totalChunks: number,
+  ): number[] {
+    const offsets: number[] = [];
+    let cumulative = 0;
+    for (let i = 0; i < totalChunks; i++) {
+      offsets.push(cumulative);
+      const dir = join(chunksBaseDir, `_chunk_${i}`, 'output', 'images');
+      const count = existsSync(dir)
+        ? readdirSync(dir).filter(
+            (f) => f.startsWith('pic_') && f.endsWith('.png'),
+          ).length
+        : 0;
+      cumulative += count;
+    }
+    return offsets;
   }
 
   /** Check if abort has been signalled and throw if so */

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -1,0 +1,526 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingDocument, TokenUsageReport } from '@heripo/model';
+import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
+
+import type {
+  ConversionCompleteCallback,
+  PDFConvertOptions,
+} from './pdf-converter';
+
+import { spawnAsync } from '@heripo/shared';
+import {
+  copyFileSync,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
+import { DoclingDocumentMerger } from '../processors/docling-document-merger';
+import { ImageExtractor } from '../processors/image-extractor';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { LocalFileServer } from '../utils/local-file-server';
+
+/** Configuration for chunked conversion */
+export interface ChunkedConversionConfig {
+  chunkSize: number;
+  maxRetries: number;
+}
+
+/** Page range for a single chunk [start, end] (1-based, inclusive) */
+type PageRange = [number, number];
+
+/**
+ * Converts large PDFs in chunks using Docling's page_range option.
+ *
+ * Splits the PDF into fixed-size page ranges, converts each chunk sequentially,
+ * then merges the resulting DoclingDocuments into a single output that is
+ * indistinguishable from a single-pass conversion.
+ */
+export class ChunkedPDFConverter {
+  constructor(
+    private readonly logger: LoggerMethods,
+    private readonly client: DoclingAPIClient,
+    private readonly config: ChunkedConversionConfig,
+    private readonly timeout: number = PDF_CONVERTER.DEFAULT_TIMEOUT_MS,
+  ) {}
+
+  /**
+   * Convert a local PDF in chunks.
+   *
+   * @param url - file:// URL to the source PDF
+   * @param reportId - Unique report identifier for output directory naming
+   * @param onComplete - Callback invoked with the final output directory
+   * @param cleanupAfterCallback - Whether to clean up the output directory after callback
+   * @param options - PDF conversion options (chunked-specific fields are stripped internally)
+   * @param buildConversionOptions - Function to build Docling ConversionOptions from PDFConvertOptions
+   * @param abortSignal - Optional abort signal for cancellation
+   */
+  async convertChunked(
+    url: string,
+    reportId: string,
+    onComplete: ConversionCompleteCallback,
+    cleanupAfterCallback: boolean,
+    options: PDFConvertOptions,
+    buildConversionOptions: (options: PDFConvertOptions) => ConversionOptions,
+    abortSignal?: AbortSignal,
+  ): Promise<TokenUsageReport | null> {
+    const pdfPath = url.slice(7); // Remove 'file://' prefix
+    const cwd = process.cwd();
+    const outputDir = join(cwd, 'output', reportId);
+    const chunksBaseDir = join(cwd, 'output', reportId, '_chunks');
+
+    // Step 1: Get total page count
+    const totalPages = await this.getPageCount(pdfPath);
+    if (totalPages === 0) {
+      throw new Error(
+        '[ChunkedPDFConverter] Failed to detect page count from PDF',
+      );
+    }
+
+    // Step 2: Calculate chunk ranges
+    const chunks = this.calculateChunks(totalPages);
+    this.logger.info(
+      `[ChunkedPDFConverter] Starting: ${totalPages} pages → ${chunks.length} chunks of ${this.config.chunkSize}`,
+    );
+
+    // Step 3: Start local file server (once for all chunks)
+    const server = new LocalFileServer();
+    const httpUrl = await server.start(pdfPath);
+    this.logger.info(
+      '[ChunkedPDFConverter] Started local file server:',
+      httpUrl,
+    );
+
+    const chunkDocuments: DoclingDocument[] = [];
+
+    try {
+      // Step 4: Process each chunk sequentially
+      for (let i = 0; i < chunks.length; i++) {
+        this.checkAbort(abortSignal);
+
+        const [start, end] = chunks[i];
+        const chunkDir = join(chunksBaseDir, `_chunk_${i}`);
+        mkdirSync(chunkDir, { recursive: true });
+
+        const doc = await this.convertChunk(
+          i,
+          chunks.length,
+          start,
+          end,
+          httpUrl,
+          chunkDir,
+          options,
+          buildConversionOptions,
+        );
+
+        chunkDocuments.push(doc);
+      }
+    } finally {
+      // Always stop the local file server
+      this.logger.info('[ChunkedPDFConverter] Stopping local file server...');
+      await server.stop();
+    }
+
+    this.checkAbort(abortSignal);
+
+    // Step 5: Merge all chunk documents
+    this.logger.info(
+      `[ChunkedPDFConverter] All ${chunks.length} chunks completed, merging...`,
+    );
+    const merger = new DoclingDocumentMerger();
+    const merged = merger.merge(chunkDocuments);
+
+    this.logger.info(
+      `[ChunkedPDFConverter] Merged: ${merged.texts.length} texts, ${merged.pictures.length} pictures, ${merged.tables.length} tables, ${Object.keys(merged.pages).length} pages`,
+    );
+
+    // Step 6: Build final output directory
+    mkdirSync(outputDir, { recursive: true });
+    const imagesDir = join(outputDir, 'images');
+    mkdirSync(imagesDir, { recursive: true });
+
+    // Relocate images from chunk directories with global indexing
+    this.relocateImages(chunksBaseDir, chunks.length, imagesDir);
+
+    // Save merged result.json
+    const resultPath = join(outputDir, 'result.json');
+    writeFileSync(resultPath, JSON.stringify(merged));
+
+    // Step 7: Render page images (ImageMagick, same as non-chunked)
+    await this.renderPageImages(pdfPath, outputDir);
+
+    // Step 7.5: Clean up orphaned pic_ files
+    this.cleanupOrphanedPicFiles(resultPath, imagesDir);
+
+    this.checkAbort(abortSignal);
+
+    // Step 8: Execute completion callback
+    this.logger.info('[ChunkedPDFConverter] Executing completion callback...');
+    await onComplete(outputDir);
+
+    // Step 9: Cleanup
+    if (existsSync(chunksBaseDir)) {
+      rmSync(chunksBaseDir, { recursive: true, force: true });
+    }
+
+    if (cleanupAfterCallback) {
+      this.logger.info(
+        '[ChunkedPDFConverter] Cleaning up output directory:',
+        outputDir,
+      );
+      if (existsSync(outputDir)) {
+        rmSync(outputDir, { recursive: true, force: true });
+      }
+    } else {
+      this.logger.info('[ChunkedPDFConverter] Output preserved at:', outputDir);
+    }
+
+    return null;
+  }
+
+  /**
+   * Convert a single chunk with retry logic.
+   */
+  private async convertChunk(
+    chunkIndex: number,
+    totalChunks: number,
+    startPage: number,
+    endPage: number,
+    httpUrl: string,
+    chunkDir: string,
+    options: PDFConvertOptions,
+    buildConversionOptions: (options: PDFConvertOptions) => ConversionOptions,
+  ): Promise<DoclingDocument> {
+    const chunkLabel = `Chunk ${chunkIndex + 1}/${totalChunks} (pages ${startPage}-${endPage})`;
+
+    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+      try {
+        if (attempt > 0) {
+          this.logger.info(
+            `[ChunkedPDFConverter] ${chunkLabel}: retrying (${attempt}/${this.config.maxRetries})...`,
+          );
+        } else {
+          this.logger.info(
+            `[ChunkedPDFConverter] ${chunkLabel}: converting...`,
+          );
+        }
+
+        const startTime = Date.now();
+
+        // Build conversion options with page_range
+        const conversionOptions = buildConversionOptions({
+          ...options,
+          page_range: [startPage, endPage],
+        });
+
+        // Start conversion task
+        const task = await this.client.convertSourceAsync({
+          sources: [{ kind: 'http', url: httpUrl }],
+          options: conversionOptions,
+          target: { kind: 'zip' },
+        });
+
+        // Poll until completion
+        await this.trackTaskProgress(task);
+
+        // Download ZIP result
+        const zipPath = join(chunkDir, 'result.zip');
+        await this.downloadResult(task.taskId, zipPath);
+
+        // Extract ZIP and process images
+        const extractDir = join(chunkDir, 'extracted');
+        const chunkOutputDir = join(chunkDir, 'output');
+        await ImageExtractor.extractAndSaveDocumentsFromZip(
+          this.logger,
+          zipPath,
+          extractDir,
+          chunkOutputDir,
+        );
+
+        // Parse result.json into a DoclingDocument object
+        const resultJsonPath = join(chunkOutputDir, 'result.json');
+        const doc = await runJqFileJson<DoclingDocument>('.', resultJsonPath);
+
+        // Cleanup chunk temp files (ZIP + extracted)
+        if (existsSync(zipPath)) rmSync(zipPath, { force: true });
+        if (existsSync(extractDir)) {
+          rmSync(extractDir, { recursive: true, force: true });
+        }
+
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        if (attempt > 0) {
+          this.logger.info(
+            `[ChunkedPDFConverter] ${chunkLabel}: completed on retry ${attempt} (${elapsed}s)`,
+          );
+        } else {
+          this.logger.info(
+            `[ChunkedPDFConverter] ${chunkLabel}: completed (${elapsed}s)`,
+          );
+        }
+
+        return doc;
+      } catch (error) {
+        if (attempt >= this.config.maxRetries) {
+          this.logger.error(
+            `[ChunkedPDFConverter] ${chunkLabel}: failed after ${this.config.maxRetries} retries`,
+          );
+          throw error;
+        }
+        this.logger.warn(
+          `[ChunkedPDFConverter] ${chunkLabel}: failed, retrying (${attempt + 1}/${this.config.maxRetries})...`,
+        );
+      }
+    }
+
+    /* v8 ignore start -- unreachable: loop always returns or throws */
+    throw new Error('Unreachable');
+    /* v8 ignore stop */
+  }
+
+  /** Calculate page ranges for chunks */
+  calculateChunks(totalPages: number): PageRange[] {
+    const ranges: PageRange[] = [];
+    for (let start = 1; start <= totalPages; start += this.config.chunkSize) {
+      const end = Math.min(start + this.config.chunkSize - 1, totalPages);
+      ranges.push([start, end]);
+    }
+    return ranges;
+  }
+
+  /** Get total page count using pdfinfo */
+  private async getPageCount(pdfPath: string): Promise<number> {
+    const result = await spawnAsync('pdfinfo', [pdfPath]);
+    if (result.code !== 0) {
+      return 0;
+    }
+    const match = result.stdout.match(/^Pages:\s+(\d+)/m);
+    return match ? parseInt(match[1], 10) : 0;
+  }
+
+  /** Poll task progress until completion */
+  private async trackTaskProgress(task: {
+    taskId: string;
+    poll: () => Promise<{ task_status: string }>;
+    getResult: () => Promise<{
+      errors?: { message: string }[];
+      status?: string;
+    }>;
+  }): Promise<void> {
+    const startTime = Date.now();
+
+    while (true) {
+      if (Date.now() - startTime > this.timeout) {
+        throw new Error('[ChunkedPDFConverter] Chunk task timeout');
+      }
+
+      const status = await task.poll();
+
+      if (status.task_status === 'success') return;
+
+      if (status.task_status === 'failure') {
+        let details = 'unknown';
+        try {
+          const result = await task.getResult();
+          if (result.errors?.length) {
+            details = result.errors.map((e) => e.message).join('; ');
+          }
+        } catch {
+          // ignore
+        }
+        throw new Error(`[ChunkedPDFConverter] Chunk task failed: ${details}`);
+      }
+
+      await new Promise((resolve) =>
+        setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
+      );
+    }
+  }
+
+  /** Download ZIP result for a task */
+  private async downloadResult(taskId: string, zipPath: string): Promise<void> {
+    const zipResult = await this.client.getTaskResultFile(taskId);
+
+    if (zipResult.fileStream) {
+      const writeStream = createWriteStream(zipPath);
+      await pipeline(zipResult.fileStream, writeStream);
+      return;
+    }
+
+    if (zipResult.data) {
+      await writeFile(zipPath, zipResult.data);
+      return;
+    }
+
+    // Fallback: direct HTTP download
+    const baseUrl = this.client.getConfig().baseUrl;
+    const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
+      headers: { Accept: 'application/zip' },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download chunk ZIP: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const buffer = new Uint8Array(await response.arrayBuffer());
+    await writeFile(zipPath, buffer);
+  }
+
+  /**
+   * Relocate images from chunk output directories to the final images directory
+   * with global indexing.
+   */
+  private relocateImages(
+    chunksBaseDir: string,
+    totalChunks: number,
+    imagesDir: string,
+  ): void {
+    // 1. Relocate pic_ files (JSON base64 images)
+    let picGlobalIndex = 0;
+    for (let i = 0; i < totalChunks; i++) {
+      const chunkImagesDir = join(
+        chunksBaseDir,
+        `_chunk_${i}`,
+        'output',
+        'images',
+      );
+      if (!existsSync(chunkImagesDir)) continue;
+
+      const picFiles = readdirSync(chunkImagesDir)
+        .filter((f) => f.startsWith('pic_') && f.endsWith('.png'))
+        .sort((a, b) => {
+          const numA = parseInt(a.replace('pic_', '').replace('.png', ''), 10);
+          const numB = parseInt(b.replace('pic_', '').replace('.png', ''), 10);
+          return numA - numB;
+        });
+
+      for (const file of picFiles) {
+        const src = join(chunkImagesDir, file);
+        const dest = join(imagesDir, `pic_${picGlobalIndex}.png`);
+        copyFileSync(src, dest);
+        picGlobalIndex++;
+      }
+    }
+
+    // 2. Relocate image_ files (HTML content images)
+    let imageGlobalIndex = 0;
+    for (let i = 0; i < totalChunks; i++) {
+      const chunkImagesDir = join(
+        chunksBaseDir,
+        `_chunk_${i}`,
+        'output',
+        'images',
+      );
+      if (!existsSync(chunkImagesDir)) continue;
+
+      const imageFiles = readdirSync(chunkImagesDir)
+        .filter((f) => f.startsWith('image_') && f.endsWith('.png'))
+        .sort((a, b) => {
+          const numA = parseInt(
+            a.replace('image_', '').replace('.png', ''),
+            10,
+          );
+          const numB = parseInt(
+            b.replace('image_', '').replace('.png', ''),
+            10,
+          );
+          return numA - numB;
+        });
+
+      for (const file of imageFiles) {
+        const src = join(chunkImagesDir, file);
+        const dest = join(imagesDir, `image_${imageGlobalIndex}.png`);
+        copyFileSync(src, dest);
+        imageGlobalIndex++;
+      }
+    }
+
+    this.logger.info(
+      `[ChunkedPDFConverter] Relocated ${picGlobalIndex} pic + ${imageGlobalIndex} image files to ${imagesDir}`,
+    );
+  }
+
+  /** Render page images from PDF using ImageMagick and update result.json */
+  private async renderPageImages(
+    pdfPath: string,
+    outputDir: string,
+  ): Promise<void> {
+    this.logger.info(
+      '[ChunkedPDFConverter] Rendering page images with ImageMagick...',
+    );
+
+    const renderer = new PageRenderer(this.logger);
+    const renderResult = await renderer.renderPages(pdfPath, outputDir);
+
+    const resultPath = join(outputDir, 'result.json');
+    const tmpPath = resultPath + '.tmp';
+    const jqProgram = `
+      .pages |= with_entries(
+        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
+          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
+          .value.image.mimetype = "image/png" |
+          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
+        else . end
+      )
+    `;
+    await runJqFileToFile(jqProgram, resultPath, tmpPath);
+    await rename(tmpPath, resultPath);
+
+    this.logger.info(
+      `[ChunkedPDFConverter] Rendered ${renderResult.pageCount} page images`,
+    );
+  }
+
+  /**
+   * Remove pic_ files from images directory that are not referenced in result.json.
+   * Chunked Docling conversion embeds page images as base64 in JSON, which get
+   * extracted as pic_ files. After renderPageImages replaces page URIs with
+   * pages/page_N.png, these pic_ files become orphaned.
+   */
+  private cleanupOrphanedPicFiles(resultPath: string, imagesDir: string): void {
+    const content = readFileSync(resultPath, 'utf-8');
+    const referencedPics = new Set<string>();
+    const picPattern = /images\/pic_\d+\.png/g;
+    let match;
+    while ((match = picPattern.exec(content)) !== null) {
+      referencedPics.add(match[0].replace('images/', ''));
+    }
+
+    const picFiles = readdirSync(imagesDir).filter(
+      (f) => f.startsWith('pic_') && f.endsWith('.png'),
+    );
+
+    let removedCount = 0;
+    for (const file of picFiles) {
+      if (!referencedPics.has(file)) {
+        rmSync(join(imagesDir, file), { force: true });
+        removedCount++;
+      }
+    }
+
+    if (removedCount > 0) {
+      this.logger.info(
+        `[ChunkedPDFConverter] Cleaned up ${removedCount} orphaned pic_ files (${referencedPics.size} referenced, kept)`,
+      );
+    }
+  }
+
+  /** Check if abort has been signalled and throw if so */
+  private checkAbort(signal?: AbortSignal): void {
+    if (signal?.aborted) {
+      const error = new Error('Chunked PDF conversion was aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+  }
+}

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -15,11 +15,16 @@ import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
 import { runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
 import { PDFConverter } from './pdf-converter';
 
 vi.mock('es-toolkit', () => ({
   omit: vi.fn(),
+}));
+
+vi.mock('./chunked-pdf-converter', () => ({
+  ChunkedPDFConverter: vi.fn(),
 }));
 
 vi.mock('./image-pdf-converter', () => ({
@@ -137,6 +142,99 @@ describe('PDFConverter', () => {
         5_000_000,
       );
       expect(customConverter).toBeInstanceOf(PDFConverter);
+    });
+
+    describe('chunked conversion', () => {
+      let mockConvertChunked: ReturnType<typeof vi.fn>;
+
+      beforeEach(() => {
+        mockConvertChunked = vi.fn().mockResolvedValue(null);
+        vi.mocked(ChunkedPDFConverter).mockImplementation(function () {
+          return { convertChunked: mockConvertChunked } as any;
+        });
+      });
+
+      test('delegates to ChunkedPDFConverter when chunkedConversion is true and url is file://', async () => {
+        await converter.convert(
+          'file:///test/input.pdf',
+          'report-1',
+          vi.fn(),
+          false,
+          { chunkedConversion: true },
+        );
+
+        expect(ChunkedPDFConverter).toHaveBeenCalledWith(
+          logger,
+          client,
+          expect.objectContaining({ chunkSize: 10, maxRetries: 2 }),
+          expect.any(Number),
+        );
+        expect(mockConvertChunked).toHaveBeenCalledWith(
+          'file:///test/input.pdf',
+          'report-1',
+          expect.any(Function),
+          false,
+          expect.objectContaining({ chunkedConversion: true }),
+          expect.any(Function),
+          undefined,
+        );
+      });
+
+      test('uses custom chunkSize and chunkMaxRetries', async () => {
+        await converter.convert(
+          'file:///test/input.pdf',
+          'report-1',
+          vi.fn(),
+          false,
+          { chunkedConversion: true, chunkSize: 20, chunkMaxRetries: 5 },
+        );
+
+        expect(ChunkedPDFConverter).toHaveBeenCalledWith(
+          logger,
+          client,
+          { chunkSize: 20, maxRetries: 5 },
+          expect.any(Number),
+        );
+      });
+
+      test('passes a working buildConversionOptions callback to ChunkedPDFConverter', async () => {
+        await converter.convert(
+          'file:///test/input.pdf',
+          'report-1',
+          vi.fn(),
+          false,
+          { chunkedConversion: true },
+        );
+
+        // Capture the buildConversionOptions callback (6th argument)
+        const buildFn = mockConvertChunked.mock.calls[0][5] as (
+          opts: any,
+        ) => any;
+        expect(typeof buildFn).toBe('function');
+
+        // Invoke it and verify it returns conversion options
+        const result = buildFn({ page_range: [1, 10] });
+        expect(result).toBeDefined();
+      });
+
+      test('does not use chunked conversion for non-file:// URLs', async () => {
+        const mockTask = createMockTask();
+        vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+        vi.mocked(client.getTaskResultFile).mockResolvedValue({
+          data: Buffer.from('zip'),
+          success: true,
+        } as any);
+
+        await converter.convert(
+          'http://example.com/test.pdf',
+          'report-1',
+          vi.fn(),
+          true,
+          { chunkedConversion: true },
+        );
+
+        expect(ChunkedPDFConverter).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -14,7 +14,11 @@ import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 
-import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
+import {
+  CHUNKED_CONVERSION,
+  PAGE_RENDERING,
+  PDF_CONVERTER,
+} from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
@@ -23,6 +27,7 @@ import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
 import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
 
 /**
@@ -71,6 +76,12 @@ export type PDFConvertOptions = Omit<
   aggregator?: LLMTokenUsageAggregator;
   /** Callback fired after each batch of VLM pages completes, with cumulative token usage */
   onTokenUsage?: (report: TokenUsageReport) => void;
+  /** Enable chunked conversion for large PDFs (local files only) */
+  chunkedConversion?: boolean;
+  /** Pages per chunk (default: CHUNKED_CONVERSION.DEFAULT_CHUNK_SIZE) */
+  chunkSize?: number;
+  /** Max retry attempts per failed chunk (default: CHUNKED_CONVERSION.DEFAULT_MAX_RETRIES) */
+  chunkMaxRetries?: number;
 };
 
 /** Result of strategy-based conversion */
@@ -98,6 +109,29 @@ export class PDFConverter {
     abortSignal?: AbortSignal,
   ): Promise<TokenUsageReport | null> {
     this.logger.info('[PDFConverter] Converting:', url);
+
+    // Chunked conversion for large local PDFs
+    if (options.chunkedConversion && url.startsWith('file://')) {
+      const chunked = new ChunkedPDFConverter(
+        this.logger,
+        this.client,
+        {
+          chunkSize: options.chunkSize ?? CHUNKED_CONVERSION.DEFAULT_CHUNK_SIZE,
+          maxRetries:
+            options.chunkMaxRetries ?? CHUNKED_CONVERSION.DEFAULT_MAX_RETRIES,
+        },
+        this.timeout,
+      );
+      return chunked.convertChunked(
+        url,
+        reportId,
+        onComplete,
+        cleanupAfterCallback,
+        options,
+        (opts) => this.buildConversionOptions(opts),
+        abortSignal,
+      );
+    }
 
     // Force image PDF pre-conversion when explicitly requested
     if (options.forceImagePdf) {
@@ -587,6 +621,9 @@ export class PDFConverter {
         'forcedMethod',
         'aggregator',
         'onTokenUsage',
+        'chunkedConversion',
+        'chunkSize',
+        'chunkMaxRetries',
       ]),
       to_formats: ['json', 'html'],
       image_export_mode: 'embedded',

--- a/packages/pdf-parser/src/processors/docling-document-merger.test.ts
+++ b/packages/pdf-parser/src/processors/docling-document-merger.test.ts
@@ -988,6 +988,57 @@ describe('DoclingDocumentMerger', () => {
     expect(result.texts[3].parent?.$ref).toBe('#/texts/2');
   });
 
+  test('image URI remapping with picFileOffsets uses file-based offset', () => {
+    const chunk1 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'images/pic_5.png' },
+        } as any,
+      ],
+    });
+    const chunk2 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'images/pic_3.png' },
+        } as any,
+      ],
+    });
+
+    // Without picFileOffsets: uses pictures count (1) as offset
+    const resultDefault = merger.merge([
+      structuredClone(chunk1),
+      structuredClone(chunk2),
+    ]);
+    const pic1Default = resultDefault.pictures[1] as any;
+    expect(pic1Default.image.uri).toBe('images/pic_4.png'); // 3 + 1
+
+    // With picFileOffsets: uses file-based offset (10) for chunk 1
+    const resultWithOffsets = merger.merge(
+      [structuredClone(chunk1), structuredClone(chunk2)],
+      [0, 10],
+    );
+    const pic1WithOffsets = resultWithOffsets.pictures[1] as any;
+    expect(pic1WithOffsets.image.uri).toBe('images/pic_13.png'); // 3 + 10
+  });
+
   test('picture with non-matching image URI is not remapped', () => {
     const chunk1 = makeChunk({
       pictures: [

--- a/packages/pdf-parser/src/processors/docling-document-merger.test.ts
+++ b/packages/pdf-parser/src/processors/docling-document-merger.test.ts
@@ -1,0 +1,1033 @@
+import type { DoclingDocument } from '@heripo/model';
+
+import { describe, expect, test } from 'vitest';
+
+import { DoclingDocumentMerger } from './docling-document-merger';
+
+function makeChunk(overrides: Partial<DoclingDocument> = {}): DoclingDocument {
+  return {
+    schema_name: 'DoclingDocument',
+    version: '1.0',
+    name: 'test',
+    origin: {
+      mimetype: 'application/pdf',
+      binary_hash: 123,
+      filename: 'test.pdf',
+    },
+    body: {
+      self_ref: '#/body',
+      children: [],
+      content_layer: 'body',
+      name: '_root_',
+      label: 'unspecified',
+    },
+    furniture: {
+      self_ref: '#/furniture',
+      children: [],
+      content_layer: 'furniture',
+      name: '_root_',
+      label: 'unspecified',
+    },
+    groups: [],
+    texts: [],
+    pictures: [],
+    tables: [],
+    pages: {},
+    ...overrides,
+  };
+}
+
+describe('DoclingDocumentMerger', () => {
+  const merger = new DoclingDocumentMerger();
+
+  test('throws on zero chunks', () => {
+    expect(() => merger.merge([])).toThrow('Cannot merge zero chunks');
+  });
+
+  test('single chunk passthrough', () => {
+    const chunk = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'hello',
+          text: 'hello',
+        },
+      ],
+      body: {
+        self_ref: '#/body',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'body',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+
+    const result = merger.merge([chunk]);
+    // Single chunk returns the same object (no clone)
+    expect(result).toBe(chunk);
+  });
+
+  test('two chunks: text $ref remapping', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'a',
+          text: 'a',
+        },
+        {
+          self_ref: '#/texts/1',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'b',
+          text: 'b',
+        },
+      ],
+      body: {
+        self_ref: '#/body',
+        children: [{ $ref: '#/texts/0' }, { $ref: '#/texts/1' }],
+        content_layer: 'body',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'c',
+          text: 'c',
+        },
+      ],
+      body: {
+        self_ref: '#/body',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'body',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.texts).toHaveLength(3);
+    expect(result.texts[2].self_ref).toBe('#/texts/2');
+    expect(result.texts[2].text).toBe('c');
+    // parent #/body should NOT be remapped
+    expect(result.texts[2].parent?.$ref).toBe('#/body');
+    expect(result.body.children).toHaveLength(3);
+    expect(result.body.children[2].$ref).toBe('#/texts/2');
+  });
+
+  test('three chunks: cumulative offset accuracy', () => {
+    const chunks = [
+      makeChunk({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: '0',
+            text: '0',
+          },
+          {
+            self_ref: '#/texts/1',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: '1',
+            text: '1',
+          },
+        ],
+        body: {
+          self_ref: '#/body',
+          children: [{ $ref: '#/texts/0' }, { $ref: '#/texts/1' }],
+          content_layer: 'body',
+          name: '_root_',
+          label: 'unspecified',
+        },
+      }),
+      makeChunk({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: '2',
+            text: '2',
+          },
+        ],
+        body: {
+          self_ref: '#/body',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          name: '_root_',
+          label: 'unspecified',
+        },
+      }),
+      makeChunk({
+        texts: [
+          {
+            self_ref: '#/texts/0',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: '3',
+            text: '3',
+          },
+          {
+            self_ref: '#/texts/1',
+            children: [],
+            content_layer: 'body',
+            label: 'text',
+            prov: [],
+            orig: '4',
+            text: '4',
+          },
+        ],
+        body: {
+          self_ref: '#/body',
+          children: [{ $ref: '#/texts/0' }, { $ref: '#/texts/1' }],
+          content_layer: 'body',
+          name: '_root_',
+          label: 'unspecified',
+        },
+      }),
+    ];
+
+    const result = merger.merge(chunks);
+
+    expect(result.texts).toHaveLength(5);
+    // Chunk 2 offset = 2
+    expect(result.texts[2].self_ref).toBe('#/texts/2');
+    // Chunk 3 offset = 3
+    expect(result.texts[3].self_ref).toBe('#/texts/3');
+    expect(result.texts[4].self_ref).toBe('#/texts/4');
+
+    expect(result.body.children).toHaveLength(5);
+    expect(result.body.children[3].$ref).toBe('#/texts/3');
+    expect(result.body.children[4].$ref).toBe('#/texts/4');
+  });
+
+  test('parent #/body and #/furniture are NOT remapped', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'a',
+          text: 'a',
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'b',
+          text: 'b',
+        },
+        {
+          self_ref: '#/texts/1',
+          parent: { $ref: '#/furniture' },
+          children: [],
+          content_layer: 'furniture',
+          label: 'page_header',
+          prov: [],
+          orig: 'c',
+          text: 'c',
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.texts[1].parent?.$ref).toBe('#/body');
+    expect(result.texts[2].parent?.$ref).toBe('#/furniture');
+  });
+
+  test('parent #/groups/N is correctly remapped', () => {
+    const chunk1 = makeChunk({
+      groups: [
+        {
+          self_ref: '#/groups/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          name: 'list',
+          label: 'list',
+        },
+      ],
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/groups/0' },
+          children: [],
+          content_layer: 'body',
+          label: 'list_item',
+          prov: [],
+          orig: 'a',
+          text: 'a',
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      groups: [
+        {
+          self_ref: '#/groups/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          name: 'list',
+          label: 'list',
+        },
+      ],
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/groups/0' },
+          children: [],
+          content_layer: 'body',
+          label: 'list_item',
+          prov: [],
+          orig: 'b',
+          text: 'b',
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    // Second chunk's group remapped from #/groups/0 to #/groups/1
+    expect(result.groups[1].self_ref).toBe('#/groups/1');
+    expect(result.groups[1].children[0].$ref).toBe('#/texts/1');
+    // Second chunk's text parent remapped
+    expect(result.texts[1].parent?.$ref).toBe('#/groups/1');
+  });
+
+  test('group with parent.$ref is remapped correctly', () => {
+    const chunk1 = makeChunk({
+      groups: [
+        {
+          self_ref: '#/groups/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          name: 'group',
+          label: 'key_value_area',
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      groups: [
+        {
+          self_ref: '#/groups/0',
+          parent: { $ref: '#/groups/0' },
+          children: [],
+          content_layer: 'body',
+          name: 'group',
+          label: 'key_value_area',
+        },
+        {
+          self_ref: '#/groups/1',
+          parent: { $ref: '#/body' },
+          children: [{ $ref: '#/groups/0' }],
+          content_layer: 'body',
+          name: 'group',
+          label: 'key_value_area',
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    // chunk2's groups/0 parent was #/groups/0 → remapped to #/groups/1
+    expect(result.groups[1].parent?.$ref).toBe('#/groups/1');
+    // chunk2's groups/1 parent was #/body → stays #/body
+    expect(result.groups[2].parent?.$ref).toBe('#/body');
+    // chunk2's groups/1 children[0] was #/groups/0 → remapped to #/groups/1
+    expect(result.groups[2].children[0].$ref).toBe('#/groups/1');
+  });
+
+  test('pictures.captions $ref remapping', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'caption',
+          prov: [],
+          orig: 'cap1',
+          text: 'cap1',
+        },
+      ],
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [{ $ref: '#/texts/0' }],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'caption',
+          prov: [],
+          orig: 'cap2',
+          text: 'cap2',
+        },
+      ],
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [{ $ref: '#/texts/0' }],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.pictures[1].self_ref).toBe('#/pictures/1');
+    expect(result.pictures[1].captions[0].$ref).toBe('#/texts/1');
+  });
+
+  test('tables.captions and tables.footnotes $ref remapping', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'caption',
+          prov: [],
+          orig: 'tcap',
+          text: 'tcap',
+        },
+        {
+          self_ref: '#/texts/1',
+          children: [],
+          content_layer: 'body',
+          label: 'footnote',
+          prov: [],
+          orig: 'tfn',
+          text: 'tfn',
+        },
+      ],
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [{ $ref: '#/texts/0' }],
+          references: [],
+          footnotes: [{ $ref: '#/texts/1' }],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'caption',
+          prov: [],
+          orig: 'tcap2',
+          text: 'tcap2',
+        },
+        {
+          self_ref: '#/texts/1',
+          children: [],
+          content_layer: 'body',
+          label: 'footnote',
+          prov: [],
+          orig: 'tfn2',
+          text: 'tfn2',
+        },
+      ],
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          parent: { $ref: '#/body' },
+          children: [],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [{ $ref: '#/texts/0' }],
+          references: [],
+          footnotes: [{ $ref: '#/texts/1' }],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.tables[1].self_ref).toBe('#/tables/1');
+    expect(result.tables[1].captions[0].$ref).toBe('#/texts/2');
+    expect(result.tables[1].footnotes[0].$ref).toBe('#/texts/3');
+  });
+
+  test('image URI remapping', () => {
+    const chunk1 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [
+            {
+              page_no: 1,
+              bbox: { l: 0, t: 0, r: 100, b: 100, coord_origin: 'BOTTOMLEFT' },
+              charspan: [0, 0],
+            },
+          ],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'images/pic_0.png' },
+        } as any,
+      ],
+    });
+    const chunk2 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [
+            {
+              page_no: 2,
+              bbox: { l: 0, t: 0, r: 100, b: 100, coord_origin: 'BOTTOMLEFT' },
+              charspan: [0, 0],
+            },
+          ],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'images/pic_0.png' },
+        } as any,
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    const pic0 = result.pictures[0] as any;
+    const pic1 = result.pictures[1] as any;
+    expect(pic0.image.uri).toBe('images/pic_0.png');
+    expect(pic1.image.uri).toBe('images/pic_1.png');
+  });
+
+  test('pages merge (no collision with global page numbers)', () => {
+    const chunk1 = makeChunk({
+      pages: {
+        '1': {
+          page_no: 1,
+          size: { width: 595, height: 842 },
+          image: {
+            mimetype: 'image/png',
+            dpi: 200,
+            size: { width: 1190, height: 1684 },
+            uri: 'pages/page_0.png',
+          },
+        },
+        '2': {
+          page_no: 2,
+          size: { width: 595, height: 842 },
+          image: {
+            mimetype: 'image/png',
+            dpi: 200,
+            size: { width: 1190, height: 1684 },
+            uri: 'pages/page_1.png',
+          },
+        },
+      },
+    });
+    const chunk2 = makeChunk({
+      pages: {
+        '3': {
+          page_no: 3,
+          size: { width: 595, height: 842 },
+          image: {
+            mimetype: 'image/png',
+            dpi: 200,
+            size: { width: 1190, height: 1684 },
+            uri: 'pages/page_2.png',
+          },
+        },
+      },
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(Object.keys(result.pages)).toEqual(['1', '2', '3']);
+    expect(result.pages['3'].page_no).toBe(3);
+  });
+
+  test('empty array chunks are handled correctly', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'a',
+          text: 'a',
+        },
+      ],
+    });
+    const chunk2 = makeChunk(); // all arrays empty
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.texts).toHaveLength(1);
+    expect(result.pictures).toHaveLength(0);
+    expect(result.tables).toHaveLength(0);
+    expect(result.groups).toHaveLength(0);
+  });
+
+  test('furniture children are merged and remapped', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/furniture' },
+          children: [],
+          content_layer: 'furniture',
+          label: 'page_header',
+          prov: [],
+          orig: 'h1',
+          text: 'h1',
+        },
+      ],
+      furniture: {
+        self_ref: '#/furniture',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'furniture',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          parent: { $ref: '#/furniture' },
+          children: [],
+          content_layer: 'furniture',
+          label: 'page_footer',
+          prov: [],
+          orig: 'f1',
+          text: 'f1',
+        },
+      ],
+      furniture: {
+        self_ref: '#/furniture',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'furniture',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    expect(result.furniture.children).toHaveLength(2);
+    expect(result.furniture.children[1].$ref).toBe('#/texts/1');
+  });
+
+  test('remapRef passes through non-matching refs', () => {
+    expect(
+      merger.remapRef('#/body', {
+        texts: 5,
+        pictures: 0,
+        tables: 0,
+        groups: 0,
+      }),
+    ).toBe('#/body');
+    expect(
+      merger.remapRef('#/furniture', {
+        texts: 5,
+        pictures: 0,
+        tables: 0,
+        groups: 0,
+      }),
+    ).toBe('#/furniture');
+    expect(
+      merger.remapRef('', { texts: 5, pictures: 0, tables: 0, groups: 0 }),
+    ).toBe('');
+  });
+
+  test('does not mutate original chunks', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'a',
+          text: 'a',
+        },
+      ],
+      body: {
+        self_ref: '#/body',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'body',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'b',
+          text: 'b',
+        },
+      ],
+      body: {
+        self_ref: '#/body',
+        children: [{ $ref: '#/texts/0' }],
+        content_layer: 'body',
+        name: '_root_',
+        label: 'unspecified',
+      },
+    });
+
+    merger.merge([chunk1, chunk2]);
+
+    // Original chunk2 should be unchanged
+    expect(chunk2.texts[0].self_ref).toBe('#/texts/0');
+    expect(chunk2.body.children[0].$ref).toBe('#/texts/0');
+  });
+
+  test('picture without image field is handled gracefully', () => {
+    const chunk1 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+    expect(result.pictures).toHaveLength(2);
+    expect(result.pictures[1].self_ref).toBe('#/pictures/1');
+  });
+
+  test('table without parent field is handled gracefully', () => {
+    const chunk1 = makeChunk({
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          children: [],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          children: [],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+    expect(result.tables).toHaveLength(2);
+    expect(result.tables[1].self_ref).toBe('#/tables/1');
+    expect(result.tables[1].parent).toBeUndefined();
+  });
+
+  test('table and picture children arrays are remapped', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'x',
+          text: 'x',
+        },
+      ],
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'y',
+          text: 'y',
+        },
+      ],
+      tables: [
+        {
+          self_ref: '#/tables/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          label: 'table',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          data: { table_cells: [], num_rows: 0, num_cols: 0, grid: [] },
+        },
+      ],
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [{ $ref: '#/texts/0' }],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    // Table children remapped
+    expect(result.tables[1].children[0].$ref).toBe('#/texts/1');
+    // Picture children remapped
+    expect(result.pictures[1].children[0].$ref).toBe('#/texts/1');
+  });
+
+  test('text children arrays are remapped', () => {
+    const chunk1 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [{ $ref: '#/texts/1' }],
+          content_layer: 'body',
+          label: 'section_header',
+          prov: [],
+          orig: 'header',
+          text: 'header',
+        },
+        {
+          self_ref: '#/texts/1',
+          parent: { $ref: '#/texts/0' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'child',
+          text: 'child',
+        },
+      ],
+    });
+    const chunk2 = makeChunk({
+      texts: [
+        {
+          self_ref: '#/texts/0',
+          children: [{ $ref: '#/texts/1' }],
+          content_layer: 'body',
+          label: 'section_header',
+          prov: [],
+          orig: 'header2',
+          text: 'header2',
+        },
+        {
+          self_ref: '#/texts/1',
+          parent: { $ref: '#/texts/0' },
+          children: [],
+          content_layer: 'body',
+          label: 'text',
+          prov: [],
+          orig: 'child2',
+          text: 'child2',
+        },
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    // chunk2's texts/0 children[0] was #/texts/1 → remapped to #/texts/3
+    expect(result.texts[2].children[0].$ref).toBe('#/texts/3');
+    // chunk2's texts/1 parent was #/texts/0 → remapped to #/texts/2
+    expect(result.texts[3].parent?.$ref).toBe('#/texts/2');
+  });
+
+  test('picture with non-matching image URI is not remapped', () => {
+    const chunk1 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'https://example.com/external.png' },
+        } as any,
+      ],
+    });
+    const chunk2 = makeChunk({
+      pictures: [
+        {
+          self_ref: '#/pictures/0',
+          children: [],
+          content_layer: 'body',
+          label: 'picture',
+          prov: [],
+          captions: [],
+          references: [],
+          footnotes: [],
+          annotations: [],
+          image: { uri: 'custom/path/image.jpg' },
+        } as any,
+      ],
+    });
+
+    const result = merger.merge([chunk1, chunk2]);
+
+    // URIs that don't match "images/pic_N.png" pattern should be left unchanged
+    const pic0 = result.pictures[0] as any;
+    const pic1 = result.pictures[1] as any;
+    expect(pic0.image.uri).toBe('https://example.com/external.png');
+    expect(pic1.image.uri).toBe('custom/path/image.jpg');
+  });
+});

--- a/packages/pdf-parser/src/processors/docling-document-merger.ts
+++ b/packages/pdf-parser/src/processors/docling-document-merger.ts
@@ -1,0 +1,171 @@
+import type { DoclingDocument, DoclingPictureItem } from '@heripo/model';
+
+/** Offsets for remapping $ref paths across chunks */
+interface RefOffsets {
+  texts: number;
+  pictures: number;
+  tables: number;
+  groups: number;
+}
+
+/** Regex matching $ref paths that need offset remapping */
+const REF_PATTERN = /^#\/(texts|pictures|tables|groups)\/(\d+)$/;
+
+/** Regex matching image URIs like "images/pic_N.png" */
+const IMAGE_URI_PATTERN = /^images\/pic_(\d+)\.png$/;
+
+/**
+ * Merges multiple DoclingDocuments into a single document.
+ *
+ * Handles $ref remapping, image path remapping, and pages merging
+ * so that the merged result is indistinguishable from a single-pass conversion.
+ */
+export class DoclingDocumentMerger {
+  /**
+   * Merge an array of DoclingDocuments into one.
+   * The first chunk's metadata (schema_name, version, name, origin) is used as the base.
+   *
+   * @param chunks - Array of DoclingDocument objects to merge (must have at least 1)
+   * @returns Merged DoclingDocument
+   */
+  merge(chunks: DoclingDocument[]): DoclingDocument {
+    if (chunks.length === 0) {
+      throw new Error('Cannot merge zero chunks');
+    }
+
+    if (chunks.length === 1) {
+      return chunks[0];
+    }
+
+    // Start with a deep clone of the first chunk as the base
+    const base = structuredClone(chunks[0]);
+
+    for (let i = 1; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const offsets: RefOffsets = {
+        texts: base.texts.length,
+        pictures: base.pictures.length,
+        tables: base.tables.length,
+        groups: base.groups.length,
+      };
+
+      // Merge texts
+      for (const text of chunk.texts) {
+        const remapped = structuredClone(text);
+        remapped.self_ref = this.remapRef(remapped.self_ref, offsets);
+        if (remapped.parent) {
+          remapped.parent.$ref = this.remapRef(remapped.parent.$ref, offsets);
+        }
+        remapped.children = remapped.children.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        base.texts.push(remapped);
+      }
+
+      // Merge pictures
+      for (const picture of chunk.pictures) {
+        const remapped = structuredClone(picture);
+        remapped.self_ref = this.remapRef(remapped.self_ref, offsets);
+        if (remapped.parent) {
+          remapped.parent.$ref = this.remapRef(remapped.parent.$ref, offsets);
+        }
+        remapped.children = remapped.children.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        remapped.captions = remapped.captions.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        // Remap image URI
+        this.remapPictureImageUri(remapped, offsets);
+        base.pictures.push(remapped);
+      }
+
+      // Merge tables
+      for (const table of chunk.tables) {
+        const remapped = structuredClone(table);
+        remapped.self_ref = this.remapRef(remapped.self_ref, offsets);
+        if (remapped.parent) {
+          remapped.parent.$ref = this.remapRef(remapped.parent.$ref, offsets);
+        }
+        remapped.children = remapped.children.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        remapped.captions = remapped.captions.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        remapped.footnotes = remapped.footnotes.map((f) => ({
+          $ref: this.remapRef(f.$ref, offsets),
+        }));
+        base.tables.push(remapped);
+      }
+
+      // Merge groups
+      for (const group of chunk.groups) {
+        const remapped = structuredClone(group);
+        remapped.self_ref = this.remapRef(remapped.self_ref, offsets);
+        if (remapped.parent) {
+          remapped.parent.$ref = this.remapRef(remapped.parent.$ref, offsets);
+        }
+        remapped.children = remapped.children.map((c) => ({
+          $ref: this.remapRef(c.$ref, offsets),
+        }));
+        base.groups.push(remapped);
+      }
+
+      // Merge body children
+      for (const child of chunk.body.children) {
+        base.body.children.push({
+          $ref: this.remapRef(child.$ref, offsets),
+        });
+      }
+
+      // Merge furniture children
+      for (const child of chunk.furniture.children) {
+        base.furniture.children.push({
+          $ref: this.remapRef(child.$ref, offsets),
+        });
+      }
+
+      // Merge pages (keys are global page number strings, so no collision)
+      Object.assign(base.pages, chunk.pages);
+    }
+
+    return base;
+  }
+
+  /**
+   * Remap a $ref string by applying offsets.
+   * Only refs matching "#/{texts|pictures|tables|groups}/{N}" are remapped.
+   * Refs like "#/body" or "#/furniture" pass through unchanged.
+   */
+  remapRef(ref: string, offsets: RefOffsets): string {
+    const match = REF_PATTERN.exec(ref);
+    if (!match) {
+      return ref;
+    }
+
+    const kind = match[1] as keyof RefOffsets;
+    const index = parseInt(match[2], 10);
+    return `#/${kind}/${index + offsets[kind]}`;
+  }
+
+  /**
+   * Remap image URI in a picture item by applying the pictures offset.
+   * Transforms "images/pic_N.png" → "images/pic_{N+offset}.png"
+   */
+  private remapPictureImageUri(
+    picture: DoclingPictureItem,
+    offsets: RefOffsets,
+  ): void {
+    // DoclingPictureItem may have an `image` field at runtime from Docling output
+    const rec = picture as unknown as { image?: { uri?: string } };
+    const image = rec.image;
+    if (!image?.uri) return;
+
+    const match = IMAGE_URI_PATTERN.exec(image.uri);
+    if (match) {
+      const index = parseInt(match[1], 10);
+      image.uri = `images/pic_${index + offsets.pictures}.png`;
+    }
+  }
+}

--- a/packages/pdf-parser/src/processors/docling-document-merger.ts
+++ b/packages/pdf-parser/src/processors/docling-document-merger.ts
@@ -26,9 +26,12 @@ export class DoclingDocumentMerger {
    * The first chunk's metadata (schema_name, version, name, origin) is used as the base.
    *
    * @param chunks - Array of DoclingDocument objects to merge (must have at least 1)
+   * @param picFileOffsets - Optional cumulative pic_ file counts per chunk.
+   *   When provided, picFileOffsets[i] is used for pic_ URI remapping instead of
+   *   the pictures array length, aligning URIs with relocated file indices.
    * @returns Merged DoclingDocument
    */
-  merge(chunks: DoclingDocument[]): DoclingDocument {
+  merge(chunks: DoclingDocument[], picFileOffsets?: number[]): DoclingDocument {
     if (chunks.length === 0) {
       throw new Error('Cannot merge zero chunks');
     }
@@ -48,6 +51,9 @@ export class DoclingDocumentMerger {
         tables: base.tables.length,
         groups: base.groups.length,
       };
+      const picFileOffset = picFileOffsets
+        ? picFileOffsets[i]
+        : offsets.pictures;
 
       // Merge texts
       for (const text of chunk.texts) {
@@ -75,8 +81,8 @@ export class DoclingDocumentMerger {
         remapped.captions = remapped.captions.map((c) => ({
           $ref: this.remapRef(c.$ref, offsets),
         }));
-        // Remap image URI
-        this.remapPictureImageUri(remapped, offsets);
+        // Remap image URI using file-based offset for correct alignment
+        this.remapPictureImageUri(remapped, picFileOffset);
         base.pictures.push(remapped);
       }
 
@@ -150,12 +156,12 @@ export class DoclingDocumentMerger {
   }
 
   /**
-   * Remap image URI in a picture item by applying the pictures offset.
+   * Remap image URI in a picture item by applying the pic file offset.
    * Transforms "images/pic_N.png" → "images/pic_{N+offset}.png"
    */
   private remapPictureImageUri(
     picture: DoclingPictureItem,
-    offsets: RefOffsets,
+    picFileOffset: number,
   ): void {
     // DoclingPictureItem may have an `image` field at runtime from Docling output
     const rec = picture as unknown as { image?: { uri?: string } };
@@ -165,7 +171,7 @@ export class DoclingDocumentMerger {
     const match = IMAGE_URI_PATTERN.exec(image.uri);
     if (match) {
       const index = parseInt(match[1], 10);
-      image.uri = `images/pic_${index + offsets.pictures}.png`;
+      image.uri = `images/pic_${index + picFileOffset}.png`;
     }
   }
 }


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Introduce chunked PDF conversion to process large PDFs in fixed-size page chunks, reducing peak memory usage and improving scalability. Instead of converting an entire PDF at once, the new `ChunkedPDFConverter` splits the document into page-range chunks, converts each independently via Docling, and merges the results using the new `DoclingDocumentMerger`.

## Changes

- Add `ChunkedPDFConverter` class that splits PDFs into configurable page-range chunks and processes them sequentially with per-chunk retry support and abort signal handling
- Add `DoclingDocumentMerger` to merge multiple `DoclingDocument` instances from chunk results into a single unified document, handling `self_ref` remapping and page index reconciliation
- Add `CHUNKED_CONVERSION` constants (`DEFAULT_CHUNK_SIZE: 10`, `DEFAULT_MAX_RETRIES: 2`) in `config/constants.ts`
- Extend `PDFConvertOptions` with `chunkedConversion` flag and integrate chunked path into `PDFConverter.convert()`
- Enable `chunkedConversion: true` by default in the demo-web task worker
- Add comprehensive test suites for `ChunkedPDFConverter` (1040 lines) and `DoclingDocumentMerger` (1033 lines)

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

N/A