### PR TITLE
chore: update deployment workflow to use org-mac runner

### DIFF
--- a/.github/workflows/cd-demo-web.yml
+++ b/.github/workflows/cd-demo-web.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   deploy:
     name: Build and Deploy Demo Web
-    runs-on: self-hosted
+    runs-on: org-mac
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Update the demo-web CD workflow to use the `org-mac` runner label instead of the generic `self-hosted` label, aligning with the organization's runner naming convention.

## Changes

- Change `runs-on` value from `self-hosted` to `org-mac` in `.github/workflows/cd-demo-web.yml`

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
