### PR TITLE
feat(demo-web): add GPT-5.4 and Gemini 3.1 Flash Lite models

### DIFF
--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -11,6 +11,11 @@ export interface LLMModel {
 export const LLM_MODELS: LLMModel[] = [
   // OpenAI
   {
+    id: 'openai/gpt-5.4',
+    label: 'GPT-5.4',
+    provider: 'OpenAI',
+  },
+  {
     id: 'openai/gpt-5.2',
     label: 'GPT-5.2',
     provider: 'OpenAI',
@@ -52,6 +57,11 @@ export const LLM_MODELS: LLMModel[] = [
   {
     id: 'google/gemini-3-flash-preview',
     label: 'Gemini 3 Flash Preview',
+    provider: 'Google',
+  },
+  {
+    id: 'google/gemini-3.1-flash-lite-preview',
+    label: 'Gemini 3.1 Flash Lite Preview',
     provider: 'Google',
   },
 

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -22,12 +22,12 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // OCR Strategy
-  strategySamplerModel: 'openai/gpt-5.2',
+  strategySamplerModel: 'openai/gpt-5.4',
   vlmProcessorModel: 'openai/gpt-5.1',
   forcedMethod: undefined,
   // LLM Models
-  fallbackModel: 'openai/gpt-5.2',
-  validatorModel: 'openai/gpt-5.2',
+  fallbackModel: 'openai/gpt-5.4',
+  validatorModel: 'openai/gpt-5.4',
   pageRangeParserModel: 'google/gemini-3-flash-preview',
   tocExtractorModel: 'together/Qwen/Qwen3-235B-A22B-Instruct-2507-tput',
   visionTocExtractorModel: 'google/gemini-3-flash-preview',

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -52,20 +52,24 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'openai/gpt-oss-120b': { input: 0.15, output: 0.6 },
     'gpt-5.1': { input: 1.25, output: 10 },
     'gpt-5.2': { input: 1.75, output: 14 },
+    'gpt-5.4': { input: 2.5, output: 15 },
     'gpt-5-mini': { input: 0.25, output: 2 },
     // Google
     'gemini-3-flash-preview': { input: 0.5, output: 3 },
     'gemini-3.1-pro-preview': { input: 2, output: 12 },
+    'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
     // Claude
     'anthropic/claude-opus-4-6': { input: 5, output: 25 },
     'anthropic/claude-sonnet-4-6': { input: 3, output: 15 },
     'anthropic/claude-haiku-4-5': { input: 1, output: 5 },
     // VLM strategy models (provider-prefixed keys from TokenUsageReport)
+    'openai/gpt-5.4': { input: 2.5, output: 15 },
     'openai/gpt-5.2': { input: 1.75, output: 14 },
     'openai/gpt-5.1': { input: 1.25, output: 10 },
     'openai/gpt-5-mini': { input: 0.25, output: 2 },
     'google/gemini-3.1-pro-preview': { input: 2, output: 12 },
     'google/gemini-3-flash-preview': { input: 0.5, output: 3 },
+    'google/gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
   };
 
 /**


### PR DESCRIPTION
## Affected Package(s)

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Add GPT-5.4 (OpenAI) and Gemini 3.1 Flash Lite Preview (Google) to the demo-web LLM model list and pricing data, and update default model selections to use GPT-5.4.

## Changes

- Add `openai/gpt-5.4` and `google/gemini-3.1-flash-lite-preview` to the LLM model list
- Add pricing entries for both new models (with and without provider prefix)
- Update default form values: `strategySamplerModel`, `fallbackModel`, and `validatorModel` from GPT-5.2 to GPT-5.4

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

N/A
