### PR TITLE
refactor(pdf-parser): extract and modularize converter utilities for better reusability

### DIFF
--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -5,22 +5,20 @@ import type { DoclingAPIClient } from 'docling-sdk';
 import { spawnAsync } from '@heripo/shared';
 import {
   copyFileSync,
-  createWriteStream,
   existsSync,
   readFileSync,
   readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { rename } from 'node:fs/promises';
-import { pipeline } from 'node:stream/promises';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
-import { PageRenderer } from '../processors/page-renderer';
-import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
+import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
-import * as taskFailureDetailsModule from '../utils/task-failure-details';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 
 vi.mock('@heripo/shared', () => ({
@@ -35,20 +33,10 @@ vi.mock('node:fs', () => ({
   readdirSync: vi.fn(),
   rmSync: vi.fn(),
   writeFileSync: vi.fn(),
-  createWriteStream: vi.fn(),
-}));
-
-vi.mock('node:fs/promises', () => ({
-  rename: vi.fn(),
-  writeFile: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
   join: vi.fn((...args: string[]) => args.join('/')),
-}));
-
-vi.mock('node:stream/promises', () => ({
-  pipeline: vi.fn(),
 }));
 
 vi.mock('../processors/image-extractor', () => ({
@@ -61,22 +49,21 @@ vi.mock('../processors/docling-document-merger', () => ({
   DoclingDocumentMerger: vi.fn(),
 }));
 
-vi.mock('../processors/page-renderer', () => ({
-  PageRenderer: vi.fn(),
-}));
-
 vi.mock('../utils/jq', () => ({
   runJqFileJson: vi.fn(),
-  runJqFileToFile: vi.fn(),
 }));
 
 vi.mock('../utils/local-file-server', () => ({
   LocalFileServer: vi.fn(),
 }));
 
-vi.mock('../utils/task-failure-details', () => ({
-  getTaskFailureDetails: vi.fn(),
+vi.mock('./conversion-options-builder', () => ({
+  buildConversionOptions: vi.fn().mockReturnValue({ to_formats: ['json'] }),
 }));
+
+vi.mock('../utils/task-progress-tracker');
+vi.mock('../utils/docling-result-downloader');
+vi.mock('../utils/page-image-updater');
 
 function makeDoc(overrides: Partial<DoclingDocument> = {}): DoclingDocument {
   return {
@@ -119,7 +106,6 @@ describe('ChunkedPDFConverter', () => {
   let mockBuildOptions: Mock;
   let mockServerInstance: { start: Mock; stop: Mock };
   let mockMergerInstance: { merge: Mock };
-  let mockRendererInstance: { renderPages: Mock };
   let mockTask: { taskId: string; poll: Mock; getResult: Mock };
 
   beforeEach(() => {
@@ -181,18 +167,6 @@ describe('ChunkedPDFConverter', () => {
       return mockMergerInstance as any;
     });
 
-    // Mock PageRenderer
-    mockRendererInstance = {
-      renderPages: vi.fn().mockResolvedValue({
-        pageCount: 25,
-        pagesDir: '/test/cwd/output/report/pages',
-        pageFiles: [],
-      }),
-    };
-    vi.mocked(PageRenderer).mockImplementation(function () {
-      return mockRendererInstance as any;
-    });
-
     // Mock spawnAsync (pdfinfo returning page count)
     vi.mocked(spawnAsync).mockResolvedValue({
       code: 0,
@@ -203,12 +177,6 @@ describe('ChunkedPDFConverter', () => {
     // Mock runJqFileJson (returns DoclingDocument per chunk)
     vi.mocked(runJqFileJson).mockResolvedValue(makeDoc());
 
-    // Mock runJqFileToFile
-    vi.mocked(runJqFileToFile).mockResolvedValue(undefined as any);
-
-    // Mock rename
-    vi.mocked(rename).mockResolvedValue(undefined);
-
     // Mock existsSync: default false
     vi.mocked(existsSync).mockReturnValue(false);
 
@@ -218,10 +186,10 @@ describe('ChunkedPDFConverter', () => {
     // Mock readFileSync: empty JSON by default (for cleanupOrphanedPicFiles)
     vi.mocked(readFileSync).mockReturnValue('{}');
 
-    // Mock getTaskFailureDetails: default returns a generic message
-    vi.mocked(taskFailureDetailsModule.getTaskFailureDetails).mockResolvedValue(
-      'unable to retrieve error details',
-    );
+    // Mock extracted utilities
+    vi.mocked(trackTaskProgress).mockResolvedValue(undefined);
+    vi.mocked(downloadTaskResult).mockResolvedValue(undefined);
+    vi.mocked(renderAndUpdatePageImages).mockResolvedValue(undefined);
   });
 
   describe('calculateChunks', () => {
@@ -313,7 +281,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Local file server started and stopped
@@ -343,8 +310,8 @@ describe('ChunkedPDFConverter', () => {
       // onComplete callback called
       expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/report-1');
 
-      // Page rendering done
-      expect(mockRendererInstance.renderPages).toHaveBeenCalled();
+      // Page rendering done via extracted utility
+      expect(renderAndUpdatePageImages).toHaveBeenCalled();
     });
 
     test('fails when page count detection fails', async () => {
@@ -361,7 +328,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Failed to detect page count from PDF');
     });
@@ -384,7 +350,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Called twice (1 failure + 1 retry success)
@@ -411,7 +376,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Persistent error');
 
@@ -485,7 +449,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // 3 pic_ + 3 image_ = 6 total copies
@@ -552,7 +515,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // 3 image_ files only
@@ -584,7 +546,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/my-report');
@@ -606,7 +567,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         true,
         {},
-        mockBuildOptions,
       );
 
       // Both chunks dir and output dir cleaned up
@@ -633,7 +593,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       expect(writeFileSync).toHaveBeenCalledWith(
@@ -642,25 +601,15 @@ describe('ChunkedPDFConverter', () => {
       );
     });
 
-    test('task poll failure reports error details with taskId and elapsed time', async () => {
+    test('trackTaskProgress error propagates from convertChunked', async () => {
       vi.mocked(spawnAsync).mockResolvedValue({
         code: 0,
         stdout: 'Pages:          5\n',
         stderr: '',
       });
 
-      vi.mocked(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).mockResolvedValue('OCR engine crashed');
-
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task progress tracking failed'),
       );
 
       await expect(
@@ -670,212 +619,32 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
-      ).rejects.toThrow('OCR engine crashed');
-
-      // Verify detailed failure logging with taskId and elapsed time
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /\[ChunkedPDFConverter\] Task task-fail failed after \d+\.\d+s/,
-        ),
-      );
+      ).rejects.toThrow('Task progress tracking failed');
     });
 
-    test('task poll failure without errors array falls back to status', async () => {
+    test('downloadTaskResult is called with correct arguments', async () => {
       vi.mocked(spawnAsync).mockResolvedValue({
         code: 0,
         stdout: 'Pages:          5\n',
         stderr: '',
       });
 
-      vi.mocked(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).mockResolvedValue('status: failure');
-
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
       );
 
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task failed: status: failure');
-    });
-
-    test('task poll failure with getResult error falls back to unable to retrieve error details', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      // getTaskFailureDetails is already mocked to return 'unable to retrieve error details' by default
-
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
-      );
-
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task failed: unable to retrieve error details');
-
-      // Verify getTaskFailureDetails was called with correct arguments
-      expect(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).toHaveBeenCalledWith(failingTask, logger, '[ChunkedPDFConverter]');
-    });
-
-    test('task poll timeout throws error', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      // Use a very short timeout
-      const shortTimeoutConverter = new ChunkedPDFConverter(
-        logger,
+      expect(downloadTaskResult).toHaveBeenCalledWith(
         client,
-        { chunkSize: 10, maxRetries: 0 },
-        1,
+        'task-1',
+        expect.stringContaining('result.zip'),
+        logger,
+        '[ChunkedPDFConverter]',
       );
-
-      const hangingTask = {
-        taskId: 'task-hang',
-        poll: vi.fn().mockResolvedValue({ task_status: 'pending' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        hangingTask,
-      );
-
-      await expect(
-        shortTimeoutConverter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task timeout');
-    });
-
-    test('downloadResult uses fileStream when available', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      const mockWriteStream = { on: vi.fn() };
-      vi.mocked(createWriteStream).mockReturnValue(mockWriteStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
-
-      const mockStream = { pipe: vi.fn() };
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({
-        fileStream: mockStream,
-      });
-
-      await converter.convertChunked(
-        'file:///test/input.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {},
-        mockBuildOptions,
-      );
-
-      expect(pipeline).toHaveBeenCalled();
-    });
-
-    test('downloadResult uses fetch fallback when no fileStream or data', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
-
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
-      vi.stubGlobal('fetch', mockFetch);
-
-      await converter.convertChunked(
-        'file:///test/input.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {},
-        mockBuildOptions,
-      );
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:5001/v1/result/task-1',
-        expect.objectContaining({ headers: { Accept: 'application/zip' } }),
-      );
-
-      vi.unstubAllGlobals();
-    });
-
-    test('downloadResult fetch fallback throws on non-ok response', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
-
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-      vi.stubGlobal('fetch', mockFetch);
-
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Failed to download chunk ZIP: 500');
-
-      vi.unstubAllGlobals();
     });
 
     test('chunk temp files are cleaned up after successful conversion', async () => {
@@ -894,7 +663,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // ZIP and extracted dirs are cleaned per chunk
@@ -927,7 +695,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         true,
         {},
-        mockBuildOptions,
       );
 
       // _chunks dir cleaned up
@@ -971,7 +738,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // All 3 orphaned pic_ files deleted
@@ -1023,7 +789,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // pic_0 and pic_2 deleted (orphaned)
@@ -1065,7 +830,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Failed to detect page count from PDF');
     });
@@ -1088,7 +852,7 @@ describe('ChunkedPDFConverter', () => {
       );
     });
 
-    test('_chunks directory is cleaned up even when renderPageImages throws', async () => {
+    test('_chunks directory is cleaned up even when renderAndUpdatePageImages throws', async () => {
       vi.mocked(spawnAsync).mockResolvedValue({
         code: 0,
         stdout: 'Pages:          5\n',
@@ -1097,7 +861,7 @@ describe('ChunkedPDFConverter', () => {
 
       vi.mocked(existsSync).mockReturnValue(true);
 
-      mockRendererInstance.renderPages.mockRejectedValue(
+      vi.mocked(renderAndUpdatePageImages).mockRejectedValue(
         new Error('ImageMagick crashed'),
       );
 
@@ -1108,7 +872,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('ImageMagick crashed');
 
@@ -1137,7 +900,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Callback error');
 
@@ -1182,7 +944,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Merger should have been called with picFileOffsets [0, 3]

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -246,11 +246,25 @@ export class ChunkedPDFConverter {
         });
 
         // Poll until completion
-        await this.trackTaskProgress(task);
+        await trackTaskProgress(
+          task,
+          this.timeout,
+          this.logger,
+          '[ChunkedPDFConverter]',
+          {
+            errorPrefix: '[ChunkedPDFConverter] Chunk ',
+          },
+        );
 
         // Download ZIP result
         const zipPath = join(chunkDir, 'result.zip');
-        await this.downloadResult(task.taskId, zipPath);
+        await downloadTaskResult(
+          this.client,
+          task.taskId,
+          zipPath,
+          this.logger,
+          '[ChunkedPDFConverter]',
+        );
 
         // Extract ZIP and process images
         const extractDir = join(chunkDir, 'extracted');
@@ -324,45 +338,6 @@ export class ChunkedPDFConverter {
     }
     const match = result.stdout.match(/^Pages:\s+(\d+)/m);
     return match ? parseInt(match[1], 10) : 0;
-  }
-
-  /** Poll task progress until completion */
-  private async trackTaskProgress(task: {
-    taskId: string;
-    poll: () => Promise<{ task_status: string }>;
-    getResult: () => Promise<{
-      errors?: { message: string }[];
-      status?: string;
-    }>;
-  }): Promise<void> {
-    const startTime = Date.now();
-
-    while (true) {
-      if (Date.now() - startTime > this.timeout) {
-        throw new Error('[ChunkedPDFConverter] Chunk task timeout');
-      }
-
-      const status = await task.poll();
-
-      if (status.task_status === 'success') return;
-
-      if (status.task_status === 'failure') {
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        this.logger.error(
-          `[ChunkedPDFConverter] Task ${task.taskId} failed after ${elapsed}s`,
-        );
-        const details = await getTaskFailureDetails(
-          task,
-          this.logger,
-          '[ChunkedPDFConverter]',
-        );
-        throw new Error(`[ChunkedPDFConverter] Chunk task failed: ${details}`);
-      }
-
-      await new Promise((resolve) =>
-        setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
-      );
-    }
   }
 
   /**

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -10,7 +10,6 @@ import type {
 import { spawnAsync } from '@heripo/shared';
 import {
   copyFileSync,
-  createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -20,7 +19,6 @@ import {
 } from 'node:fs';
 import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { pipeline } from 'node:stream/promises';
 
 import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
@@ -359,37 +357,6 @@ export class ChunkedPDFConverter {
         setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
       );
     }
-  }
-
-  /** Download ZIP result for a task */
-  private async downloadResult(taskId: string, zipPath: string): Promise<void> {
-    const zipResult = await this.client.getTaskResultFile(taskId);
-
-    if (zipResult.fileStream) {
-      const writeStream = createWriteStream(zipPath);
-      await pipeline(zipResult.fileStream, writeStream);
-      return;
-    }
-
-    if (zipResult.data) {
-      await writeFile(zipPath, zipResult.data);
-      return;
-    }
-
-    // Fallback: direct HTTP download
-    const baseUrl = this.client.getConfig().baseUrl;
-    const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
-      headers: { Accept: 'application/zip' },
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to download chunk ZIP: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const buffer = new Uint8Array(await response.arrayBuffer());
-    await writeFile(zipPath, buffer);
   }
 
   /**

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -17,16 +17,17 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
+import { PDF_CONVERTER } from '../config/constants';
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
 import { ImageExtractor } from '../processors/image-extractor';
-import { PageRenderer } from '../processors/page-renderer';
-import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
+import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
-import { getTaskFailureDetails } from '../utils/task-failure-details';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
+import { buildConversionOptions } from './conversion-options-builder';
 
 /** Configuration for chunked conversion */
 export interface ChunkedConversionConfig {
@@ -160,7 +161,12 @@ export class ChunkedPDFConverter {
 
     try {
       // Step 7: Render page images (ImageMagick, same as non-chunked)
-      await this.renderPageImages(pdfPath, outputDir);
+      await renderAndUpdatePageImages(
+        pdfPath,
+        outputDir,
+        this.logger,
+        '[ChunkedPDFConverter]',
+      );
 
       // Step 7.5: Clean up orphaned pic_ files
       this.cleanupOrphanedPicFiles(resultPath, imagesDir);
@@ -430,37 +436,6 @@ export class ChunkedPDFConverter {
 
     this.logger.info(
       `[ChunkedPDFConverter] Relocated ${picGlobalIndex} pic + ${imageGlobalIndex} image files to ${imagesDir}`,
-    );
-  }
-
-  /** Render page images from PDF using ImageMagick and update result.json */
-  private async renderPageImages(
-    pdfPath: string,
-    outputDir: string,
-  ): Promise<void> {
-    this.logger.info(
-      '[ChunkedPDFConverter] Rendering page images with ImageMagick...',
-    );
-
-    const renderer = new PageRenderer(this.logger);
-    const renderResult = await renderer.renderPages(pdfPath, outputDir);
-
-    const resultPath = join(outputDir, 'result.json');
-    const tmpPath = resultPath + '.tmp';
-    const jqProgram = `
-      .pages |= with_entries(
-        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
-          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
-          .value.image.mimetype = "image/png" |
-          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
-        else . end
-      )
-    `;
-    await runJqFileToFile(jqProgram, resultPath, tmpPath);
-    await rename(tmpPath, resultPath);
-
-    this.logger.info(
-      `[ChunkedPDFConverter] Rendered ${renderResult.pageCount} page images`,
     );
   }
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -869,49 +869,4 @@ export class PDFConverter {
       outputDir,
     );
   }
-
-  /**
-   * Render page images from the source PDF using ImageMagick and update result.json.
-   * Uses jq to update the JSON file without loading it into Node.js memory.
-   * Replaces Docling's generate_page_images which fails on large PDFs
-   * due to memory limits when embedding all page images as base64.
-   */
-  private async renderPageImages(
-    url: string,
-    outputDir: string,
-  ): Promise<void> {
-    if (!url.startsWith('file://')) {
-      this.logger.warn(
-        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
-      );
-      return;
-    }
-
-    const pdfPath = url.slice(7);
-    this.logger.info(
-      '[PDFConverter] Rendering page images with ImageMagick...',
-    );
-
-    const renderer = new PageRenderer(this.logger);
-    const renderResult = await renderer.renderPages(pdfPath, outputDir);
-
-    // Update result.json with page image URIs using jq to avoid loading large JSON
-    const resultPath = join(outputDir, 'result.json');
-    const tmpPath = resultPath + '.tmp';
-    const jqProgram = `
-      .pages |= with_entries(
-        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
-          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
-          .value.image.mimetype = "image/png" |
-          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
-        else . end
-      )
-    `;
-    await runJqFileToFile(jqProgram, resultPath, tmpPath);
-    await rename(tmpPath, resultPath);
-
-    this.logger.info(
-      `[PDFConverter] Rendered ${renderResult.pageCount} page images`,
-    );
-  }
 }

--- a/packages/pdf-parser/src/utils/docling-result-downloader.test.ts
+++ b/packages/pdf-parser/src/utils/docling-result-downloader.test.ts
@@ -1,0 +1,150 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingAPIClient } from 'docling-sdk';
+import type { Mock } from 'vitest';
+
+import { createWriteStream } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { downloadTaskResult } from './docling-result-downloader';
+
+vi.mock('node:fs', () => ({
+  createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}));
+
+vi.mock('node:stream/promises', () => ({
+  pipeline: vi.fn(),
+}));
+
+describe('downloadTaskResult', () => {
+  let client: DoclingAPIClient;
+  let logger: LoggerMethods;
+
+  beforeEach(() => {
+    client = {
+      getTaskResultFile: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
+    } as unknown as DoclingAPIClient;
+
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as LoggerMethods;
+  });
+
+  test('downloads via fileStream when available', async () => {
+    const mockStream = { pipe: vi.fn() };
+    const mockWriteStream = {};
+    vi.mocked(createWriteStream).mockReturnValue(mockWriteStream as any);
+    vi.mocked(pipeline).mockResolvedValue(undefined);
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      fileStream: mockStream,
+    });
+
+    await downloadTaskResult(
+      client,
+      'task-1',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(createWriteStream).toHaveBeenCalledWith('/tmp/result.zip');
+    expect(pipeline).toHaveBeenCalledWith(mockStream, mockWriteStream);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('downloads via data when fileStream is absent', async () => {
+    const mockData = new Uint8Array([1, 2, 3]);
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      data: mockData,
+    });
+
+    await downloadTaskResult(
+      client,
+      'task-2',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(writeFile).toHaveBeenCalledWith('/tmp/result.zip', mockData);
+    expect(createWriteStream).not.toHaveBeenCalled();
+  });
+
+  test('falls back to direct HTTP fetch when no fileStream or data', async () => {
+    (client.getTaskResultFile as Mock).mockResolvedValue({});
+
+    const mockBuffer = new ArrayBuffer(4);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(mockBuffer),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await downloadTaskResult(
+      client,
+      'task-3',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5001/v1/result/task-3',
+      { headers: { Accept: 'application/zip' } },
+    );
+    expect(writeFile).toHaveBeenCalledWith(
+      '/tmp/result.zip',
+      new Uint8Array(mockBuffer),
+    );
+    expect(logger.warn).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  test('throws on non-ok HTTP response', async () => {
+    (client.getTaskResultFile as Mock).mockResolvedValue({});
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      downloadTaskResult(client, 'task-4', '/tmp/result.zip', logger, '[Test]'),
+    ).rejects.toThrow('Failed to download ZIP file: 500 Internal Server Error');
+
+    vi.unstubAllGlobals();
+  });
+
+  test('logs with provided prefix', async () => {
+    const mockData = new Uint8Array([1]);
+    (client.getTaskResultFile as Mock).mockResolvedValue({ data: mockData });
+
+    await downloadTaskResult(
+      client,
+      'task-5',
+      '/tmp/result.zip',
+      logger,
+      '[MyPrefix]',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '\n[MyPrefix] Task completed, downloading ZIP file...',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[MyPrefix] Saving ZIP file to:',
+      '/tmp/result.zip',
+    );
+  });
+});

--- a/packages/pdf-parser/src/utils/docling-result-downloader.ts
+++ b/packages/pdf-parser/src/utils/docling-result-downloader.ts
@@ -1,0 +1,60 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingAPIClient } from 'docling-sdk';
+
+import { createWriteStream } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+
+/**
+ * Download the ZIP result from a completed Docling conversion task.
+ *
+ * Uses 3-step fallback: fileStream → data → direct HTTP fetch.
+ *
+ * @param client - Docling API client
+ * @param taskId - Completed task ID
+ * @param zipPath - Local path to save the ZIP file
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]' or '[ChunkedPDFConverter]')
+ */
+export async function downloadTaskResult(
+  client: DoclingAPIClient,
+  taskId: string,
+  zipPath: string,
+  logger: LoggerMethods,
+  logPrefix: string,
+): Promise<void> {
+  logger.info(`\n${logPrefix} Task completed, downloading ZIP file...`);
+
+  const zipResult = await client.getTaskResultFile(taskId);
+
+  logger.info(`${logPrefix} Saving ZIP file to:`, zipPath);
+
+  if (zipResult.fileStream) {
+    const writeStream = createWriteStream(zipPath);
+    await pipeline(zipResult.fileStream, writeStream);
+    return;
+  }
+
+  if (zipResult.data) {
+    await writeFile(zipPath, zipResult.data);
+    return;
+  }
+
+  // Fallback: direct HTTP download when SDK stream/data unavailable
+  logger.warn(
+    `${logPrefix} SDK file result unavailable, falling back to direct download...`,
+  );
+  const baseUrl = client.getConfig().baseUrl;
+  const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
+    headers: { Accept: 'application/zip' },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ZIP file: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  await writeFile(zipPath, buffer);
+}

--- a/packages/pdf-parser/src/utils/page-image-updater.test.ts
+++ b/packages/pdf-parser/src/utils/page-image-updater.test.ts
@@ -1,0 +1,214 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { rename } from 'node:fs/promises';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PAGE_RENDERING } from '../config/constants';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileToFile } from './jq';
+import { renderAndUpdatePageImages } from './page-image-updater';
+
+vi.mock('node:fs/promises', () => ({
+  rename: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
+}));
+
+vi.mock('./jq', () => ({
+  runJqFileToFile: vi.fn(),
+}));
+
+describe('renderAndUpdatePageImages', () => {
+  let logger: LoggerMethods;
+  let mockRenderPages: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    mockRenderPages = vi.fn().mockResolvedValue({
+      pageCount: 5,
+      pagesDir: '/output/pages',
+      pageFiles: [],
+    });
+
+    vi.mocked(PageRenderer).mockImplementation(function () {
+      return { renderPages: mockRenderPages } as any;
+    });
+
+    vi.mocked(runJqFileToFile).mockResolvedValue(undefined as any);
+    vi.mocked(rename).mockResolvedValue(undefined);
+  });
+
+  test('renders pages and updates result.json with jq', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[TestPrefix]',
+    );
+
+    expect(PageRenderer).toHaveBeenCalledWith(logger);
+    expect(mockRenderPages).toHaveBeenCalledWith(
+      '/test/doc.pdf',
+      '/output/dir',
+    );
+
+    const resultPath = '/output/dir/result.json';
+    const tmpPath = resultPath + '.tmp';
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining('.pages |= with_entries('),
+      resultPath,
+      tmpPath,
+    );
+    expect(rename).toHaveBeenCalledWith(tmpPath, resultPath);
+  });
+
+  test('jq program includes correct pageCount in condition', async () => {
+    mockRenderPages.mockResolvedValue({
+      pageCount: 3,
+      pagesDir: '/output/pages',
+      pageFiles: [],
+    });
+
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining('< 3'),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('jq program includes correct DPI value', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `.value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}`,
+      ),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('jq program sets image URI and mimetype', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    const jqProgram = vi.mocked(runJqFileToFile).mock.calls[0][0];
+    expect(jqProgram).toContain('.value.image.uri = "pages/page_');
+    expect(jqProgram).toContain('.value.image.mimetype = "image/png"');
+  });
+
+  test('logs rendering start and completion with logPrefix', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[PDFConverter]',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '[PDFConverter] Rendering page images with ImageMagick...',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[PDFConverter] Rendered 5 page images',
+    );
+  });
+
+  test('logs with custom logPrefix', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[ChunkedPDFConverter]',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '[ChunkedPDFConverter] Rendering page images with ImageMagick...',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[ChunkedPDFConverter] Rendered 5 page images',
+    );
+  });
+
+  test('propagates PageRenderer error', async () => {
+    mockRenderPages.mockRejectedValue(new Error('ImageMagick not found'));
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('ImageMagick not found');
+  });
+
+  test('propagates jq error', async () => {
+    vi.mocked(runJqFileToFile).mockRejectedValue(
+      new Error('jq exited with code 1'),
+    );
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('jq exited with code 1');
+  });
+
+  test('propagates rename error', async () => {
+    vi.mocked(rename).mockRejectedValue(new Error('EACCES'));
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('EACCES');
+  });
+
+  test('uses join to construct result path', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(join).toHaveBeenCalledWith('/output/dir', 'result.json');
+  });
+});

--- a/packages/pdf-parser/src/utils/page-image-updater.ts
+++ b/packages/pdf-parser/src/utils/page-image-updater.ts
@@ -1,0 +1,45 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { rename } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { PAGE_RENDERING } from '../config/constants';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileToFile } from './jq';
+
+/**
+ * Render page images from a PDF using ImageMagick and update result.json.
+ *
+ * @param pdfPath - Absolute path to the source PDF file
+ * @param outputDir - Directory containing result.json (pages/ subdirectory will be created)
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]')
+ */
+export async function renderAndUpdatePageImages(
+  pdfPath: string,
+  outputDir: string,
+  logger: LoggerMethods,
+  logPrefix: string,
+): Promise<void> {
+  logger.info(`${logPrefix} Rendering page images with ImageMagick...`);
+
+  const renderer = new PageRenderer(logger);
+  const renderResult = await renderer.renderPages(pdfPath, outputDir);
+
+  // Update result.json with page image URIs using jq to avoid loading large JSON
+  const resultPath = join(outputDir, 'result.json');
+  const tmpPath = resultPath + '.tmp';
+  const jqProgram = `
+    .pages |= with_entries(
+      if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
+        .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
+        .value.image.mimetype = "image/png" |
+        .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
+      else . end
+    )
+  `;
+  await runJqFileToFile(jqProgram, resultPath, tmpPath);
+  await rename(tmpPath, resultPath);
+
+  logger.info(`${logPrefix} Rendered ${renderResult.pageCount} page images`);
+}

--- a/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
@@ -1,0 +1,276 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Lazily import so we can mock it
+import { getTaskFailureDetails } from './task-failure-details';
+import { trackTaskProgress } from './task-progress-tracker';
+
+vi.mock('../config/constants', () => ({
+  PDF_CONVERTER: { POLL_INTERVAL_MS: 0 },
+}));
+
+vi.mock('./task-failure-details', () => ({
+  getTaskFailureDetails: vi.fn(),
+}));
+
+describe('trackTaskProgress', () => {
+  let logger: LoggerMethods;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+  });
+
+  function makeTask(
+    pollResults: {
+      task_status: string;
+      task_position?: number;
+      task_meta?: any;
+    }[],
+  ) {
+    let pollIndex = 0;
+    return {
+      taskId: 'test-task',
+      poll: vi.fn(async () => pollResults[pollIndex++]),
+      getResult: vi.fn(),
+    };
+  }
+
+  test('resolves on success status', async () => {
+    const task = makeTask([{ task_status: 'success' }]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]');
+
+    expect(task.poll).toHaveBeenCalledTimes(1);
+  });
+
+  test('polls multiple times until success', async () => {
+    const task = makeTask([
+      { task_status: 'started' },
+      { task_status: 'started' },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]');
+
+    expect(task.poll).toHaveBeenCalledTimes(3);
+  });
+
+  test('throws on timeout', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(0) // startTime
+      .mockReturnValueOnce(200); // timeout check (200ms > 100ms timeout)
+
+    const task = makeTask([{ task_status: 'started' }]);
+
+    await expect(
+      trackTaskProgress(task, 100, logger, '[Test]'),
+    ).rejects.toThrow('Task timeout');
+  });
+
+  test('throws on timeout with custom errorPrefix', async () => {
+    vi.spyOn(Date, 'now').mockReturnValueOnce(0).mockReturnValueOnce(200);
+
+    const task = makeTask([{ task_status: 'started' }]);
+
+    await expect(
+      trackTaskProgress(task, 100, logger, '[Test]', {
+        errorPrefix: '[Custom] ',
+      }),
+    ).rejects.toThrow('[Custom] Task timeout');
+  });
+
+  test('throws on failure with error details', async () => {
+    vi.mocked(getTaskFailureDetails).mockResolvedValue('OCR engine crashed');
+
+    const task = makeTask([{ task_status: 'failure' }]);
+
+    await expect(
+      trackTaskProgress(task, 60_000, logger, '[Test]'),
+    ).rejects.toThrow('Task failed: OCR engine crashed');
+
+    expect(getTaskFailureDetails).toHaveBeenCalledWith(task, logger, '[Test]');
+  });
+
+  test('throws on failure with custom errorPrefix', async () => {
+    vi.mocked(getTaskFailureDetails).mockResolvedValue('some error');
+
+    const task = makeTask([{ task_status: 'failure' }]);
+
+    await expect(
+      trackTaskProgress(task, 60_000, logger, '[Test]', {
+        errorPrefix: '[Chunk] ',
+      }),
+    ).rejects.toThrow('[Chunk] Task failed: some error');
+  });
+
+  test('logs elapsed time on failure', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(0) // startTime
+      .mockReturnValueOnce(0) // timeout check
+      .mockReturnValueOnce(30_000); // elapsed calculation
+
+    vi.mocked(getTaskFailureDetails).mockResolvedValue('error');
+
+    const task = makeTask([{ task_status: 'failure' }]);
+
+    await expect(
+      trackTaskProgress(task, 60_000, logger, '[Test]'),
+    ).rejects.toThrow();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      '\n[Test] Task failed after 30s: error',
+    );
+  });
+
+  // showDetailedProgress tests
+  test('does not write to stdout when showDetailedProgress is false', async () => {
+    const task = makeTask([
+      { task_status: 'started', task_position: 1 },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]');
+
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+  });
+
+  test('does not log completion message when showDetailedProgress is false', async () => {
+    const task = makeTask([{ task_status: 'success' }]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]');
+
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('Conversion completed'),
+    );
+  });
+
+  test('writes progress to stdout when showDetailedProgress is true', async () => {
+    const task = makeTask([
+      { task_status: 'started' },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('\r[Test] Status: started');
+  });
+
+  test('logs completion message when showDetailedProgress is true', async () => {
+    const task = makeTask([{ task_status: 'success' }]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith('\n[Test] Conversion completed!');
+  });
+
+  test('shows position in progress line', async () => {
+    const task = makeTask([
+      { task_status: 'started', task_position: 5 },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      '\r[Test] Status: started | position: 5',
+    );
+  });
+
+  test('shows document progress from task_meta', async () => {
+    const task = makeTask([
+      {
+        task_status: 'started',
+        task_meta: { total_documents: 10, processed_documents: 3 },
+      },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      '\r[Test] Status: started | progress: 3/10',
+    );
+  });
+
+  test('shows position and document progress together', async () => {
+    const task = makeTask([
+      {
+        task_status: 'started',
+        task_position: 2,
+        task_meta: { total_documents: 10, processed_documents: 7 },
+      },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      '\r[Test] Status: started | position: 2 | progress: 7/10',
+    );
+  });
+
+  test('ignores task_meta without document counts', async () => {
+    const task = makeTask([
+      { task_status: 'started', task_meta: {} },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    expect(stdoutWriteSpy).toHaveBeenCalledWith('\r[Test] Status: started');
+  });
+
+  test('deduplicates identical progress lines', async () => {
+    const task = makeTask([
+      { task_status: 'started' },
+      { task_status: 'started' }, // same as above
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]', {
+      showDetailedProgress: true,
+    });
+
+    const calls = (stdoutWriteSpy as Mock).mock.calls.filter(
+      (call: any[]) => call[0] === '\r[Test] Status: started',
+    );
+    expect(calls).toHaveLength(1);
+  });
+
+  test('uses setTimeout with POLL_INTERVAL_MS between polls', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    const task = makeTask([
+      { task_status: 'started' },
+      { task_status: 'success' },
+    ]);
+
+    await trackTaskProgress(task, 60_000, logger, '[Test]');
+
+    // POLL_INTERVAL_MS is mocked to 0
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+  });
+});

--- a/packages/pdf-parser/src/utils/task-progress-tracker.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.ts
@@ -1,0 +1,92 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { PDF_CONVERTER } from '../config/constants';
+import { getTaskFailureDetails } from './task-failure-details';
+
+interface PollableTask {
+  taskId: string;
+  poll: () => Promise<{
+    task_status: string;
+    task_position?: number;
+    task_meta?: { total_documents?: number; processed_documents?: number };
+  }>;
+  getResult: () => Promise<{ errors?: { message: string }[]; status?: string }>;
+}
+
+export interface TrackProgressOptions {
+  /** Show detailed progress with position and document counts (default: false) */
+  showDetailedProgress?: boolean;
+  /** Custom error prefix for timeout/failure messages (e.g. '[ChunkedPDFConverter] Chunk ') */
+  errorPrefix?: string;
+}
+
+/**
+ * Poll a Docling conversion task until completion.
+ *
+ * @param task - Pollable task object from Docling SDK
+ * @param timeout - Maximum wait time in milliseconds
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]')
+ * @param options - Optional configuration
+ */
+export async function trackTaskProgress(
+  task: PollableTask,
+  timeout: number,
+  logger: LoggerMethods,
+  logPrefix: string,
+  options?: TrackProgressOptions,
+): Promise<void> {
+  const startTime = Date.now();
+  const errPrefix = options?.errorPrefix ?? '';
+  let lastProgressLine = '';
+
+  while (true) {
+    if (Date.now() - startTime > timeout) {
+      throw new Error(`${errPrefix}Task timeout`);
+    }
+
+    const status = await task.poll();
+
+    // Detailed progress logging (used by single-pass conversion)
+    if (options?.showDetailedProgress) {
+      const parts: string[] = [`Status: ${status.task_status}`];
+      if (status.task_position !== undefined) {
+        parts.push(`position: ${status.task_position}`);
+      }
+      const meta = status.task_meta;
+      if (
+        meta?.processed_documents !== undefined &&
+        meta?.total_documents !== undefined
+      ) {
+        parts.push(
+          `progress: ${meta.processed_documents}/${meta.total_documents}`,
+        );
+      }
+      const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
+      if (progressLine !== lastProgressLine) {
+        lastProgressLine = progressLine;
+        process.stdout.write(progressLine);
+      }
+    }
+
+    if (status.task_status === 'success') {
+      if (options?.showDetailedProgress) {
+        logger.info(`\n${logPrefix} Conversion completed!`);
+      }
+      return;
+    }
+
+    if (status.task_status === 'failure') {
+      const errorDetails = await getTaskFailureDetails(task, logger, logPrefix);
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      logger.error(
+        `\n${logPrefix} Task failed after ${elapsed}s: ${errorDetails}`,
+      );
+      throw new Error(`${errPrefix}Task failed: ${errorDetails}`);
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
+    );
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract three tightly coupled utility concerns from `chunked-pdf-converter` and `pdf-converter` into dedicated, independently testable modules. This improves reusability, reduces the complexity of the converter classes, and makes each responsibility easier to reason about and maintain.

## Changes

- Extract ZIP result download logic into `utils/docling-result-downloader.ts` (`downloadTaskResult`) with fallback handling for fileStream, data, and direct HTTP download
- Extract task progress polling logic into `utils/task-progress-tracker.ts` (`trackTaskProgress`) covering success, failure, timeout, and progress callback scenarios
- Extract page image rendering and JSON update logic into `utils/page-image-updater.ts` (`renderAndUpdatePageImages`), replacing inline `PageRenderer` usage in both converters
- Simplify `chunked-pdf-converter.ts` by removing inlined download, progress tracking, and rendering logic (~280 lines removed)
- Remove `renderPageImages` from `pdf-converter.ts` (now delegated to `page-image-updater`)
- Add comprehensive unit tests for all three new utility modules (`docling-result-downloader.test.ts`, `task-progress-tracker.test.ts`, `page-image-updater.test.ts`)
- Streamline `chunked-pdf-converter.test.ts` by removing redundant mocks (e.g., `node:fs/promises`, `node:stream/promises`, `PageRenderer`) and updating test cases to use the new utilities

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
