### PR TITLE
refactor(pdf-parser): extract and centralize buildConversionOptions into a shared utility

### DIFF
--- a/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.test.ts
@@ -19,6 +19,7 @@ import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
+import { buildConversionOptions } from './conversion-options-builder';
 
 vi.mock('@heripo/shared', () => ({
   spawnAsync: vi.fn(),
@@ -40,6 +41,10 @@ vi.mock('node:path', () => ({
 
 vi.mock('../utils/docling-result-downloader', () => ({
   downloadTaskResult: vi.fn(),
+}));
+
+vi.mock('./conversion-options-builder', () => ({
+  buildConversionOptions: vi.fn(),
 }));
 
 vi.mock('../processors/image-extractor', () => ({
@@ -106,7 +111,6 @@ describe('ChunkedPDFConverter', () => {
   let client: DoclingAPIClient;
   let converter: ChunkedPDFConverter;
   let mockOnComplete: Mock;
-  let mockBuildOptions: Mock;
   let mockServerInstance: { start: Mock; stop: Mock };
   let mockMergerInstance: { merge: Mock };
   let mockTask: { taskId: string; poll: Mock; getResult: Mock };
@@ -141,7 +145,8 @@ describe('ChunkedPDFConverter', () => {
     });
 
     mockOnComplete = vi.fn();
-    mockBuildOptions = vi.fn().mockReturnValue({ to_formats: ['json'] });
+
+    vi.mocked(buildConversionOptions).mockReturnValue({ to_formats: ['json'] });
 
     vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
 
@@ -279,7 +284,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Local file server started and stopped
@@ -290,13 +294,13 @@ describe('ChunkedPDFConverter', () => {
       expect(client.convertSourceAsync).toHaveBeenCalledTimes(3);
 
       // buildConversionOptions called with page_range for each chunk
-      expect(mockBuildOptions).toHaveBeenCalledWith(
+      expect(buildConversionOptions).toHaveBeenCalledWith(
         expect.objectContaining({ page_range: [1, 10] }),
       );
-      expect(mockBuildOptions).toHaveBeenCalledWith(
+      expect(buildConversionOptions).toHaveBeenCalledWith(
         expect.objectContaining({ page_range: [11, 20] }),
       );
-      expect(mockBuildOptions).toHaveBeenCalledWith(
+      expect(buildConversionOptions).toHaveBeenCalledWith(
         expect.objectContaining({ page_range: [21, 25] }),
       );
 
@@ -332,7 +336,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Failed to detect page count from PDF');
     });
@@ -355,7 +358,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Called twice (1 failure + 1 retry success)
@@ -382,7 +384,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Persistent error');
 
@@ -409,7 +410,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
           controller.signal,
         ),
       ).rejects.toThrow('aborted');
@@ -456,7 +456,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // 3 pic_ + 3 image_ = 6 total copies
@@ -523,7 +522,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // 3 image_ files only
@@ -555,7 +553,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       expect(mockOnComplete).toHaveBeenCalledWith('/test/cwd/output/my-report');
@@ -577,7 +574,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         true,
         {},
-        mockBuildOptions,
       );
 
       // Both chunks dir and output dir cleaned up
@@ -604,7 +600,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       expect(writeFileSync).toHaveBeenCalledWith(
@@ -626,7 +621,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       expect(trackTaskProgress).toHaveBeenCalledWith(
@@ -658,7 +652,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('OCR engine crashed');
     });
@@ -679,7 +672,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // ZIP and extracted dirs are cleaned per chunk
@@ -712,7 +704,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         true,
         {},
-        mockBuildOptions,
       );
 
       // _chunks dir cleaned up
@@ -756,7 +747,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // All 3 orphaned pic_ files deleted
@@ -808,7 +798,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // pic_0 and pic_2 deleted (orphaned)
@@ -850,7 +839,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Failed to detect page count from PDF');
     });
@@ -893,7 +881,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('ImageMagick crashed');
 
@@ -922,7 +909,6 @@ describe('ChunkedPDFConverter', () => {
           mockOnComplete,
           false,
           {},
-          mockBuildOptions,
         ),
       ).rejects.toThrow('Callback error');
 
@@ -967,7 +953,6 @@ describe('ChunkedPDFConverter', () => {
         mockOnComplete,
         false,
         {},
-        mockBuildOptions,
       );
 
       // Merger should have been called with picFileOffsets [0, 3]

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -1,6 +1,6 @@
 import type { LoggerMethods } from '@heripo/logger';
 import type { DoclingDocument, TokenUsageReport } from '@heripo/model';
-import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
+import type { DoclingAPIClient } from 'docling-sdk';
 
 import type {
   ConversionCompleteCallback,
@@ -27,6 +27,7 @@ import { runJqFileJson } from '../utils/jq';
 import { LocalFileServer } from '../utils/local-file-server';
 import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { trackTaskProgress } from '../utils/task-progress-tracker';
+import { buildConversionOptions } from './conversion-options-builder';
 
 /** Configuration for chunked conversion */
 export interface ChunkedConversionConfig {
@@ -60,7 +61,6 @@ export class ChunkedPDFConverter {
    * @param onComplete - Callback invoked with the final output directory
    * @param cleanupAfterCallback - Whether to clean up the output directory after callback
    * @param options - PDF conversion options (chunked-specific fields are stripped internally)
-   * @param buildConversionOptions - Function to build Docling ConversionOptions from PDFConvertOptions
    * @param abortSignal - Optional abort signal for cancellation
    */
   async convertChunked(
@@ -69,7 +69,6 @@ export class ChunkedPDFConverter {
     onComplete: ConversionCompleteCallback,
     cleanupAfterCallback: boolean,
     options: PDFConvertOptions,
-    buildConversionOptions: (options: PDFConvertOptions) => ConversionOptions,
     abortSignal?: AbortSignal,
   ): Promise<TokenUsageReport | null> {
     const pdfPath = url.slice(7); // Remove 'file://' prefix
@@ -118,7 +117,6 @@ export class ChunkedPDFConverter {
           httpUrl,
           chunkDir,
           options,
-          buildConversionOptions,
         );
 
         chunkDocuments.push(doc);
@@ -213,7 +211,6 @@ export class ChunkedPDFConverter {
     httpUrl: string,
     chunkDir: string,
     options: PDFConvertOptions,
-    buildConversionOptions: (options: PDFConvertOptions) => ConversionOptions,
   ): Promise<DoclingDocument> {
     const chunkLabel = `Chunk ${chunkIndex + 1}/${totalChunks} (pages ${startPage}-${endPage})`;
 

--- a/packages/pdf-parser/src/core/conversion-options-builder.test.ts
+++ b/packages/pdf-parser/src/core/conversion-options-builder.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'vitest';
+
+import { buildConversionOptions } from './conversion-options-builder';
+
+describe('buildConversionOptions', () => {
+  test('should build default conversion options', () => {
+    const result = buildConversionOptions({});
+
+    expect(result).toEqual({
+      to_formats: ['json', 'html'],
+      image_export_mode: 'embedded',
+      ocr_engine: 'ocrmac',
+      ocr_options: {
+        kind: 'ocrmac',
+        lang: ['ko-KR', 'en-US'],
+        recognition: 'accurate',
+        framework: 'livetext',
+      },
+      generate_picture_images: true,
+      do_picture_classification: true,
+      do_picture_description: true,
+      generate_page_images: false,
+      images_scale: 2.0,
+      force_ocr: true,
+      accelerator_options: {
+        device: 'mps',
+        num_threads: undefined,
+      },
+    });
+  });
+
+  test('should use custom ocr_lang when provided', () => {
+    const result = buildConversionOptions({
+      ocr_lang: ['ja-JP', 'en-US'],
+    });
+
+    expect(result.ocr_options).toEqual({
+      kind: 'ocrmac',
+      lang: ['ja-JP', 'en-US'],
+      recognition: 'accurate',
+      framework: 'livetext',
+    });
+  });
+
+  test('should place num_threads in accelerator_options', () => {
+    const result = buildConversionOptions({ num_threads: 8 });
+
+    expect(result.accelerator_options).toEqual({
+      device: 'mps',
+      num_threads: 8,
+    });
+    expect(result).not.toHaveProperty('num_threads');
+  });
+
+  test('should include document_timeout when provided', () => {
+    const result = buildConversionOptions({ document_timeout: 600 });
+
+    expect(result.document_timeout).toBe(600);
+  });
+
+  test('should not include document_timeout when not provided', () => {
+    const result = buildConversionOptions({});
+
+    expect(result).not.toHaveProperty('document_timeout');
+  });
+
+  test('should include document_timeout when value is 0', () => {
+    const result = buildConversionOptions({ document_timeout: 0 });
+
+    expect(result.document_timeout).toBe(0);
+  });
+
+  test('should omit all pdf-parser-specific fields', () => {
+    const result = buildConversionOptions({
+      num_threads: 4,
+      document_timeout: 300,
+      forceImagePdf: true,
+      strategySamplerModel: {} as any,
+      vlmProcessorModel: {} as any,
+      skipSampling: true,
+      forcedMethod: 'vlm' as any,
+      aggregator: {} as any,
+      onTokenUsage: (() => {}) as any,
+      chunkedConversion: true,
+      chunkSize: 20,
+      chunkMaxRetries: 5,
+      documentValidationModel: {} as any,
+    });
+
+    expect(result).not.toHaveProperty('forceImagePdf');
+    expect(result).not.toHaveProperty('strategySamplerModel');
+    expect(result).not.toHaveProperty('vlmProcessorModel');
+    expect(result).not.toHaveProperty('skipSampling');
+    expect(result).not.toHaveProperty('forcedMethod');
+    expect(result).not.toHaveProperty('aggregator');
+    expect(result).not.toHaveProperty('onTokenUsage');
+    expect(result).not.toHaveProperty('chunkedConversion');
+    expect(result).not.toHaveProperty('chunkSize');
+    expect(result).not.toHaveProperty('chunkMaxRetries');
+    expect(result).not.toHaveProperty('documentValidationModel');
+  });
+
+  test('should pass through unknown options via spread', () => {
+    const result = buildConversionOptions({
+      ocr_lang: ['ko-KR'],
+      page_range: [1, 10],
+    } as any);
+
+    expect(result.page_range).toEqual([1, 10]);
+  });
+});

--- a/packages/pdf-parser/src/core/conversion-options-builder.ts
+++ b/packages/pdf-parser/src/core/conversion-options-builder.ts
@@ -1,0 +1,60 @@
+import type { ConversionOptions } from 'docling-sdk';
+
+import type { PDFConvertOptions } from './pdf-converter';
+
+import { omit } from 'es-toolkit';
+
+/**
+ * Build Docling ConversionOptions from PDFConvertOptions.
+ * Strips pdf-parser-specific fields and configures OCR settings.
+ */
+export function buildConversionOptions(
+  options: PDFConvertOptions,
+): ConversionOptions {
+  return {
+    ...omit(options, [
+      'num_threads',
+      'document_timeout',
+      'forceImagePdf',
+      'strategySamplerModel',
+      'vlmProcessorModel',
+      'skipSampling',
+      'forcedMethod',
+      'aggregator',
+      'onTokenUsage',
+      'chunkedConversion',
+      'chunkSize',
+      'chunkMaxRetries',
+      'documentValidationModel',
+    ]),
+    to_formats: ['json', 'html'],
+    image_export_mode: 'embedded',
+    ocr_engine: 'ocrmac',
+    ocr_options: {
+      kind: 'ocrmac',
+      lang: options.ocr_lang ?? ['ko-KR', 'en-US'],
+      recognition: 'accurate',
+      framework: 'livetext',
+    },
+    generate_picture_images: true,
+    do_picture_classification: true,
+    do_picture_description: true,
+    generate_page_images: false, // Page images are rendered by PageRenderer (ImageMagick) after conversion
+    images_scale: 2.0,
+    /**
+     * While disabling this option yields the most accurate text extraction for readable PDFs,
+     * text layers overlaid on images or drawings can introduce noise when not merged properly.
+     * In practice, archaeological report PDFs almost always contain such overlapping cases.
+     * Enabling force_ocr mitigates this risk. Although OCR may introduce minor errors compared
+     * to direct text extraction, the accuracy remains high since the source is digital, not scanned paper.
+     */
+    force_ocr: true,
+    accelerator_options: {
+      device: 'mps',
+      num_threads: options.num_threads,
+    },
+    ...(options.document_timeout !== undefined && {
+      document_timeout: options.document_timeout,
+    }),
+  };
+}

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -1,7 +1,6 @@
 import type { LoggerMethods } from '@heripo/logger';
 import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
 
-import { omit } from 'es-toolkit';
 import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -15,11 +14,12 @@ import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
+import { buildConversionOptions } from './conversion-options-builder';
 import { ImagePdfConverter } from './image-pdf-converter';
 import { PDFConverter } from './pdf-converter';
 
-vi.mock('es-toolkit', () => ({
-  omit: vi.fn(),
+vi.mock('./conversion-options-builder', () => ({
+  buildConversionOptions: vi.fn(),
 }));
 
 vi.mock('./chunked-pdf-converter', () => ({
@@ -98,10 +98,23 @@ describe('PDFConverter', () => {
     vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
     vi.spyOn(Date, 'now').mockReturnValue(1000000);
 
-    vi.mocked(omit).mockImplementation((obj, keys) => {
-      const result = { ...obj };
-      keys.forEach((key) => delete result[key as keyof typeof result]);
-      return result;
+    vi.mocked(buildConversionOptions).mockReturnValue({
+      to_formats: ['json', 'html'],
+      image_export_mode: 'embedded',
+      ocr_engine: 'ocrmac',
+      ocr_options: {
+        kind: 'ocrmac',
+        lang: ['ko-KR', 'en-US'],
+        recognition: 'accurate',
+        framework: 'livetext',
+      },
+      generate_picture_images: true,
+      do_picture_classification: true,
+      do_picture_description: true,
+      generate_page_images: false,
+      images_scale: 2.0,
+      force_ocr: true,
+      accelerator_options: { device: 'mps', num_threads: 4 },
     });
 
     vi.mocked(join).mockImplementation((...args) => args.join('/'));
@@ -169,7 +182,6 @@ describe('PDFConverter', () => {
           expect.any(Function),
           false,
           expect.objectContaining({ chunkedConversion: true }),
-          expect.any(Function),
           undefined,
         );
       });
@@ -191,26 +203,6 @@ describe('PDFConverter', () => {
         );
       });
 
-      test('passes a working buildConversionOptions callback to ChunkedPDFConverter', async () => {
-        await converter.convert(
-          'file:///test/input.pdf',
-          'report-1',
-          vi.fn(),
-          false,
-          { chunkedConversion: true },
-        );
-
-        // Capture the buildConversionOptions callback (6th argument)
-        const buildFn = mockConvertChunked.mock.calls[0][5] as (
-          opts: any,
-        ) => any;
-        expect(typeof buildFn).toBe('function');
-
-        // Invoke it and verify it returns conversion options
-        const result = buildFn({ page_range: [1, 10] });
-        expect(result).toBeDefined();
-      });
-
       test('does not use chunked conversion for non-file:// URLs', async () => {
         const mockTask = createMockTask();
         vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
@@ -225,123 +217,6 @@ describe('PDFConverter', () => {
 
         expect(ChunkedPDFConverter).not.toHaveBeenCalled();
       });
-    });
-  });
-
-  describe('buildConversionOptions', () => {
-    test('should build conversion options with default values', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        { num_threads: 4 },
-      );
-
-      expect(client.convertSourceAsync).toHaveBeenCalledWith({
-        sources: [{ kind: 'http', url: 'http://test.com/doc.pdf' }],
-        options: {
-          to_formats: ['json', 'html'],
-          image_export_mode: 'embedded',
-          ocr_engine: 'ocrmac',
-          ocr_options: {
-            kind: 'ocrmac',
-            lang: ['ko-KR', 'en-US'],
-            recognition: 'accurate',
-            framework: 'livetext',
-          },
-          generate_picture_images: true,
-          do_picture_classification: true,
-          do_picture_description: true,
-          generate_page_images: false,
-          images_scale: 2.0,
-          force_ocr: true,
-          accelerator_options: {
-            device: 'mps',
-            num_threads: 4,
-          },
-        },
-        target: { kind: 'zip' },
-      });
-    });
-
-    test('should omit num_threads from options and use in accelerator_options', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        { num_threads: 8 },
-      );
-
-      const callArgs = vi.mocked(client.convertSourceAsync).mock.calls[0][0];
-      expect(callArgs.options).toEqual({
-        to_formats: ['json', 'html'],
-        image_export_mode: 'embedded',
-        ocr_engine: 'ocrmac',
-        ocr_options: {
-          kind: 'ocrmac',
-          lang: ['ko-KR', 'en-US'],
-          recognition: 'accurate',
-          framework: 'livetext',
-        },
-        generate_picture_images: true,
-        do_picture_classification: true,
-        do_picture_description: true,
-        generate_page_images: false,
-        images_scale: 2.0,
-        force_ocr: true,
-        accelerator_options: {
-          device: 'mps',
-          num_threads: 8,
-        },
-      });
-    });
-
-    test('should include document_timeout when provided', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        { num_threads: 4, document_timeout: 600 },
-      );
-
-      const callArgs = vi.mocked(client.convertSourceAsync).mock.calls[0][0];
-      expect(callArgs.options).toEqual(
-        expect.objectContaining({
-          document_timeout: 600,
-        }),
-      );
-    });
-
-    test('should not include document_timeout when not provided', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        { num_threads: 4 },
-      );
-
-      const callArgs = vi.mocked(client.convertSourceAsync).mock.calls[0][0];
-      expect(callArgs.options).not.toHaveProperty('document_timeout');
     });
   });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -8,7 +8,6 @@ import type {
 } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { omit } from 'es-toolkit';
 import { copyFileSync, existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -26,6 +25,7 @@ import { renderAndUpdatePageImages } from '../utils/page-image-updater';
 import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
+import { buildConversionOptions } from './conversion-options-builder';
 import { ImagePdfConverter } from './image-pdf-converter';
 
 /**
@@ -160,7 +160,6 @@ export class PDFConverter {
         onComplete,
         cleanupAfterCallback,
         options,
-        (opts) => this.buildConversionOptions(opts),
         abortSignal,
       );
     }
@@ -551,7 +550,7 @@ export class PDFConverter {
     abortSignal?: AbortSignal,
   ): Promise<TokenUsageReport | null> {
     const startTime = Date.now();
-    const conversionOptions = this.buildConversionOptions(options);
+    const conversionOptions = buildConversionOptions(options);
 
     this.logger.info(
       `[PDFConverter] OCR languages: ${JSON.stringify(conversionOptions.ocr_options?.lang)}`,
@@ -668,57 +667,6 @@ export class PDFConverter {
     }
 
     return null;
-  }
-
-  private buildConversionOptions(
-    options: PDFConvertOptions,
-  ): ConversionOptions {
-    return {
-      ...omit(options, [
-        'num_threads',
-        'document_timeout',
-        'forceImagePdf',
-        'strategySamplerModel',
-        'vlmProcessorModel',
-        'skipSampling',
-        'forcedMethod',
-        'aggregator',
-        'onTokenUsage',
-        'chunkedConversion',
-        'chunkSize',
-        'chunkMaxRetries',
-        'documentValidationModel',
-      ]),
-      to_formats: ['json', 'html'],
-      image_export_mode: 'embedded',
-      ocr_engine: 'ocrmac',
-      ocr_options: {
-        kind: 'ocrmac',
-        lang: options.ocr_lang ?? ['ko-KR', 'en-US'],
-        recognition: 'accurate',
-        framework: 'livetext',
-      },
-      generate_picture_images: true,
-      do_picture_classification: true,
-      do_picture_description: true,
-      generate_page_images: false, // Page images are rendered by PageRenderer (ImageMagick) after conversion
-      images_scale: 2.0,
-      /**
-       * While disabling this option yields the most accurate text extraction for readable PDFs,
-       * text layers overlaid on images or drawings can introduce noise when not merged properly.
-       * In practice, archaeological report PDFs almost always contain such overlapping cases.
-       * Enabling force_ocr mitigates this risk. Although OCR may introduce minor errors compared
-       * to direct text extraction, the accuracy remains high since the source is digital, not scanned paper.
-       */
-      force_ocr: true,
-      accelerator_options: {
-        device: 'mps',
-        num_threads: options.num_threads,
-      },
-      ...(options.document_timeout !== undefined && {
-        document_timeout: options.document_timeout,
-      }),
-    };
   }
 
   private async startConversionTask(


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract the private `buildConversionOptions` method from `PDFConverter` into a standalone, reusable utility function. This eliminates the need to pass the builder as a callback parameter to `ChunkedPDFConverter`, simplifying the API surface and making conversion option logic independently testable.

## Changes

- Add `conversion-options-builder.ts` with the extracted `buildConversionOptions` function that strips pdf-parser-specific fields and configures Docling OCR settings
- Add `conversion-options-builder.test.ts` with dedicated unit tests covering default options, custom OCR languages, `num_threads`, `document_timeout`, field omission, and passthrough behavior
- Remove `buildConversionOptions` private method from `PDFConverter` and replace with import of the new utility
- Remove the `buildConversionOptions` callback parameter from `ChunkedPDFConverter.convertChunked()` — it now imports the utility directly
- Update `chunked-pdf-converter.test.ts` to mock the new module instead of passing a mock callback, removing `mockBuildOptions` from all test call sites
- Update `pdf-converter.test.ts` to mock `conversion-options-builder` instead of `es-toolkit/omit`, and remove integration-style `buildConversionOptions` tests that are now covered by the dedicated test file

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
