### PR TITLE
fix(demo-web): include active tasks in daily limit count

### DIFF
--- a/apps/demo-web/src/app/api/rate-limit/check/route.ts
+++ b/apps/demo-web/src/app/api/rate-limit/check/route.ts
@@ -12,7 +12,7 @@ export async function GET() {
   return NextResponse.json({
     canCreate: status.canCreate,
     reason: status.reason,
-    todayCompleted: status.todayCompleted,
+    todayUsed: status.todayUsed,
     dailyLimit: status.dailyLimit,
     remaining: status.remaining,
     resetsAt,

--- a/apps/demo-web/src/app/api/tasks/route.ts
+++ b/apps/demo-web/src/app/api/tasks/route.ts
@@ -214,7 +214,7 @@ export async function POST(request: NextRequest) {
               ...clientInfo,
               filename: file.name,
               dailyLimit: usageStatus.dailyLimit,
-              todayCompleted: usageStatus.todayCompleted,
+              todayUsed: usageStatus.todayUsed,
             }),
           );
 

--- a/apps/demo-web/src/app/api/upload/session/route.ts
+++ b/apps/demo-web/src/app/api/upload/session/route.ts
@@ -194,7 +194,7 @@ export async function POST(request: NextRequest) {
               ...clientInfo,
               filename,
               dailyLimit: usageStatus.dailyLimit,
-              todayCompleted: usageStatus.todayCompleted,
+              todayUsed: usageStatus.todayUsed,
             }),
           );
 

--- a/apps/demo-web/src/app/page.tsx
+++ b/apps/demo-web/src/app/page.tsx
@@ -261,7 +261,7 @@ function HomePageContent() {
               {/* Info Banner - Always visible in public mode when not blocked */}
               {isPublicMode && !isBlocked && rateLimit && (
                 <PublicModeInfoBanner
-                  todayCompleted={rateLimit.todayCompleted}
+                  todayUsed={rateLimit.todayUsed}
                   dailyLimit={rateLimit.dailyLimit}
                   remaining={rateLimit.remaining}
                   resetsAt={rateLimit.resetsAt}

--- a/apps/demo-web/src/features/upload/components/public-mode-info-banner.tsx
+++ b/apps/demo-web/src/features/upload/components/public-mode-info-banner.tsx
@@ -1,7 +1,7 @@
 import { Info } from 'lucide-react';
 
 interface PublicModeInfoBannerProps {
-  todayCompleted: number;
+  todayUsed: number;
   dailyLimit: number;
   remaining: number;
   resetsAt: string;
@@ -19,7 +19,7 @@ function formatResetTime(isoString: string): string {
 }
 
 export function PublicModeInfoBanner({
-  todayCompleted: _todayCompleted,
+  todayUsed: _todayUsed,
   dailyLimit,
   remaining,
   resetsAt,

--- a/apps/demo-web/src/features/upload/hooks/use-rate-limit.ts
+++ b/apps/demo-web/src/features/upload/hooks/use-rate-limit.ts
@@ -6,7 +6,7 @@ import { rateLimitKeys } from '~/lib/query-keys';
 export interface RateLimitCheckResponse {
   canCreate: boolean;
   reason?: string;
-  todayCompleted: number;
+  todayUsed: number;
   dailyLimit: number;
   remaining: number;
   resetsAt: string;

--- a/apps/demo-web/src/lib/db/repositories/usage-repository.ts
+++ b/apps/demo-web/src/lib/db/repositories/usage-repository.ts
@@ -3,7 +3,7 @@ import { readDatabase } from '../index';
 export interface UsageStatus {
   canCreate: boolean;
   reason?: string;
-  todayCompleted: number;
+  todayUsed: number;
   dailyLimit: number;
   remaining: number;
   activeTaskCount: number;
@@ -61,7 +61,15 @@ export function getUsageStatus(): UsageStatus {
     (t) => t.status === 'queued' || t.status === 'running',
   ).length;
 
-  const remaining = Math.max(0, limit - todayCompleted);
+  // Count active non-OTP tasks toward daily usage
+  const activeNonOtpCount = db.tasks.filter(
+    (t) =>
+      (t.status === 'queued' || t.status === 'running') && !t.is_otp_bypass,
+  ).length;
+
+  // Include both completed and in-progress tasks in daily usage
+  const todayUsed = todayCompleted + activeNonOtpCount;
+  const remaining = Math.max(0, limit - todayUsed);
 
   // Block if concurrent task limit is exceeded
   if (concurrentLimit > 0 && activeTaskCount >= concurrentLimit) {
@@ -72,7 +80,7 @@ export function getUsageStatus(): UsageStatus {
     return {
       canCreate: false,
       reason,
-      todayCompleted,
+      todayUsed,
       dailyLimit: limit,
       remaining,
       activeTaskCount,
@@ -80,11 +88,11 @@ export function getUsageStatus(): UsageStatus {
   }
 
   // Block if daily limit reached
-  if (todayCompleted >= limit) {
+  if (todayUsed >= limit) {
     return {
       canCreate: false,
       reason: `Daily limit (${limit} ${limit === 1 ? 'task' : 'tasks'}) reached. Please try again tomorrow.`,
-      todayCompleted,
+      todayUsed,
       dailyLimit: limit,
       remaining: 0,
       activeTaskCount,
@@ -94,7 +102,7 @@ export function getUsageStatus(): UsageStatus {
   // Allow
   return {
     canCreate: true,
-    todayCompleted,
+    todayUsed,
     dailyLimit: limit,
     remaining,
     activeTaskCount,

--- a/apps/demo-web/src/lib/db/repositories/usage-repository.ts
+++ b/apps/demo-web/src/lib/db/repositories/usage-repository.ts
@@ -64,7 +64,9 @@ export function getUsageStatus(): UsageStatus {
   // Count active non-OTP tasks toward daily usage
   const activeNonOtpCount = db.tasks.filter(
     (t) =>
-      (t.status === 'queued' || t.status === 'running') && !t.is_otp_bypass,
+      (t.status === 'queued' || t.status === 'running') &&
+      !t.is_otp_bypass &&
+      t.created_at.startsWith(todayUTC),
   ).length;
 
   // Include both completed and in-progress tasks in daily usage

--- a/apps/demo-web/src/lib/webhook/payloads.ts
+++ b/apps/demo-web/src/lib/webhook/payloads.ts
@@ -148,7 +148,7 @@ export function createRateLimitExceededPayload(params: {
   userAgent: string;
   filename: string;
   dailyLimit: number;
-  todayCompleted: number;
+  todayUsed: number;
 }): RateLimitExceededPayload {
   return {
     event: 'rate_limit.exceeded',
@@ -157,7 +157,7 @@ export function createRateLimitExceededPayload(params: {
     userAgent: params.userAgent,
     filename: params.filename,
     dailyLimit: params.dailyLimit,
-    todayCompleted: params.todayCompleted,
+    todayUsed: params.todayUsed,
   };
 }
 

--- a/apps/demo-web/src/lib/webhook/types.ts
+++ b/apps/demo-web/src/lib/webhook/types.ts
@@ -97,7 +97,7 @@ export interface RateLimitExceededPayload extends WebhookBasePayload {
   event: 'rate_limit.exceeded';
   filename: string;
   dailyLimit: number;
-  todayCompleted: number;
+  todayUsed: number;
 }
 
 /**


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Fix daily rate limiting to account for in-progress (queued/running) tasks, preventing users from exceeding the daily limit when multiple tasks run concurrently.

Previously, only completed tasks were counted toward `DAILY_LIMIT`. This meant users could submit more tasks than the limit allows while earlier tasks were still running. Now, active non-OTP tasks are included in the usage count.

## Changes

- Count queued/running non-OTP tasks toward daily usage in `getUsageStatus()`
- Rename `todayCompleted` → `todayUsed` across the codebase to accurately reflect the new semantics (completed + active tasks)
- Update `UsageStatus` interface, API responses, webhook payloads, and UI components to use the renamed field

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
