### PR TITLE
fix(demo-web): scope PDF parser log forwarding to current task context

### DIFF
--- a/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
+++ b/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
@@ -2,6 +2,7 @@ import type { LoggerMethods } from '@heripo/logger';
 
 import { Logger } from '@heripo/logger';
 import { PDFParser } from '@heripo/pdf-parser';
+import { AsyncLocalStorage } from 'node:async_hooks';
 
 import { TaskQueueManager } from './task-queue-manager';
 
@@ -20,6 +21,7 @@ class PDFParserManager {
 
   // Task-specific loggers for forwarding PDF parser logs to frontend
   private taskLoggers: Map<string, LoggerMethods> = new Map();
+  private taskContext = new AsyncLocalStorage<string>();
 
   private constructor() {
     this.setupShutdownHandlers();
@@ -44,6 +46,14 @@ class PDFParserManager {
    */
   clearTaskLogger(taskId: string): void {
     this.taskLoggers.delete(taskId);
+  }
+
+  /**
+   * Run a function within a task context so PDF parser logs are forwarded
+   * only to the logger registered for this task.
+   */
+  runInTaskContext<T>(taskId: string, fn: () => T): T {
+    return this.taskContext.run(taskId, fn);
   }
 
   async getParser(): Promise<PDFParser> {
@@ -74,9 +84,12 @@ class PDFParserManager {
       level: 'debug' | 'info' | 'warn' | 'error',
       ...args: unknown[]
     ) => {
-      // Forward to all active task loggers
-      for (const taskLogger of this.taskLoggers.values()) {
-        taskLogger[level](...args);
+      const currentTaskId = this.taskContext.getStore();
+      if (currentTaskId) {
+        const taskLogger = this.taskLoggers.get(currentTaskId);
+        if (taskLogger) {
+          taskLogger[level](...args);
+        }
       }
     };
 

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -289,12 +289,8 @@ export async function runTaskWorker(
     };
 
     try {
-      const parseResult = await parsePdf(
-        pdfParser,
-        pdfUrl,
-        taskId,
-        pdfConvertOptions,
-        abortSignal,
+      const parseResult = await pdfParserManager.runInTaskContext(taskId, () =>
+        parsePdf(pdfParser, pdfUrl, taskId, pdfConvertOptions, abortSignal),
       );
 
       doclingDocument = parseResult.doclingDocument;

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -260,7 +260,6 @@ export async function runTaskWorker(
     // Register task logger to receive PDF parser logs
     pdfParserManager.setTaskLogger(taskId, logger);
 
-    const pdfParser = await pdfParserManager.getParser();
     const pdfUrl = `file://${filePath}`;
 
     let doclingDocument: DoclingDocument;
@@ -289,8 +288,18 @@ export async function runTaskWorker(
     };
 
     try {
-      const parseResult = await pdfParserManager.runInTaskContext(taskId, () =>
-        parsePdf(pdfParser, pdfUrl, taskId, pdfConvertOptions, abortSignal),
+      const parseResult = await pdfParserManager.runInTaskContext(
+        taskId,
+        async () => {
+          const pdfParser = await pdfParserManager.getParser();
+          return parsePdf(
+            pdfParser,
+            pdfUrl,
+            taskId,
+            pdfConvertOptions,
+            abortSignal,
+          );
+        },
       );
 
       doclingDocument = parseResult.doclingDocument;


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Fix PDF parser log forwarding so that logs are sent only to the task that produced them, instead of broadcasting to all active task loggers. This prevents log cross-contamination when multiple tasks run concurrently.

## Changes

- Introduce `AsyncLocalStorage` in `PDFParserManager` to track the current task context
- Add `runInTaskContext()` method that wraps PDF parsing execution within a task-scoped context
- Update log forwarding logic to look up the current task ID from `AsyncLocalStorage` and forward logs only to the matching task logger
- Simplify `parsePdf` call in `task-worker.ts` by wrapping it with `runInTaskContext()` instead of passing extra arguments

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
