### PR TITLE
feat(pdf-parser): centralize task failure handling with reusable helper

### DIFF
--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -689,10 +689,10 @@ describe('ChunkedPDFConverter', () => {
           {},
           mockBuildOptions,
         ),
-      ).rejects.toThrow('Chunk task failed: unknown');
+      ).rejects.toThrow('Chunk task failed: status: failure');
     });
 
-    test('task poll failure with getResult error falls back to unknown', async () => {
+    test('task poll failure with getResult error falls back to unable to retrieve error details', async () => {
       vi.mocked(spawnAsync).mockResolvedValue({
         code: 0,
         stdout: 'Pages:          5\n',
@@ -718,7 +718,12 @@ describe('ChunkedPDFConverter', () => {
           {},
           mockBuildOptions,
         ),
-      ).rejects.toThrow('Chunk task failed: unknown');
+      ).rejects.toThrow('Chunk task failed: unable to retrieve error details');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[ChunkedPDFConverter] Failed to retrieve task result:',
+        expect.any(Error),
+      );
     });
 
     test('task poll timeout throws error', async () => {

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -28,6 +28,7 @@ import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
 import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { getTaskFailureDetails } from '../utils/task-failure-details';
 
 /** Configuration for chunked conversion */
 export interface ChunkedConversionConfig {
@@ -342,15 +343,11 @@ export class ChunkedPDFConverter {
       if (status.task_status === 'success') return;
 
       if (status.task_status === 'failure') {
-        let details = 'unknown';
-        try {
-          const result = await task.getResult();
-          if (result.errors?.length) {
-            details = result.errors.map((e) => e.message).join('; ');
-          }
-        } catch {
-          // ignore
-        }
+        const details = await getTaskFailureDetails(
+          task,
+          this.logger,
+          '[ChunkedPDFConverter]',
+        );
         throw new Error(`[ChunkedPDFConverter] Chunk task failed: ${details}`);
       }
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -27,6 +27,7 @@ import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
 import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { getTaskFailureDetails } from '../utils/task-failure-details';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
 
@@ -767,20 +768,7 @@ export class PDFConverter {
   private async getTaskFailureDetails(
     task: AsyncConversionTask,
   ): Promise<string> {
-    try {
-      const result = await task.getResult();
-      if (result.errors?.length) {
-        return result.errors
-          .map((e: { message: string }) => e.message)
-          .join('; ');
-      }
-      /* v8 ignore start -- status is always present in ConvertDocumentResponse */
-      return `status: ${result.status ?? 'unknown'}`;
-      /* v8 ignore stop */
-    } catch (err) {
-      this.logger.error('[PDFConverter] Failed to retrieve task result:', err);
-      return 'unable to retrieve error details';
-    }
+    return getTaskFailureDetails(task, this.logger, '[PDFConverter]');
   }
 
   private async downloadResult(taskId: string): Promise<void> {

--- a/packages/pdf-parser/src/utils/task-failure-details.test.ts
+++ b/packages/pdf-parser/src/utils/task-failure-details.test.ts
@@ -1,0 +1,81 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { getTaskFailureDetails } from './task-failure-details';
+
+describe('getTaskFailureDetails', () => {
+  let logger: LoggerMethods;
+
+  beforeEach(() => {
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as LoggerMethods;
+  });
+
+  test('returns joined error messages when errors array is present', async () => {
+    const task = {
+      getResult: vi.fn().mockResolvedValue({
+        errors: [{ message: 'error one' }, { message: 'error two' }],
+        status: 'failure',
+      }),
+    };
+
+    const result = await getTaskFailureDetails(task, logger, '[Test]');
+
+    expect(result).toBe('error one; error two');
+  });
+
+  test('returns status fallback when errors array is empty', async () => {
+    const task = {
+      getResult: vi.fn().mockResolvedValue({
+        errors: [],
+        status: 'failure',
+      }),
+    };
+
+    const result = await getTaskFailureDetails(task, logger, '[Test]');
+
+    expect(result).toBe('status: failure');
+  });
+
+  test('returns status fallback when errors is undefined', async () => {
+    const task = {
+      getResult: vi.fn().mockResolvedValue({
+        status: 'partial_failure',
+      }),
+    };
+
+    const result = await getTaskFailureDetails(task, logger, '[Test]');
+
+    expect(result).toBe('status: partial_failure');
+  });
+
+  test('returns "status: unknown" when both errors and status are absent', async () => {
+    const task = {
+      getResult: vi.fn().mockResolvedValue({}),
+    };
+
+    const result = await getTaskFailureDetails(task, logger, '[Test]');
+
+    expect(result).toBe('status: unknown');
+  });
+
+  test('logs error and returns fallback when getResult throws', async () => {
+    const networkError = new Error('Network error');
+    const task = {
+      getResult: vi.fn().mockRejectedValue(networkError),
+    };
+
+    const result = await getTaskFailureDetails(task, logger, '[Test]');
+
+    expect(result).toBe('unable to retrieve error details');
+    expect(logger.error).toHaveBeenCalledWith(
+      '[Test] Failed to retrieve task result:',
+      networkError,
+    );
+  });
+});

--- a/packages/pdf-parser/src/utils/task-failure-details.ts
+++ b/packages/pdf-parser/src/utils/task-failure-details.ts
@@ -1,0 +1,32 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+/**
+ * Retrieve detailed error information from a failed async conversion task.
+ *
+ * Tries `task.getResult()` and inspects:
+ * 1. `result.errors` array – joins all messages with "; "
+ * 2. `result.status` fallback – returns "status: <value>"
+ * 3. If both are absent – returns "status: unknown"
+ * 4. If `getResult()` throws – logs the error and returns a fallback string
+ */
+export async function getTaskFailureDetails(
+  task: {
+    getResult: () => Promise<{
+      errors?: { message: string }[];
+      status?: string;
+    }>;
+  },
+  logger: LoggerMethods,
+  logPrefix: string,
+): Promise<string> {
+  try {
+    const result = await task.getResult();
+    if (result.errors?.length) {
+      return result.errors.map((e) => e.message).join('; ');
+    }
+    return `status: ${result.status ?? 'unknown'}`;
+  } catch (err) {
+    logger.error(`${logPrefix} Failed to retrieve task result:`, err);
+    return 'unable to retrieve error details';
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract duplicated task failure detail logic from `PDFConverter` and `ChunkedPDFConverter` into a shared `getTaskFailureDetails` utility function to improve maintainability and consistency.

## Changes

- Add `getTaskFailureDetails` utility in `packages/pdf-parser/src/utils/task-failure-details.ts`
- Replace inline failure detail extraction in `ChunkedPDFConverter` with the new utility
- Delegate `PDFConverter.getTaskFailureDetails` to the shared utility
- Add comprehensive unit tests for the utility covering error messages, status fallback, and `getResult` rejection scenarios
- Update `ChunkedPDFConverter` tests to match refined error messages (`"status: failure"` instead of `"unknown"`, `"unable to retrieve error details"` instead of `"unknown"`)

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

N/A
