### PR TITLE
refactor(pdf-parser): extract shared converter logic into reusable utility functions

### DIFF
--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -5,7 +5,6 @@ import type { DoclingAPIClient } from 'docling-sdk';
 import { spawnAsync } from '@heripo/shared';
 import {
   copyFileSync,
-  createWriteStream,
   existsSync,
   readFileSync,
   readdirSync,
@@ -13,7 +12,6 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { rename } from 'node:fs/promises';
-import { pipeline } from 'node:stream/promises';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
@@ -35,20 +33,18 @@ vi.mock('node:fs', () => ({
   readdirSync: vi.fn(),
   rmSync: vi.fn(),
   writeFileSync: vi.fn(),
-  createWriteStream: vi.fn(),
 }));
 
 vi.mock('node:fs/promises', () => ({
   rename: vi.fn(),
-  writeFile: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
   join: vi.fn((...args: string[]) => args.join('/')),
 }));
 
-vi.mock('node:stream/promises', () => ({
-  pipeline: vi.fn(),
+vi.mock('../utils/docling-result-downloader', () => ({
+  downloadTaskResult: vi.fn(),
 }));
 
 vi.mock('../processors/image-extractor', () => ({
@@ -786,96 +782,6 @@ describe('ChunkedPDFConverter', () => {
           mockBuildOptions,
         ),
       ).rejects.toThrow('Chunk task timeout');
-    });
-
-    test('downloadResult uses fileStream when available', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      const mockWriteStream = { on: vi.fn() };
-      vi.mocked(createWriteStream).mockReturnValue(mockWriteStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
-
-      const mockStream = { pipe: vi.fn() };
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({
-        fileStream: mockStream,
-      });
-
-      await converter.convertChunked(
-        'file:///test/input.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {},
-        mockBuildOptions,
-      );
-
-      expect(pipeline).toHaveBeenCalled();
-    });
-
-    test('downloadResult uses fetch fallback when no fileStream or data', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
-
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(8)),
-      });
-      vi.stubGlobal('fetch', mockFetch);
-
-      await converter.convertChunked(
-        'file:///test/input.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {},
-        mockBuildOptions,
-      );
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        'http://localhost:5001/v1/result/task-1',
-        expect.objectContaining({ headers: { Accept: 'application/zip' } }),
-      );
-
-      vi.unstubAllGlobals();
-    });
-
-    test('downloadResult fetch fallback throws on non-ok response', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      vi.mocked(client.getTaskResultFile as Mock).mockResolvedValue({});
-
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-      });
-      vi.stubGlobal('fetch', mockFetch);
-
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Failed to download chunk ZIP: 500');
-
-      vi.unstubAllGlobals();
     });
 
     test('chunk temp files are cleaned up after successful conversion', async () => {

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -17,7 +17,7 @@ import { DoclingDocumentMerger } from '../processors/docling-document-merger';
 import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
-import * as taskFailureDetailsModule from '../utils/task-failure-details';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 
 vi.mock('@heripo/shared', () => ({
@@ -64,8 +64,8 @@ vi.mock('../utils/local-file-server', () => ({
   LocalFileServer: vi.fn(),
 }));
 
-vi.mock('../utils/task-failure-details', () => ({
-  getTaskFailureDetails: vi.fn(),
+vi.mock('../utils/task-progress-tracker', () => ({
+  trackTaskProgress: vi.fn(),
 }));
 
 function makeDoc(overrides: Partial<DoclingDocument> = {}): DoclingDocument {
@@ -188,11 +188,6 @@ describe('ChunkedPDFConverter', () => {
 
     // Mock readFileSync: empty JSON by default (for cleanupOrphanedPicFiles)
     vi.mocked(readFileSync).mockReturnValue('{}');
-
-    // Mock getTaskFailureDetails: default returns a generic message
-    vi.mocked(taskFailureDetailsModule.getTaskFailureDetails).mockResolvedValue(
-      'unable to retrieve error details',
-    );
   });
 
   describe('calculateChunks', () => {
@@ -618,25 +613,42 @@ describe('ChunkedPDFConverter', () => {
       );
     });
 
-    test('task poll failure reports error details with taskId and elapsed time', async () => {
+    test('trackTaskProgress is called with correct options per chunk', async () => {
       vi.mocked(spawnAsync).mockResolvedValue({
         code: 0,
         stdout: 'Pages:          5\n',
         stderr: '',
       });
 
-      vi.mocked(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).mockResolvedValue('OCR engine crashed');
+      await converter.convertChunked(
+        'file:///test/input.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {},
+        mockBuildOptions,
+      );
 
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
+      expect(trackTaskProgress).toHaveBeenCalledWith(
+        mockTask,
+        expect.any(Number),
+        logger,
+        '[ChunkedPDFConverter]',
+        { errorPrefix: '[ChunkedPDFConverter] Chunk task ' },
+      );
+    });
 
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
+    test('chunk task failure propagates through retry logic', async () => {
+      vi.mocked(spawnAsync).mockResolvedValue({
+        code: 0,
+        stdout: 'Pages:          5\n',
+        stderr: '',
+      });
+
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error(
+          '[ChunkedPDFConverter] Chunk task failed: OCR engine crashed',
+        ),
       );
 
       await expect(
@@ -649,119 +661,6 @@ describe('ChunkedPDFConverter', () => {
           mockBuildOptions,
         ),
       ).rejects.toThrow('OCR engine crashed');
-
-      // Verify detailed failure logging with taskId and elapsed time
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /\[ChunkedPDFConverter\] Task task-fail failed after \d+\.\d+s/,
-        ),
-      );
-    });
-
-    test('task poll failure without errors array falls back to status', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      vi.mocked(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).mockResolvedValue('status: failure');
-
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
-      );
-
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task failed: status: failure');
-    });
-
-    test('task poll failure with getResult error falls back to unable to retrieve error details', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      // getTaskFailureDetails is already mocked to return 'unable to retrieve error details' by default
-
-      const failingTask = {
-        taskId: 'task-fail',
-        poll: vi.fn().mockResolvedValue({ task_status: 'failure' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        failingTask,
-      );
-
-      await expect(
-        converter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task failed: unable to retrieve error details');
-
-      // Verify getTaskFailureDetails was called with correct arguments
-      expect(
-        taskFailureDetailsModule.getTaskFailureDetails,
-      ).toHaveBeenCalledWith(failingTask, logger, '[ChunkedPDFConverter]');
-    });
-
-    test('task poll timeout throws error', async () => {
-      vi.mocked(spawnAsync).mockResolvedValue({
-        code: 0,
-        stdout: 'Pages:          5\n',
-        stderr: '',
-      });
-
-      // Use a very short timeout
-      const shortTimeoutConverter = new ChunkedPDFConverter(
-        logger,
-        client,
-        { chunkSize: 10, maxRetries: 0 },
-        1,
-      );
-
-      const hangingTask = {
-        taskId: 'task-hang',
-        poll: vi.fn().mockResolvedValue({ task_status: 'pending' }),
-        getResult: vi.fn(),
-      };
-
-      vi.mocked(client.convertSourceAsync as Mock).mockResolvedValue(
-        hangingTask,
-      );
-
-      await expect(
-        shortTimeoutConverter.convertChunked(
-          'file:///test/input.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          {},
-          mockBuildOptions,
-        ),
-      ).rejects.toThrow('Chunk task timeout');
     });
 
     test('chunk temp files are cleaned up after successful conversion', async () => {

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -11,13 +11,12 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { rename } from 'node:fs/promises';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
-import { PageRenderer } from '../processors/page-renderer';
-import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import * as taskFailureDetailsModule from '../utils/task-failure-details';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 
@@ -33,10 +32,6 @@ vi.mock('node:fs', () => ({
   readdirSync: vi.fn(),
   rmSync: vi.fn(),
   writeFileSync: vi.fn(),
-}));
-
-vi.mock('node:fs/promises', () => ({
-  rename: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
@@ -57,13 +52,12 @@ vi.mock('../processors/docling-document-merger', () => ({
   DoclingDocumentMerger: vi.fn(),
 }));
 
-vi.mock('../processors/page-renderer', () => ({
-  PageRenderer: vi.fn(),
-}));
-
 vi.mock('../utils/jq', () => ({
   runJqFileJson: vi.fn(),
-  runJqFileToFile: vi.fn(),
+}));
+
+vi.mock('../utils/page-image-updater', () => ({
+  renderAndUpdatePageImages: vi.fn(),
 }));
 
 vi.mock('../utils/local-file-server', () => ({
@@ -115,7 +109,6 @@ describe('ChunkedPDFConverter', () => {
   let mockBuildOptions: Mock;
   let mockServerInstance: { start: Mock; stop: Mock };
   let mockMergerInstance: { merge: Mock };
-  let mockRendererInstance: { renderPages: Mock };
   let mockTask: { taskId: string; poll: Mock; getResult: Mock };
 
   beforeEach(() => {
@@ -177,18 +170,6 @@ describe('ChunkedPDFConverter', () => {
       return mockMergerInstance as any;
     });
 
-    // Mock PageRenderer
-    mockRendererInstance = {
-      renderPages: vi.fn().mockResolvedValue({
-        pageCount: 25,
-        pagesDir: '/test/cwd/output/report/pages',
-        pageFiles: [],
-      }),
-    };
-    vi.mocked(PageRenderer).mockImplementation(function () {
-      return mockRendererInstance as any;
-    });
-
     // Mock spawnAsync (pdfinfo returning page count)
     vi.mocked(spawnAsync).mockResolvedValue({
       code: 0,
@@ -198,12 +179,6 @@ describe('ChunkedPDFConverter', () => {
 
     // Mock runJqFileJson (returns DoclingDocument per chunk)
     vi.mocked(runJqFileJson).mockResolvedValue(makeDoc());
-
-    // Mock runJqFileToFile
-    vi.mocked(runJqFileToFile).mockResolvedValue(undefined as any);
-
-    // Mock rename
-    vi.mocked(rename).mockResolvedValue(undefined);
 
     // Mock existsSync: default false
     vi.mocked(existsSync).mockReturnValue(false);
@@ -340,7 +315,12 @@ describe('ChunkedPDFConverter', () => {
       expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/report-1');
 
       // Page rendering done
-      expect(mockRendererInstance.renderPages).toHaveBeenCalled();
+      expect(renderAndUpdatePageImages).toHaveBeenCalledWith(
+        '/test/input.pdf',
+        '/test/cwd/output/report-1',
+        logger,
+        '[ChunkedPDFConverter]',
+      );
     });
 
     test('fails when page count detection fails', async () => {
@@ -1003,7 +983,7 @@ describe('ChunkedPDFConverter', () => {
 
       vi.mocked(existsSync).mockReturnValue(true);
 
-      mockRendererInstance.renderPages.mockRejectedValue(
+      vi.mocked(renderAndUpdatePageImages).mockRejectedValue(
         new Error('ImageMagick crashed'),
       );
 

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -10,7 +10,6 @@ import type {
 import { spawnAsync } from '@heripo/shared';
 import {
   copyFileSync,
-  createWriteStream,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -18,14 +17,14 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { rename, writeFile } from 'node:fs/promises';
+import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
-import { pipeline } from 'node:stream/promises';
 
 import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { getTaskFailureDetails } from '../utils/task-failure-details';
@@ -246,7 +245,13 @@ export class ChunkedPDFConverter {
 
         // Download ZIP result
         const zipPath = join(chunkDir, 'result.zip');
-        await this.downloadResult(task.taskId, zipPath);
+        await downloadTaskResult(
+          this.client,
+          task.taskId,
+          zipPath,
+          this.logger,
+          '[ChunkedPDFConverter]',
+        );
 
         // Extract ZIP and process images
         const extractDir = join(chunkDir, 'extracted');
@@ -359,37 +364,6 @@ export class ChunkedPDFConverter {
         setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
       );
     }
-  }
-
-  /** Download ZIP result for a task */
-  private async downloadResult(taskId: string, zipPath: string): Promise<void> {
-    const zipResult = await this.client.getTaskResultFile(taskId);
-
-    if (zipResult.fileStream) {
-      const writeStream = createWriteStream(zipPath);
-      await pipeline(zipResult.fileStream, writeStream);
-      return;
-    }
-
-    if (zipResult.data) {
-      await writeFile(zipPath, zipResult.data);
-      return;
-    }
-
-    // Fallback: direct HTTP download
-    const baseUrl = this.client.getConfig().baseUrl;
-    const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
-      headers: { Accept: 'application/zip' },
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to download chunk ZIP: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const buffer = new Uint8Array(await response.arrayBuffer());
-    await writeFile(zipPath, buffer);
   }
 
   /**

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -26,7 +26,7 @@ import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
-import { getTaskFailureDetails } from '../utils/task-failure-details';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
 
 /** Configuration for chunked conversion */
 export interface ChunkedConversionConfig {
@@ -245,7 +245,15 @@ export class ChunkedPDFConverter {
         });
 
         // Poll until completion
-        await this.trackTaskProgress(task);
+        await trackTaskProgress(
+          task,
+          this.timeout,
+          this.logger,
+          '[ChunkedPDFConverter]',
+          {
+            errorPrefix: '[ChunkedPDFConverter] Chunk task ',
+          },
+        );
 
         // Download ZIP result
         const zipPath = join(chunkDir, 'result.zip');
@@ -329,45 +337,6 @@ export class ChunkedPDFConverter {
     }
     const match = result.stdout.match(/^Pages:\s+(\d+)/m);
     return match ? parseInt(match[1], 10) : 0;
-  }
-
-  /** Poll task progress until completion */
-  private async trackTaskProgress(task: {
-    taskId: string;
-    poll: () => Promise<{ task_status: string }>;
-    getResult: () => Promise<{
-      errors?: { message: string }[];
-      status?: string;
-    }>;
-  }): Promise<void> {
-    const startTime = Date.now();
-
-    while (true) {
-      if (Date.now() - startTime > this.timeout) {
-        throw new Error('[ChunkedPDFConverter] Chunk task timeout');
-      }
-
-      const status = await task.poll();
-
-      if (status.task_status === 'success') return;
-
-      if (status.task_status === 'failure') {
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        this.logger.error(
-          `[ChunkedPDFConverter] Task ${task.taskId} failed after ${elapsed}s`,
-        );
-        const details = await getTaskFailureDetails(
-          task,
-          this.logger,
-          '[ChunkedPDFConverter]',
-        );
-        throw new Error(`[ChunkedPDFConverter] Chunk task failed: ${details}`);
-      }
-
-      await new Promise((resolve) =>
-        setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
-      );
-    }
   }
 
   /**

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -17,16 +17,15 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { PAGE_RENDERING, PDF_CONVERTER } from '../config/constants';
+import { PDF_CONVERTER } from '../config/constants';
 import { DoclingDocumentMerger } from '../processors/docling-document-merger';
 import { ImageExtractor } from '../processors/image-extractor';
-import { PageRenderer } from '../processors/page-renderer';
 import { downloadTaskResult } from '../utils/docling-result-downloader';
-import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { getTaskFailureDetails } from '../utils/task-failure-details';
 
 /** Configuration for chunked conversion */
@@ -161,7 +160,12 @@ export class ChunkedPDFConverter {
 
     try {
       // Step 7: Render page images (ImageMagick, same as non-chunked)
-      await this.renderPageImages(pdfPath, outputDir);
+      await renderAndUpdatePageImages(
+        pdfPath,
+        outputDir,
+        this.logger,
+        '[ChunkedPDFConverter]',
+      );
 
       // Step 7.5: Clean up orphaned pic_ files
       this.cleanupOrphanedPicFiles(resultPath, imagesDir);
@@ -437,37 +441,6 @@ export class ChunkedPDFConverter {
 
     this.logger.info(
       `[ChunkedPDFConverter] Relocated ${picGlobalIndex} pic + ${imageGlobalIndex} image files to ${imagesDir}`,
-    );
-  }
-
-  /** Render page images from PDF using ImageMagick and update result.json */
-  private async renderPageImages(
-    pdfPath: string,
-    outputDir: string,
-  ): Promise<void> {
-    this.logger.info(
-      '[ChunkedPDFConverter] Rendering page images with ImageMagick...',
-    );
-
-    const renderer = new PageRenderer(this.logger);
-    const renderResult = await renderer.renderPages(pdfPath, outputDir);
-
-    const resultPath = join(outputDir, 'result.json');
-    const tmpPath = resultPath + '.tmp';
-    const jqProgram = `
-      .pages |= with_entries(
-        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
-          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
-          .value.image.mimetype = "image/png" |
-          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
-        else . end
-      )
-    `;
-    await runJqFileToFile(jqProgram, resultPath, tmpPath);
-    await rename(tmpPath, resultPath);
-
-    this.logger.info(
-      `[ChunkedPDFConverter] Rendered ${renderResult.pageCount} page images`,
     );
   }
 

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -3,18 +3,16 @@ import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
 
 import { omit } from 'es-toolkit';
 import { existsSync, rmSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
-import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { downloadTaskResult } from '../utils/docling-result-downloader';
-import { runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
@@ -42,10 +40,6 @@ vi.mock('node:fs', () => ({
   rmSync: vi.fn(),
 }));
 
-vi.mock('node:fs/promises', () => ({
-  rename: vi.fn(),
-}));
-
 vi.mock('node:path', () => ({
   join: vi.fn(),
 }));
@@ -68,13 +62,12 @@ vi.mock('../validators/document-type-validator', () => ({
   DocumentTypeValidator: vi.fn(),
 }));
 
-vi.mock('../processors/page-renderer', () => ({
-  PageRenderer: vi.fn(),
+vi.mock('../utils/jq', () => ({
+  runJqFileJson: vi.fn(),
 }));
 
-vi.mock('../utils/jq', () => ({
-  runJqFileToFile: vi.fn(),
-  runJqFileJson: vi.fn(),
+vi.mock('../utils/page-image-updater', () => ({
+  renderAndUpdatePageImages: vi.fn(),
 }));
 
 describe('PDFConverter', () => {
@@ -123,15 +116,6 @@ describe('PDFConverter', () => {
       return {
         convert: vi.fn().mockResolvedValue('/tmp/image.pdf'),
         cleanup: vi.fn(),
-      } as any;
-    });
-
-    // Mock PageRenderer (used by renderPageImages)
-    vi.mocked(PageRenderer).mockImplementation(function () {
-      return {
-        renderPages: vi
-          .fn()
-          .mockResolvedValue({ pageCount: 3, pagesDir: '', pageFiles: [] }),
       } as any;
     });
   });
@@ -1264,8 +1248,6 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1383,8 +1365,6 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -1403,7 +1383,7 @@ describe('PDFConverter', () => {
   });
 
   describe('renderPageImages', () => {
-    test('should render page images and update result.json for file:// URLs', async () => {
+    test('should call renderAndUpdatePageImages for file:// URLs', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
 
@@ -1412,15 +1392,6 @@ describe('PDFConverter', () => {
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
-
-      const mockRenderPages = vi
-        .fn()
-        .mockResolvedValue({ pageCount: 2, pagesDir: '', pageFiles: [] });
-      vi.mocked(PageRenderer).mockImplementation(function () {
-        return { renderPages: mockRenderPages } as any;
-      });
 
       await converter.convert(
         'file:///test/doc.pdf',
@@ -1430,21 +1401,11 @@ describe('PDFConverter', () => {
         {},
       );
 
-      expect(mockRenderPages).toHaveBeenCalledWith(
+      expect(renderAndUpdatePageImages).toHaveBeenCalledWith(
         '/test/doc.pdf',
         '/test/cwd/output/report-render',
-      );
-
-      const resultPath = '/test/cwd/output/report-render/result.json';
-      expect(runJqFileToFile).toHaveBeenCalledWith(
-        expect.stringContaining('.pages |= with_entries('),
-        resultPath,
-        resultPath + '.tmp',
-      );
-      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Rendered 2 page images',
+        logger,
+        '[PDFConverter]',
       );
     });
 
@@ -1458,8 +1419,6 @@ describe('PDFConverter', () => {
       ).mockResolvedValue(undefined);
       vi.mocked(existsSync).mockReturnValue(false);
 
-      vi.mocked(PageRenderer).mockClear();
-
       await converter.convert(
         'http://test.com/doc.pdf',
         'report-skip-render',
@@ -1468,90 +1427,10 @@ describe('PDFConverter', () => {
         {},
       );
 
-      expect(PageRenderer).not.toHaveBeenCalled();
+      expect(renderAndUpdatePageImages).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(
         '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
       );
-    });
-
-    test('should update page image URIs with correct indices', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
-
-      vi.mocked(PageRenderer).mockImplementation(function () {
-        return {
-          renderPages: vi
-            .fn()
-            .mockResolvedValue({ pageCount: 3, pagesDir: '', pageFiles: [] }),
-        } as any;
-      });
-
-      await converter.convert(
-        'file:///test/doc.pdf',
-        'report-uris',
-        onComplete,
-        false,
-        {},
-      );
-
-      const resultPath = '/test/cwd/output/report-uris/result.json';
-      expect(runJqFileToFile).toHaveBeenCalledWith(
-        expect.stringContaining('< 3'),
-        resultPath,
-        resultPath + '.tmp',
-      );
-      expect(runJqFileToFile).toHaveBeenCalledWith(
-        expect.stringContaining('.value.image.dpi = 200'),
-        resultPath,
-        resultPath + '.tmp',
-      );
-      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
-    });
-
-    test('should skip pages with page_no exceeding rendered page count', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
-
-      vi.mocked(PageRenderer).mockImplementation(function () {
-        return {
-          renderPages: vi
-            .fn()
-            .mockResolvedValue({ pageCount: 2, pagesDir: '', pageFiles: [] }),
-        } as any;
-      });
-
-      await converter.convert(
-        'file:///test/doc.pdf',
-        'report-skip-excess',
-        onComplete,
-        false,
-        {},
-      );
-
-      // The jq program uses pageCount (2) so pages with page_no > 2 are skipped
-      const resultPath = '/test/cwd/output/report-skip-excess/result.json';
-      expect(runJqFileToFile).toHaveBeenCalledWith(
-        expect.stringContaining('< 2'),
-        resultPath,
-        resultPath + '.tmp',
-      );
-      expect(rename).toHaveBeenCalledWith(resultPath + '.tmp', resultPath);
     });
   });
 
@@ -1560,8 +1439,6 @@ describe('PDFConverter', () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
       vi.mocked(existsSync).mockReturnValue(false);
-      vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
-      vi.mocked(rename).mockResolvedValue(undefined);
 
       await converter.convert(
         'http://test.com/doc.pdf',

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -6,13 +6,13 @@ import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
@@ -70,6 +70,10 @@ vi.mock('../utils/page-image-updater', () => ({
   renderAndUpdatePageImages: vi.fn(),
 }));
 
+vi.mock('../utils/task-progress-tracker', () => ({
+  trackTaskProgress: vi.fn(),
+}));
+
 describe('PDFConverter', () => {
   let logger: LoggerMethods;
   let client: DoclingAPIClient;
@@ -92,7 +96,6 @@ describe('PDFConverter', () => {
     converter = new PDFConverter(logger, client);
 
     vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
-    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     vi.spyOn(Date, 'now').mockReturnValue(1000000);
 
     vi.mocked(omit).mockImplementation((obj, keys) => {
@@ -592,9 +595,12 @@ describe('PDFConverter', () => {
     });
 
     test('should handle conversion task failure', async () => {
-      const mockTask = createMockTask('failure');
+      const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
 
       await expect(
         converter.convert(
@@ -709,156 +715,9 @@ describe('PDFConverter', () => {
     });
   });
 
-  describe('trackTaskProgress', () => {
-    test('should track progress via poll with status and position', async () => {
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-          task_position: 50,
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'success' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(process.stdout.write).toHaveBeenCalledWith(
-        '\r[PDFConverter] Status: started',
-      );
-      expect(process.stdout.write).toHaveBeenCalledWith(
-        '\r[PDFConverter] Status: started | position: 50',
-      );
-    });
-
-    test('should log document progress from task_meta', async () => {
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-          task_meta: {
-            total_documents: 10,
-            processed_documents: 3,
-          },
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-          task_position: 1,
-          task_meta: {
-            total_documents: 10,
-            processed_documents: 7,
-          },
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'success' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(process.stdout.write).toHaveBeenCalledWith(
-        '\r[PDFConverter] Status: started | progress: 3/10',
-      );
-      expect(process.stdout.write).toHaveBeenCalledWith(
-        '\r[PDFConverter] Status: started | position: 1 | progress: 7/10',
-      );
-    });
-
-    test('should ignore task_meta without document counts', async () => {
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-          task_meta: {},
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'success' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      // Should only show status, not progress
-      expect(process.stdout.write).toHaveBeenCalledWith(
-        '\r[PDFConverter] Status: started',
-      );
-    });
-
-    test('should deduplicate identical progress lines', async () => {
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-        },
-        // Same status again — should be deduplicated
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'success' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      const calls = vi
-        .mocked(process.stdout.write)
-        .mock.calls.filter(
-          (call) => call[0] === '\r[PDFConverter] Status: started',
-        );
-      expect(calls).toHaveLength(1);
-    });
-
-    test('should log completion message on success', async () => {
+  describe('trackTaskProgress delegation', () => {
+    test('should call trackTaskProgress with showDetailedProgress', async () => {
       const mockTask = createMockTask();
-
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
       vi.mocked(existsSync).mockReturnValue(false);
 
@@ -870,91 +729,12 @@ describe('PDFConverter', () => {
         {},
       );
 
-      expect(logger.info).toHaveBeenCalledWith(
-        '\n[PDFConverter] Conversion completed!',
-      );
-    });
-
-    test('should throw on task failure status', async () => {
-      const mockTask = createMockTask('failure');
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report123',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Task failed: Processing failed');
-    });
-
-    test('should throw on task timeout', async () => {
-      // Create a converter with a very short timeout
-      const shortTimeoutConverter = new PDFConverter(
+      expect(trackTaskProgress).toHaveBeenCalledWith(
+        mockTask,
+        expect.any(Number),
         logger,
-        client,
-        false,
-        100,
-      );
-
-      // Make Date.now() advance past the timeout
-      vi.spyOn(Date, 'now')
-        .mockReturnValueOnce(1000000) // performConversion startTime
-        .mockReturnValueOnce(1000000) // trackTaskProgress conversionStartTime
-        .mockReturnValueOnce(1000200); // timeout check (200ms > 100ms timeout)
-
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        shortTimeoutConverter.convert(
-          'http://test.com/doc.pdf',
-          'report-timeout',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Task timeout');
-    });
-
-    test('should poll with configured interval between polls', async () => {
-      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
-
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'started' as const,
-        },
-        {
-          task_id: 'task-123',
-          task_status: 'success' as const,
-        },
-      ]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      // setTimeout should have been called with POLL_INTERVAL_MS between polls
-      expect(setTimeoutSpy).toHaveBeenCalledWith(
-        expect.any(Function),
-        PDF_CONVERTER.POLL_INTERVAL_MS,
+        '[PDFConverter]',
+        { showDetailedProgress: true },
       );
     });
   });
@@ -991,19 +771,12 @@ describe('PDFConverter', () => {
   describe('abort signal handling', () => {
     test('should throw AbortError when aborted after docling task completes', async () => {
       const abortController = new AbortController();
+      const mockTask = createMockTask();
 
-      // Abort during poll (after success)
-      const mockTask = {
-        taskId: 'task-123',
-        poll: vi.fn(async () => {
-          abortController.abort();
-          return {
-            task_id: 'task-123',
-            task_status: 'success' as const,
-          };
-        }),
-      } as unknown as AsyncConversionTask;
-
+      // Simulate trackTaskProgress completing but abort being triggered during it
+      vi.mocked(trackTaskProgress).mockImplementation(async () => {
+        abortController.abort();
+      });
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
 
       await expect(
@@ -1056,13 +829,12 @@ describe('PDFConverter', () => {
       const abortController = new AbortController();
       abortController.abort();
 
-      const mockTask = createMockTaskWithPollSequence([
-        {
-          task_id: 'task-123',
-          task_status: 'failure' as const,
-        },
-      ]);
+      const mockTask = createMockTask();
 
+      // trackTaskProgress rejects (simulating task failure)
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
@@ -1083,130 +855,14 @@ describe('PDFConverter', () => {
     });
   });
 
-  describe('getTaskFailureDetails', () => {
-    test('should include error messages from task result', async () => {
-      const mockTask = {
-        taskId: 'task-123',
-        poll: vi.fn().mockResolvedValue({
-          task_id: 'task-123',
-          task_status: 'failure',
-        }),
-        getResult: vi.fn().mockResolvedValue({
-          document: {},
-          status: 'failure',
-          processing_time: 0,
-          errors: [
-            { message: 'Page 3: OCR engine timeout' },
-            { message: 'Page 7: Image extraction failed' },
-          ],
-        }),
-      } as unknown as AsyncConversionTask;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-errors',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow(
-        'Task failed: Page 3: OCR engine timeout; Page 7: Image extraction failed',
-      );
-
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Page 3: OCR engine timeout'),
-      );
-    });
-
-    test('should return status when result has no errors', async () => {
-      const mockTask = {
-        taskId: 'task-123',
-        poll: vi.fn().mockResolvedValue({
-          task_id: 'task-123',
-          task_status: 'failure',
-        }),
-        getResult: vi.fn().mockResolvedValue({
-          document: {},
-          status: 'failure',
-          processing_time: 0,
-        }),
-      } as unknown as AsyncConversionTask;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-no-errors',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Task failed: status: failure');
-    });
-
-    test('should return fallback message when getResult throws', async () => {
-      const mockTask = {
-        taskId: 'task-123',
-        poll: vi.fn().mockResolvedValue({
-          task_id: 'task-123',
-          task_status: 'failure',
-        }),
-        getResult: vi.fn().mockRejectedValue(new Error('Network error')),
-      } as unknown as AsyncConversionTask;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-getresult-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Task failed: unable to retrieve error details');
-
-      expect(logger.error).toHaveBeenCalledWith(
-        '[PDFConverter] Failed to retrieve task result after 3 attempts:',
-        expect.any(Error),
-      );
-    });
-
-    test('should log elapsed time in failure message', async () => {
-      vi.spyOn(Date, 'now')
-        .mockReturnValueOnce(1000000) // performConversion startTime
-        .mockReturnValueOnce(1000000) // trackTaskProgress conversionStartTime
-        .mockReturnValueOnce(1000000) // timeout check
-        .mockReturnValueOnce(1060000); // elapsed calculation (60s later)
-
-      const mockTask = createMockTask('failure');
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-elapsed',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow();
-
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('Task failed after 60s'),
-      );
-    });
-  });
-
   describe('image PDF fallback', () => {
     test('should not attempt fallback when enableImagePdfFallback is false', async () => {
-      const mockTask = createMockTask('failure');
+      const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
 
       const converterWithoutFallback = new PDFConverter(logger, client, false);
 
@@ -1224,17 +880,13 @@ describe('PDFConverter', () => {
     });
 
     test('should attempt fallback when enableImagePdfFallback is true and original fails', async () => {
-      const successTask = createMockTask();
-      let callCount = 0;
+      const mockTask = createMockTask();
 
-      vi.mocked(client.convertSourceAsync).mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          const failTask = createMockTask('failure');
-          return Promise.resolve(failTask);
-        }
-        return Promise.resolve(successTask);
-      });
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      // First call fails, second succeeds
+      vi.mocked(trackTaskProgress)
+        .mockRejectedValueOnce(new Error('Task failed: Processing failed'))
+        .mockResolvedValueOnce(undefined);
 
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
@@ -1276,9 +928,12 @@ describe('PDFConverter', () => {
     });
 
     test('should throw ImagePdfFallbackError when both original and fallback fail', async () => {
-      const mockTask = createMockTask('failure');
+      const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
 
       const mockImagePdfConverter = {
         convert: vi
@@ -1309,10 +964,12 @@ describe('PDFConverter', () => {
     });
 
     test('should cleanup image PDF even when fallback conversion fails', async () => {
-      vi.mocked(client.convertSourceAsync).mockImplementation(() => {
-        const failTask = createMockTask('failure');
-        return Promise.resolve(failTask);
-      });
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
 
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
@@ -1341,17 +998,13 @@ describe('PDFConverter', () => {
     });
 
     test('should log success message when fallback succeeds', async () => {
-      const successTask = createMockTask();
-      let callCount = 0;
+      const mockTask = createMockTask();
 
-      vi.mocked(client.convertSourceAsync).mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          const failTask = createMockTask('failure');
-          return Promise.resolve(failTask);
-        }
-        return Promise.resolve(successTask);
-      });
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      // First call fails, second succeeds
+      vi.mocked(trackTaskProgress)
+        .mockRejectedValueOnce(new Error('Task failed: Processing failed'))
+        .mockResolvedValueOnce(undefined);
 
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
@@ -1494,60 +1147,19 @@ describe('PDFConverter', () => {
 });
 
 /**
- * Create a mock task that returns success (or specified status) on first poll.
+ * Create a mock task that returns success on first poll.
  */
-function createMockTask(
-  finalStatus: 'success' | 'failure' = 'success',
-): AsyncConversionTask {
+function createMockTask(): AsyncConversionTask {
   const task = {
     taskId: 'task-123',
     poll: vi.fn().mockResolvedValue({
       task_id: 'task-123',
-      task_status: finalStatus,
+      task_status: 'success',
     }),
     getResult: vi.fn().mockResolvedValue({
       document: {},
-      status: finalStatus,
+      status: 'success',
       processing_time: 0,
-      errors:
-        finalStatus === 'failure'
-          ? [{ message: 'Processing failed' }]
-          : undefined,
-    }),
-  };
-  return task as unknown as AsyncConversionTask;
-}
-
-/**
- * Create a mock task with a sequence of poll responses.
- * Each call to poll() returns the next response in the sequence.
- */
-function createMockTaskWithPollSequence(
-  responses: Array<{
-    task_id: string;
-    task_status: 'pending' | 'started' | 'success' | 'failure';
-    task_position?: number;
-    task_meta?: { total_documents?: number; processed_documents?: number };
-  }>,
-): AsyncConversionTask {
-  const pollMock = vi.fn();
-  responses.forEach((response) => {
-    pollMock.mockResolvedValueOnce(response);
-  });
-
-  const lastStatus = responses[responses.length - 1]?.task_status ?? 'success';
-
-  const task = {
-    taskId: 'task-123',
-    poll: pollMock,
-    getResult: vi.fn().mockResolvedValue({
-      document: {},
-      status: lastStatus,
-      processing_time: 0,
-      errors:
-        lastStatus === 'failure'
-          ? [{ message: 'Processing failed' }]
-          : undefined,
     }),
   };
   return task as unknown as AsyncConversionTask;

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -1,12 +1,10 @@
 import type { LoggerMethods } from '@heripo/logger';
 import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
-import type { Readable } from 'node:stream';
 
 import { omit } from 'es-toolkit';
-import { createWriteStream, existsSync, rmSync } from 'node:fs';
-import { rename, writeFile } from 'node:fs/promises';
+import { existsSync, rmSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
-import { pipeline } from 'node:stream/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PDF_CONVERTER } from '../config/constants';
@@ -14,6 +12,7 @@ import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
@@ -41,11 +40,9 @@ vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
   copyFileSync: vi.fn(),
   rmSync: vi.fn(),
-  createWriteStream: vi.fn(),
 }));
 
 vi.mock('node:fs/promises', () => ({
-  writeFile: vi.fn(),
   rename: vi.fn(),
 }));
 
@@ -53,8 +50,8 @@ vi.mock('node:path', () => ({
   join: vi.fn(),
 }));
 
-vi.mock('node:stream/promises', () => ({
-  pipeline: vi.fn(),
+vi.mock('../utils/docling-result-downloader', () => ({
+  downloadTaskResult: vi.fn(),
 }));
 
 vi.mock('../processors/image-extractor', () => ({
@@ -230,10 +227,6 @@ describe('PDFConverter', () => {
       test('does not use chunked conversion for non-file:// URLs', async () => {
         const mockTask = createMockTask();
         vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-        vi.mocked(client.getTaskResultFile).mockResolvedValue({
-          data: Buffer.from('zip'),
-          success: true,
-        } as any);
 
         await converter.convert(
           'http://example.com/test.pdf',
@@ -252,10 +245,6 @@ describe('PDFConverter', () => {
     test('should build conversion options with default values', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -296,10 +285,6 @@ describe('PDFConverter', () => {
     test('should omit num_threads from options and use in accelerator_options', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -337,10 +322,6 @@ describe('PDFConverter', () => {
     test('should include document_timeout when provided', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -362,10 +343,6 @@ describe('PDFConverter', () => {
     test('should not include document_timeout when not provided', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -397,16 +374,9 @@ describe('PDFConverter', () => {
     test('should validate document type for file:// URL with documentValidationModel', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
       const mockModel = {} as any;
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -433,16 +403,9 @@ describe('PDFConverter', () => {
     test('should skip validation for non-file:// URLs', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
       const mockModel = {} as any;
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -466,16 +429,9 @@ describe('PDFConverter', () => {
     test('should only validate once per converter instance', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
       const mockModel = {} as any;
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -493,10 +449,6 @@ describe('PDFConverter', () => {
       expect(mockValidate).toHaveBeenCalledTimes(1);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(createMockTask());
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
 
       // Second call skips validation (already validated)
       await converter.convert(
@@ -513,15 +465,8 @@ describe('PDFConverter', () => {
     test('should skip validation when documentValidationModel is not set', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -547,15 +492,8 @@ describe('PDFConverter', () => {
     test('should successfully convert PDF with cleanupAfterCallback=false', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -577,8 +515,7 @@ describe('PDFConverter', () => {
         'http://test.com/doc.pdf',
       );
       expect(client.convertSourceAsync).toHaveBeenCalled();
-      expect(client.getTaskResultFile).toHaveBeenCalledWith('task-123');
-      expect(pipeline).toHaveBeenCalled();
+      expect(downloadTaskResult).toHaveBeenCalled();
       expect(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).toHaveBeenCalledWith(
@@ -608,15 +545,8 @@ describe('PDFConverter', () => {
     test('should successfully convert PDF with cleanupAfterCallback=true', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -651,15 +581,8 @@ describe('PDFConverter', () => {
     test('should cleanup temporary files even if callback throws error', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockRejectedValue(new Error('Callback error'));
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -709,7 +632,7 @@ describe('PDFConverter', () => {
       const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockRejectedValue(
+      vi.mocked(downloadTaskResult).mockRejectedValue(
         new Error('Download failed'),
       );
 
@@ -731,15 +654,8 @@ describe('PDFConverter', () => {
 
     test('should handle processing failure and cleanup', async () => {
       const mockTask = createMockTask();
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockRejectedValue(new Error('Processing failed'));
@@ -767,15 +683,8 @@ describe('PDFConverter', () => {
     test('should handle non-existent files during cleanup', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -797,10 +706,6 @@ describe('PDFConverter', () => {
     test('should start conversion task and log task ID', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -839,10 +744,6 @@ describe('PDFConverter', () => {
       ]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -887,10 +788,6 @@ describe('PDFConverter', () => {
       ]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -923,10 +820,6 @@ describe('PDFConverter', () => {
       ]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -961,10 +854,6 @@ describe('PDFConverter', () => {
       ]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -987,10 +876,6 @@ describe('PDFConverter', () => {
       const mockTask = createMockTask();
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -1072,10 +957,6 @@ describe('PDFConverter', () => {
       ]);
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       await converter.convert(
@@ -1094,146 +975,11 @@ describe('PDFConverter', () => {
     });
   });
 
-  describe('downloadResult', () => {
-    test('should download via stream when fileStream is present', async () => {
-      const mockTask = createMockTask();
-      const mockFileStream = {} as Readable;
-      const writeStream = { write: vi.fn(), end: vi.fn() };
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: mockFileStream,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '\n[PDFConverter] Task completed, downloading ZIP file...',
-      );
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Saving ZIP file to:',
-        '/test/cwd/result.zip',
-      );
-      expect(createWriteStream).toHaveBeenCalledWith('/test/cwd/result.zip');
-      expect(pipeline).toHaveBeenCalledWith(mockFileStream, writeStream);
-    });
-
-    test('should download via writeFile when data is present', async () => {
-      const mockTask = createMockTask();
-      const mockData = new Uint8Array([1, 2, 3]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        data: mockData,
-      });
-      vi.mocked(writeFile).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(writeFile).toHaveBeenCalledWith('/test/cwd/result.zip', mockData);
-      expect(createWriteStream).not.toHaveBeenCalled();
-      expect(pipeline).not.toHaveBeenCalled();
-    });
-
-    test('should fallback to direct fetch when neither fileStream nor data is present', async () => {
-      const mockTask = createMockTask();
-      const mockZipData = new Uint8Array([80, 75, 3, 4]);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: false,
-      } as any);
-      vi.mocked(writeFile).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: vi.fn().mockResolvedValue(mockZipData.buffer),
-      });
-      vi.stubGlobal('fetch', fetchMock);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report-fallback',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'http://localhost:5001/v1/result/task-123',
-        { headers: { Accept: 'application/zip' } },
-      );
-      expect(writeFile).toHaveBeenCalledWith(
-        '/test/cwd/result.zip',
-        expect.any(Uint8Array),
-      );
-      expect(logger.warn).toHaveBeenCalledWith(
-        '[PDFConverter] SDK file result unavailable, falling back to direct download...',
-      );
-
-      vi.unstubAllGlobals();
-    });
-
-    test('should throw error when direct fetch fallback fails', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: false,
-      } as any);
-
-      const fetchMock = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found',
-      });
-      vi.stubGlobal('fetch', fetchMock);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Failed to download ZIP file: 404 Not Found');
-
-      vi.unstubAllGlobals();
-    });
-  });
-
   describe('processConvertedFiles', () => {
     test('should call ImageExtractor with correct paths', async () => {
       const mockTask = createMockTask();
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1275,10 +1021,6 @@ describe('PDFConverter', () => {
       } as unknown as AsyncConversionTask;
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
 
       await expect(
         converter.convert(
@@ -1299,15 +1041,8 @@ describe('PDFConverter', () => {
     test('should throw AbortError when aborted before callback', async () => {
       const mockTask = createMockTask();
       const abortController = new AbortController();
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
 
       // Abort after processConvertedFiles (ImageExtractor) completes
       vi.mocked(
@@ -1517,11 +1252,6 @@ describe('PDFConverter', () => {
         return Promise.resolve(successTask);
       });
 
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
         cleanup: vi.fn(),
@@ -1530,9 +1260,6 @@ describe('PDFConverter', () => {
         return mockImagePdfConverter as any;
       });
 
-      const writeStream = { write: vi.fn(), end: vi.fn() };
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1644,11 +1371,6 @@ describe('PDFConverter', () => {
         return Promise.resolve(successTask);
       });
 
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
         cleanup: vi.fn(),
@@ -1657,9 +1379,6 @@ describe('PDFConverter', () => {
         return mockImagePdfConverter as any;
       });
 
-      const writeStream = { write: vi.fn(), end: vi.fn() };
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1687,15 +1406,8 @@ describe('PDFConverter', () => {
     test('should render page images and update result.json for file:// URLs', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1739,15 +1451,8 @@ describe('PDFConverter', () => {
     test('should skip rendering and log warning for http:// URLs', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1772,15 +1477,8 @@ describe('PDFConverter', () => {
     test('should update page image URIs with correct indices', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1821,15 +1519,8 @@ describe('PDFConverter', () => {
     test('should skip pages with page_no exceeding rendered page count', async () => {
       const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-      const writeStream = { write: vi.fn(), end: vi.fn() };
 
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
-      vi.mocked(createWriteStream).mockReturnValue(writeStream as any);
-      vi.mocked(pipeline).mockResolvedValue(undefined);
       vi.mocked(
         ImageExtractor.extractAndSaveDocumentsFromZip,
       ).mockResolvedValue(undefined);
@@ -1868,10 +1559,6 @@ describe('PDFConverter', () => {
     test('should convert via image PDF when forceImagePdf is true', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
       vi.mocked(runJqFileToFile).mockResolvedValue(undefined);
       vi.mocked(rename).mockResolvedValue(undefined);
@@ -1893,10 +1580,6 @@ describe('PDFConverter', () => {
     test('should not convert via image PDF when forceImagePdf is false', async () => {
       const mockTask = createMockTask();
       vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(client.getTaskResultFile).mockResolvedValue({
-        success: true,
-        fileStream: {} as Readable,
-      });
       vi.mocked(existsSync).mockReturnValue(false);
 
       vi.mocked(ImagePdfConverter).mockClear();

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -23,7 +23,7 @@ import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
-import { getTaskFailureDetails } from '../utils/task-failure-details';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { ImagePdfConverter } from './image-pdf-converter';
@@ -569,7 +569,15 @@ export class PDFConverter {
 
     try {
       const task = await this.startConversionTask(httpUrl, conversionOptions);
-      await this.trackTaskProgress(task);
+      await trackTaskProgress(
+        task,
+        this.timeout,
+        this.logger,
+        '[PDFConverter]',
+        {
+          showDetailedProgress: true,
+        },
+      );
 
       // Check abort after docling task completes
       if (abortSignal?.aborted) {
@@ -756,79 +764,6 @@ export class PDFConverter {
     }
 
     return { httpUrl: url };
-  }
-
-  private async trackTaskProgress(task: AsyncConversionTask): Promise<void> {
-    const conversionStartTime = Date.now();
-    let lastProgressLine = '';
-
-    const logProgress = (status: {
-      task_status: string;
-      task_position?: number;
-      task_meta?: { total_documents?: number; processed_documents?: number };
-    }) => {
-      const parts: string[] = [`Status: ${status.task_status}`];
-
-      if (status.task_position !== undefined) {
-        parts.push(`position: ${status.task_position}`);
-      }
-
-      const meta = status.task_meta;
-      if (meta) {
-        if (
-          meta.processed_documents !== undefined &&
-          meta.total_documents !== undefined
-        ) {
-          parts.push(
-            `progress: ${meta.processed_documents}/${meta.total_documents}`,
-          );
-        }
-      }
-
-      const progressLine = `\r[PDFConverter] ${parts.join(' | ')}`;
-      if (progressLine !== lastProgressLine) {
-        lastProgressLine = progressLine;
-        process.stdout.write(progressLine);
-      }
-    };
-
-    while (true) {
-      if (Date.now() - conversionStartTime > this.timeout) {
-        throw new Error('Task timeout');
-      }
-
-      const status = await task.poll();
-
-      logProgress(status);
-
-      if (status.task_status === 'success') {
-        this.logger.info('\n[PDFConverter] Conversion completed!');
-        return;
-      }
-
-      if (status.task_status === 'failure') {
-        // Try to get detailed error info from the task result
-        const errorDetails = await this.getTaskFailureDetails(task);
-        const elapsed = Math.round((Date.now() - conversionStartTime) / 1000);
-        this.logger.error(
-          `\n[PDFConverter] Task failed after ${elapsed}s: ${errorDetails}`,
-        );
-        throw new Error(`Task failed: ${errorDetails}`);
-      }
-
-      await new Promise((resolve) =>
-        setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
-      );
-    }
-  }
-
-  /**
-   * Fetch detailed error information from a failed task result.
-   */
-  private async getTaskFailureDetails(
-    task: AsyncConversionTask,
-  ): Promise<string> {
-    return getTaskFailureDetails(task, this.logger, '[PDFConverter]');
   }
 
   private async processConvertedFiles(

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -10,14 +10,9 @@ import type {
 import { LLMTokenUsageAggregator } from '@heripo/shared';
 import { omit } from 'es-toolkit';
 import { copyFileSync, existsSync, rmSync } from 'node:fs';
-import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import {
-  CHUNKED_CONVERSION,
-  PAGE_RENDERING,
-  PDF_CONVERTER,
-} from '../config/constants';
+import { CHUNKED_CONVERSION, PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
@@ -25,8 +20,9 @@ import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
 import { downloadTaskResult } from '../utils/docling-result-downloader';
-import { runJqFileJson, runJqFileToFile } from '../utils/jq';
+import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { getTaskFailureDetails } from '../utils/task-failure-details';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
@@ -611,7 +607,18 @@ export class PDFConverter {
       await this.processConvertedFiles(zipPath, extractDir, outputDir);
 
       // Render page images using ImageMagick (replaces Docling's page image generation)
-      await this.renderPageImages(url, outputDir);
+      if (url.startsWith('file://')) {
+        await renderAndUpdatePageImages(
+          url.slice(7),
+          outputDir,
+          this.logger,
+          '[PDFConverter]',
+        );
+      } else {
+        this.logger.warn(
+          '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
+        );
+      }
 
       // Check abort before callback
       if (abortSignal?.aborted) {
@@ -835,51 +842,6 @@ export class PDFConverter {
       zipPath,
       extractDir,
       outputDir,
-    );
-  }
-
-  /**
-   * Render page images from the source PDF using ImageMagick and update result.json.
-   * Uses jq to update the JSON file without loading it into Node.js memory.
-   * Replaces Docling's generate_page_images which fails on large PDFs
-   * due to memory limits when embedding all page images as base64.
-   */
-  private async renderPageImages(
-    url: string,
-    outputDir: string,
-  ): Promise<void> {
-    if (!url.startsWith('file://')) {
-      this.logger.warn(
-        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
-      );
-      return;
-    }
-
-    const pdfPath = url.slice(7);
-    this.logger.info(
-      '[PDFConverter] Rendering page images with ImageMagick...',
-    );
-
-    const renderer = new PageRenderer(this.logger);
-    const renderResult = await renderer.renderPages(pdfPath, outputDir);
-
-    // Update result.json with page image URIs using jq to avoid loading large JSON
-    const resultPath = join(outputDir, 'result.json');
-    const tmpPath = resultPath + '.tmp';
-    const jqProgram = `
-      .pages |= with_entries(
-        if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
-          .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
-          .value.image.mimetype = "image/png" |
-          .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
-        else . end
-      )
-    `;
-    await runJqFileToFile(jqProgram, resultPath, tmpPath);
-    await rename(tmpPath, resultPath);
-
-    this.logger.info(
-      `[PDFConverter] Rendered ${renderResult.pageCount} page images`,
     );
   }
 }

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -9,10 +9,9 @@ import type {
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
 import { omit } from 'es-toolkit';
-import { copyFileSync, createWriteStream, existsSync, rmSync } from 'node:fs';
-import { rename, writeFile } from 'node:fs/promises';
+import { copyFileSync, existsSync, rmSync } from 'node:fs';
+import { rename } from 'node:fs/promises';
 import { join } from 'node:path';
-import { pipeline } from 'node:stream/promises';
 
 import {
   CHUNKED_CONVERSION,
@@ -25,6 +24,7 @@ import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileJson, runJqFileToFile } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { getTaskFailureDetails } from '../utils/task-failure-details';
@@ -585,7 +585,15 @@ export class PDFConverter {
         throw error;
       }
 
-      await this.downloadResult(task.taskId);
+      const cwd = process.cwd();
+      const zipPath = join(cwd, 'result.zip');
+      await downloadTaskResult(
+        this.client,
+        task.taskId,
+        zipPath,
+        this.logger,
+        '[PDFConverter]',
+      );
     } finally {
       // Stop local file server if started
       if (server) {
@@ -814,46 +822,6 @@ export class PDFConverter {
     task: AsyncConversionTask,
   ): Promise<string> {
     return getTaskFailureDetails(task, this.logger, '[PDFConverter]');
-  }
-
-  private async downloadResult(taskId: string): Promise<void> {
-    this.logger.info(
-      '\n[PDFConverter] Task completed, downloading ZIP file...',
-    );
-
-    const zipResult = await this.client.getTaskResultFile(taskId);
-
-    const zipPath = join(process.cwd(), 'result.zip');
-    this.logger.info('[PDFConverter] Saving ZIP file to:', zipPath);
-
-    if (zipResult.fileStream) {
-      const writeStream = createWriteStream(zipPath);
-      await pipeline(zipResult.fileStream, writeStream);
-      return;
-    }
-
-    if (zipResult.data) {
-      await writeFile(zipPath, zipResult.data);
-      return;
-    }
-
-    // Fallback: direct HTTP download when SDK stream/data unavailable
-    this.logger.warn(
-      '[PDFConverter] SDK file result unavailable, falling back to direct download...',
-    );
-    const baseUrl = this.client.getConfig().baseUrl;
-    const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
-      headers: { Accept: 'application/zip' },
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to download ZIP file: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const buffer = new Uint8Array(await response.arrayBuffer());
-    await writeFile(zipPath, buffer);
   }
 
   private async processConvertedFiles(

--- a/packages/pdf-parser/src/utils/docling-result-downloader.test.ts
+++ b/packages/pdf-parser/src/utils/docling-result-downloader.test.ts
@@ -1,0 +1,200 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingAPIClient } from 'docling-sdk';
+import type { Mock } from 'vitest';
+
+import { createWriteStream } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { downloadTaskResult } from './docling-result-downloader';
+
+vi.mock('node:fs', () => ({
+  createWriteStream: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn(),
+}));
+
+vi.mock('node:stream/promises', () => ({
+  pipeline: vi.fn(),
+}));
+
+describe('downloadTaskResult', () => {
+  let client: DoclingAPIClient;
+  let logger: LoggerMethods;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    client = {
+      getTaskResultFile: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
+    } as unknown as DoclingAPIClient;
+
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as LoggerMethods;
+  });
+
+  test('should download via fileStream when available', async () => {
+    const mockStream = { pipe: vi.fn() };
+    const mockWriteStream = { on: vi.fn() };
+
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      fileStream: mockStream,
+    });
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockWriteStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(pipeline).mockResolvedValue(undefined);
+
+    await downloadTaskResult(
+      client,
+      'task-123',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(client.getTaskResultFile).toHaveBeenCalledWith('task-123');
+    expect(createWriteStream).toHaveBeenCalledWith('/tmp/result.zip');
+    expect(pipeline).toHaveBeenCalledWith(mockStream, mockWriteStream);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  test('should download via writeFile when data is present', async () => {
+    const mockData = Buffer.from('zip-data');
+
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      data: mockData,
+    });
+
+    await downloadTaskResult(
+      client,
+      'task-456',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(writeFile).toHaveBeenCalledWith('/tmp/result.zip', mockData);
+    expect(createWriteStream).not.toHaveBeenCalled();
+    expect(pipeline).not.toHaveBeenCalled();
+  });
+
+  test('should fallback to direct HTTP fetch when neither fileStream nor data is present', async () => {
+    (client.getTaskResultFile as Mock).mockResolvedValue({});
+
+    const mockArrayBuffer = new ArrayBuffer(8);
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(mockArrayBuffer),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await downloadTaskResult(
+      client,
+      'task-789',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[Test] SDK file result unavailable, falling back to direct download...',
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:5001/v1/result/task-789',
+      { headers: { Accept: 'application/zip' } },
+    );
+    expect(writeFile).toHaveBeenCalledWith(
+      '/tmp/result.zip',
+      new Uint8Array(mockArrayBuffer),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  test('should throw error when direct fetch fallback fails', async () => {
+    (client.getTaskResultFile as Mock).mockResolvedValue({});
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(
+      downloadTaskResult(
+        client,
+        'task-fail',
+        '/tmp/result.zip',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('Failed to download ZIP file: 500 Internal Server Error');
+
+    vi.unstubAllGlobals();
+  });
+
+  test('should log correct messages with provided prefix', async () => {
+    const mockStream = { pipe: vi.fn() };
+    const mockWriteStream = { on: vi.fn() };
+
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      fileStream: mockStream,
+    });
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockWriteStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(pipeline).mockResolvedValue(undefined);
+
+    await downloadTaskResult(
+      client,
+      'task-log',
+      '/output/result.zip',
+      logger,
+      '[PDFConverter]',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '\n[PDFConverter] Task completed, downloading ZIP file...',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[PDFConverter] Saving ZIP file to:',
+      '/output/result.zip',
+    );
+  });
+
+  test('should prefer fileStream over data when both are present', async () => {
+    const mockStream = { pipe: vi.fn() };
+    const mockData = Buffer.from('zip-data');
+    const mockWriteStream = { on: vi.fn() };
+
+    (client.getTaskResultFile as Mock).mockResolvedValue({
+      fileStream: mockStream,
+      data: mockData,
+    });
+    vi.mocked(createWriteStream).mockReturnValue(
+      mockWriteStream as unknown as ReturnType<typeof createWriteStream>,
+    );
+    vi.mocked(pipeline).mockResolvedValue(undefined);
+
+    await downloadTaskResult(
+      client,
+      'task-both',
+      '/tmp/result.zip',
+      logger,
+      '[Test]',
+    );
+
+    expect(pipeline).toHaveBeenCalledWith(mockStream, mockWriteStream);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pdf-parser/src/utils/docling-result-downloader.ts
+++ b/packages/pdf-parser/src/utils/docling-result-downloader.ts
@@ -1,0 +1,60 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { DoclingAPIClient } from 'docling-sdk';
+
+import { createWriteStream } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { pipeline } from 'node:stream/promises';
+
+/**
+ * Download the ZIP result from a completed Docling conversion task.
+ *
+ * Uses 3-step fallback: fileStream → data → direct HTTP fetch.
+ *
+ * @param client - Docling API client
+ * @param taskId - Completed task ID
+ * @param zipPath - Local path to save the ZIP file
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]' or '[ChunkedPDFConverter]')
+ */
+export async function downloadTaskResult(
+  client: DoclingAPIClient,
+  taskId: string,
+  zipPath: string,
+  logger: LoggerMethods,
+  logPrefix: string,
+): Promise<void> {
+  logger.info(`\n${logPrefix} Task completed, downloading ZIP file...`);
+
+  const zipResult = await client.getTaskResultFile(taskId);
+
+  logger.info(`${logPrefix} Saving ZIP file to:`, zipPath);
+
+  if (zipResult.fileStream) {
+    const writeStream = createWriteStream(zipPath);
+    await pipeline(zipResult.fileStream, writeStream);
+    return;
+  }
+
+  if (zipResult.data) {
+    await writeFile(zipPath, zipResult.data);
+    return;
+  }
+
+  // Fallback: direct HTTP download when SDK stream/data unavailable
+  logger.warn(
+    `${logPrefix} SDK file result unavailable, falling back to direct download...`,
+  );
+  const baseUrl = client.getConfig().baseUrl;
+  const response = await fetch(`${baseUrl}/v1/result/${taskId}`, {
+    headers: { Accept: 'application/zip' },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ZIP file: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const buffer = new Uint8Array(await response.arrayBuffer());
+  await writeFile(zipPath, buffer);
+}

--- a/packages/pdf-parser/src/utils/page-image-updater.test.ts
+++ b/packages/pdf-parser/src/utils/page-image-updater.test.ts
@@ -1,0 +1,215 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { rename } from 'node:fs/promises';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PAGE_RENDERING } from '../config/constants';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileToFile } from './jq';
+import { renderAndUpdatePageImages } from './page-image-updater';
+
+vi.mock('node:fs/promises', () => ({
+  rename: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
+}));
+
+vi.mock('./jq', () => ({
+  runJqFileToFile: vi.fn(),
+}));
+
+describe('renderAndUpdatePageImages', () => {
+  let logger: LoggerMethods;
+  let mockRenderPages: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    mockRenderPages = vi.fn().mockResolvedValue({
+      pageCount: 5,
+      pagesDir: '/output/pages',
+      pageFiles: [],
+    });
+
+    vi.mocked(PageRenderer).mockImplementation(function () {
+      return { renderPages: mockRenderPages } as any;
+    });
+
+    vi.mocked(runJqFileToFile).mockResolvedValue(undefined as any);
+    vi.mocked(rename).mockResolvedValue(undefined);
+  });
+
+  test('renders pages and updates result.json via jq', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(PageRenderer).toHaveBeenCalledWith(logger);
+    expect(mockRenderPages).toHaveBeenCalledWith(
+      '/test/doc.pdf',
+      '/output/dir',
+    );
+
+    const resultPath = '/output/dir/result.json';
+    const tmpPath = resultPath + '.tmp';
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining('.pages |= with_entries('),
+      resultPath,
+      tmpPath,
+    );
+    expect(rename).toHaveBeenCalledWith(tmpPath, resultPath);
+  });
+
+  test('jq program uses correct pageCount from render result', async () => {
+    mockRenderPages.mockResolvedValue({
+      pageCount: 10,
+      pagesDir: '/output/pages',
+      pageFiles: [],
+    });
+
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining('< 10'),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('jq program sets correct DPI from PAGE_RENDERING constant', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `.value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}`,
+      ),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('jq program sets page image URI pattern', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '.value.image.uri = "pages/page_\\(.value.page_no - 1).png"',
+      ),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('jq program sets mimetype to image/png', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(runJqFileToFile).toHaveBeenCalledWith(
+      expect.stringContaining('.value.image.mimetype = "image/png"'),
+      expect.any(String),
+      expect.any(String),
+    );
+  });
+
+  test('logs rendering start and completion with logPrefix', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[MyConverter]',
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      '[MyConverter] Rendering page images with ImageMagick...',
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      '[MyConverter] Rendered 5 page images',
+    );
+  });
+
+  test('uses join to construct resultPath and tmpPath', async () => {
+    await renderAndUpdatePageImages(
+      '/test/doc.pdf',
+      '/output/dir',
+      logger,
+      '[Test]',
+    );
+
+    expect(join).toHaveBeenCalledWith('/output/dir', 'result.json');
+  });
+
+  test('propagates PageRenderer error', async () => {
+    mockRenderPages.mockRejectedValue(new Error('ImageMagick not found'));
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('ImageMagick not found');
+  });
+
+  test('propagates jq error', async () => {
+    vi.mocked(runJqFileToFile).mockRejectedValue(new Error('jq failed'));
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('jq failed');
+  });
+
+  test('propagates rename error', async () => {
+    vi.mocked(rename).mockRejectedValue(new Error('EACCES'));
+
+    await expect(
+      renderAndUpdatePageImages(
+        '/test/doc.pdf',
+        '/output/dir',
+        logger,
+        '[Test]',
+      ),
+    ).rejects.toThrow('EACCES');
+  });
+});

--- a/packages/pdf-parser/src/utils/page-image-updater.ts
+++ b/packages/pdf-parser/src/utils/page-image-updater.ts
@@ -1,0 +1,49 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { rename } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { PAGE_RENDERING } from '../config/constants';
+import { PageRenderer } from '../processors/page-renderer';
+import { runJqFileToFile } from './jq';
+
+/**
+ * Render page images from a PDF using ImageMagick and update result.json.
+ *
+ * Uses jq to update the JSON file without loading it into Node.js memory.
+ * Replaces Docling's generate_page_images which fails on large PDFs
+ * due to memory limits when embedding all page images as base64.
+ *
+ * @param pdfPath - Absolute path to the source PDF file
+ * @param outputDir - Directory containing result.json (pages/ subdirectory will be created)
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]')
+ */
+export async function renderAndUpdatePageImages(
+  pdfPath: string,
+  outputDir: string,
+  logger: LoggerMethods,
+  logPrefix: string,
+): Promise<void> {
+  logger.info(`${logPrefix} Rendering page images with ImageMagick...`);
+
+  const renderer = new PageRenderer(logger);
+  const renderResult = await renderer.renderPages(pdfPath, outputDir);
+
+  // Update result.json with page image URIs using jq to avoid loading large JSON
+  const resultPath = join(outputDir, 'result.json');
+  const tmpPath = resultPath + '.tmp';
+  const jqProgram = `
+    .pages |= with_entries(
+      if (.value.page_no - 1) >= 0 and (.value.page_no - 1) < ${renderResult.pageCount} then
+        .value.image.uri = "pages/page_\\(.value.page_no - 1).png" |
+        .value.image.mimetype = "image/png" |
+        .value.image.dpi = ${PAGE_RENDERING.DEFAULT_DPI}
+      else . end
+    )
+  `;
+  await runJqFileToFile(jqProgram, resultPath, tmpPath);
+  await rename(tmpPath, resultPath);
+
+  logger.info(`${logPrefix} Rendered ${renderResult.pageCount} page images`);
+}

--- a/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
@@ -1,0 +1,332 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PDF_CONVERTER } from '../config/constants';
+import { getTaskFailureDetails } from './task-failure-details';
+import { trackTaskProgress } from './task-progress-tracker';
+
+vi.mock('./task-failure-details', () => ({
+  getTaskFailureDetails: vi.fn(),
+}));
+
+function createMockTask(overrides?: {
+  taskId?: string;
+  pollResponses?: {
+    task_status: string;
+    task_position?: number;
+    task_meta?: Record<string, unknown>;
+  }[];
+  getResultValue?: unknown;
+}) {
+  const responses = overrides?.pollResponses ?? [{ task_status: 'success' }];
+  let pollIndex = 0;
+  return {
+    taskId: overrides?.taskId ?? 'task-1',
+    poll: vi.fn(
+      async () => responses[Math.min(pollIndex++, responses.length - 1)],
+    ),
+    getResult: vi.fn().mockResolvedValue(overrides?.getResultValue ?? {}),
+  };
+}
+
+describe('trackTaskProgress', () => {
+  let logger: LoggerMethods;
+  let stdoutWriteSpy: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    stdoutWriteSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockReturnValue(true) as unknown as Mock;
+  });
+
+  describe('success', () => {
+    test('resolves when task completes successfully', async () => {
+      const task = createMockTask();
+
+      await trackTaskProgress(task, 60000, logger, '[Test]');
+
+      expect(task.poll).toHaveBeenCalledTimes(1);
+    });
+
+    test('polls multiple times before success', async () => {
+      const task = createMockTask({
+        pollResponses: [
+          { task_status: 'pending' },
+          { task_status: 'started' },
+          { task_status: 'success' },
+        ],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]');
+
+      expect(task.poll).toHaveBeenCalledTimes(3);
+    });
+
+    test('logs completion message when showDetailedProgress is enabled', async () => {
+      const task = createMockTask();
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '\n[Test] Conversion completed!',
+      );
+    });
+
+    test('does not log completion message when showDetailedProgress is disabled', async () => {
+      const task = createMockTask();
+
+      await trackTaskProgress(task, 60000, logger, '[Test]');
+
+      expect(logger.info).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('detailed progress', () => {
+    test('writes status to stdout', async () => {
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'started' }, { task_status: 'success' }],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      expect(stdoutWriteSpy).toHaveBeenCalledWith('\r[Test] Status: started');
+    });
+
+    test('writes position to stdout', async () => {
+      const task = createMockTask({
+        pollResponses: [
+          { task_status: 'started', task_position: 5 },
+          { task_status: 'success' },
+        ],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        '\r[Test] Status: started | position: 5',
+      );
+    });
+
+    test('writes document progress from task_meta', async () => {
+      const task = createMockTask({
+        pollResponses: [
+          {
+            task_status: 'started',
+            task_position: 1,
+            task_meta: { total_documents: 10, processed_documents: 3 },
+          },
+          { task_status: 'success' },
+        ],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      expect(stdoutWriteSpy).toHaveBeenCalledWith(
+        '\r[Test] Status: started | position: 1 | progress: 3/10',
+      );
+    });
+
+    test('ignores task_meta without document counts', async () => {
+      const task = createMockTask({
+        pollResponses: [
+          { task_status: 'started', task_meta: {} },
+          { task_status: 'success' },
+        ],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      expect(stdoutWriteSpy).toHaveBeenCalledWith('\r[Test] Status: started');
+    });
+
+    test('deduplicates identical progress lines', async () => {
+      const task = createMockTask({
+        pollResponses: [
+          { task_status: 'started' },
+          { task_status: 'started' },
+          { task_status: 'success' },
+        ],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]', {
+        showDetailedProgress: true,
+      });
+
+      const startedCalls = stdoutWriteSpy.mock.calls.filter(
+        (call: unknown[]) => call[0] === '\r[Test] Status: started',
+      );
+      expect(startedCalls).toHaveLength(1);
+    });
+
+    test('does not write progress when showDetailedProgress is disabled', async () => {
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'started' }, { task_status: 'success' }],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]');
+
+      expect(stdoutWriteSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('timeout', () => {
+    test('throws default timeout error with Task prefix', async () => {
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1000200);
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'pending' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 100, logger, '[Test]'),
+      ).rejects.toThrow('Task timeout');
+    });
+
+    test('throws timeout error with custom errorPrefix', async () => {
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1000200);
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'pending' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 100, logger, '[Test]', {
+          errorPrefix: '[Custom] Chunk task ',
+        }),
+      ).rejects.toThrow('[Custom] Chunk task timeout');
+    });
+  });
+
+  describe('failure', () => {
+    test('throws failure error with error details (default prefix)', async () => {
+      vi.mocked(getTaskFailureDetails).mockResolvedValue('OCR engine crashed');
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'failure' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 60000, logger, '[Test]'),
+      ).rejects.toThrow('Task failed: OCR engine crashed');
+    });
+
+    test('throws failure error with custom errorPrefix', async () => {
+      vi.mocked(getTaskFailureDetails).mockResolvedValue('OCR engine crashed');
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'failure' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 60000, logger, '[Test]', {
+          errorPrefix: '[Chunked] task ',
+        }),
+      ).rejects.toThrow('[Chunked] task failed: OCR engine crashed');
+    });
+
+    test('logs detailed failure with elapsed time when showDetailedProgress is enabled', async () => {
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1060000);
+
+      vi.mocked(getTaskFailureDetails).mockResolvedValue('Processing failed');
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'failure' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 120000, logger, '[Test]', {
+          showDetailedProgress: true,
+        }),
+      ).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '\n[Test] Task failed after 60s: Processing failed',
+      );
+    });
+
+    test('logs compact failure with taskId and decimal elapsed when showDetailedProgress is disabled', async () => {
+      vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1000000)
+        .mockReturnValueOnce(1005500);
+
+      vi.mocked(getTaskFailureDetails).mockResolvedValue('Processing failed');
+
+      const task = createMockTask({
+        taskId: 'task-abc',
+        pollResponses: [{ task_status: 'failure' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 120000, logger, '[Test]'),
+      ).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[Test] Task task-abc failed after 5.5s',
+      );
+    });
+
+    test('calls getTaskFailureDetails with correct arguments', async () => {
+      vi.mocked(getTaskFailureDetails).mockResolvedValue('some error');
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'failure' }],
+      });
+
+      await expect(
+        trackTaskProgress(task, 60000, logger, '[MyPrefix]'),
+      ).rejects.toThrow();
+
+      expect(getTaskFailureDetails).toHaveBeenCalledWith(
+        task,
+        logger,
+        '[MyPrefix]',
+      );
+    });
+  });
+
+  describe('polling interval', () => {
+    test('waits POLL_INTERVAL_MS between polls', async () => {
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+      const task = createMockTask({
+        pollResponses: [{ task_status: 'started' }, { task_status: 'success' }],
+      });
+
+      await trackTaskProgress(task, 60000, logger, '[Test]');
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        PDF_CONVERTER.POLL_INTERVAL_MS,
+      );
+    });
+  });
+});

--- a/packages/pdf-parser/src/utils/task-progress-tracker.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.ts
@@ -1,0 +1,101 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { PDF_CONVERTER } from '../config/constants';
+import { getTaskFailureDetails } from './task-failure-details';
+
+interface PollableTask {
+  taskId: string;
+  poll: () => Promise<{
+    task_status: string;
+    task_position?: number;
+    task_meta?: { total_documents?: number; processed_documents?: number };
+  }>;
+  getResult: () => Promise<{ errors?: { message: string }[]; status?: string }>;
+}
+
+export interface TrackProgressOptions {
+  /** Show detailed progress with position and document counts (default: false) */
+  showDetailedProgress?: boolean;
+  /** Error message prefix prepended to 'timeout' / 'failed: <details>' (default: 'Task ') */
+  errorPrefix?: string;
+}
+
+/**
+ * Poll a Docling conversion task until completion.
+ *
+ * @param task - Pollable task object from Docling SDK
+ * @param timeout - Maximum wait time in milliseconds
+ * @param logger - Logger instance
+ * @param logPrefix - Log prefix (e.g. '[PDFConverter]')
+ * @param options - Optional configuration
+ */
+export async function trackTaskProgress(
+  task: PollableTask,
+  timeout: number,
+  logger: LoggerMethods,
+  logPrefix: string,
+  options?: TrackProgressOptions,
+): Promise<void> {
+  const startTime = Date.now();
+  const errPrefix = options?.errorPrefix ?? 'Task ';
+  let lastProgressLine = '';
+
+  while (true) {
+    if (Date.now() - startTime > timeout) {
+      throw new Error(`${errPrefix}timeout`);
+    }
+
+    const status = await task.poll();
+
+    // Detailed progress logging (used by single-pass conversion)
+    if (options?.showDetailedProgress) {
+      const parts: string[] = [`Status: ${status.task_status}`];
+      if (status.task_position !== undefined) {
+        parts.push(`position: ${status.task_position}`);
+      }
+      const meta = status.task_meta;
+      if (
+        meta?.processed_documents !== undefined &&
+        meta?.total_documents !== undefined
+      ) {
+        parts.push(
+          `progress: ${meta.processed_documents}/${meta.total_documents}`,
+        );
+      }
+      const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
+      if (progressLine !== lastProgressLine) {
+        lastProgressLine = progressLine;
+        process.stdout.write(progressLine);
+      }
+    }
+
+    if (status.task_status === 'success') {
+      if (options?.showDetailedProgress) {
+        logger.info(`\n${logPrefix} Conversion completed!`);
+      }
+      return;
+    }
+
+    if (status.task_status === 'failure') {
+      const errorDetails = await getTaskFailureDetails(task, logger, logPrefix);
+
+      if (options?.showDetailedProgress) {
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        logger.error(
+          `\n${logPrefix} Task failed after ${elapsed}s: ${errorDetails}`,
+        );
+      } else {
+        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+        logger.error(
+          `${logPrefix} Task ${task.taskId} failed after ${elapsed}s`,
+        );
+      }
+
+      throw new Error(`${errPrefix}failed: ${errorDetails}`);
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
+    );
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract duplicated logic shared between `PdfConverter` and `ChunkedPDFConverter` into three dedicated utility modules. This eliminates code duplication, improves testability, and makes each converter thinner and easier to maintain.

## Changes

- Add `downloadTaskResult` utility (`utils/docling-result-downloader.ts`) to centralize Docling task result downloading with streaming file writes and atomic rename
- Add `renderAndUpdatePageImages` utility (`utils/page-image-updater.ts`) to centralize page rendering and result file JSON patching via `PageRenderer` and `runJqFileToFile`
- Add `trackTaskProgress` utility (`utils/task-progress-tracker.ts`) to centralize task polling, progress reporting via `onProgress`, and failure detail extraction
- Refactor `PdfConverter` and `ChunkedPDFConverter` to delegate to the new utilities, removing redundant private methods (`trackTaskProgress`, `getTaskFailureDetails`, `renderPageImages`, inline download logic)
- Add dedicated test files for each new utility with comprehensive coverage
- Remove obsolete mocks and imports from converter test files (e.g., `createWriteStream`, `pipeline`, `rename`, `PageRenderer`, `runJqFileToFile`)

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
