### PR TITLE
refactor(pdf-parser): extract conversion and strategy logic into dedicated modules

### DIFF
--- a/packages/pdf-parser/src/core/docling-conversion-executor.test.ts
+++ b/packages/pdf-parser/src/core/docling-conversion-executor.test.ts
@@ -1,0 +1,611 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
+
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ImageExtractor } from '../processors/image-extractor';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
+import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
+import { buildConversionOptions } from './conversion-options-builder';
+import { DoclingConversionExecutor } from './docling-conversion-executor';
+
+vi.mock('./conversion-options-builder', () => ({
+  buildConversionOptions: vi.fn(),
+}));
+
+vi.mock('../utils/local-file-server', () => ({
+  LocalFileServer: vi.fn(),
+}));
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn(),
+}));
+
+vi.mock('../utils/docling-result-downloader', () => ({
+  downloadTaskResult: vi.fn(),
+}));
+
+vi.mock('../processors/image-extractor', () => ({
+  ImageExtractor: {
+    extractAndSaveDocumentsFromZip: vi.fn(),
+  },
+}));
+
+vi.mock('../utils/page-image-updater', () => ({
+  renderAndUpdatePageImages: vi.fn(),
+}));
+
+vi.mock('../utils/task-progress-tracker', () => ({
+  trackTaskProgress: vi.fn(),
+}));
+
+function createMockTask(): AsyncConversionTask {
+  const task = {
+    taskId: 'task-123',
+    poll: vi.fn().mockResolvedValue({
+      task_id: 'task-123',
+      task_status: 'success',
+    }),
+    getResult: vi.fn().mockResolvedValue({
+      document: {},
+      status: 'success',
+      processing_time: 0,
+    }),
+  };
+  return task as unknown as AsyncConversionTask;
+}
+
+describe('DoclingConversionExecutor', () => {
+  let logger: LoggerMethods;
+  let client: DoclingAPIClient;
+  let executor: DoclingConversionExecutor;
+  const DEFAULT_TIMEOUT = 600_000;
+
+  beforeEach(() => {
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    client = {
+      convertSourceAsync: vi.fn(),
+      getTaskResultFile: vi.fn(),
+      getConfig: vi.fn().mockReturnValue({ baseUrl: 'http://localhost:5001' }),
+    } as unknown as DoclingAPIClient;
+
+    executor = new DoclingConversionExecutor(logger, client, DEFAULT_TIMEOUT);
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
+    vi.spyOn(Date, 'now').mockReturnValue(1000000);
+
+    vi.mocked(buildConversionOptions).mockReturnValue({
+      to_formats: ['json', 'html'],
+      image_export_mode: 'embedded',
+      ocr_engine: 'ocrmac',
+      ocr_options: {
+        kind: 'ocrmac',
+        lang: ['ko-KR', 'en-US'],
+        recognition: 'accurate',
+        framework: 'livetext',
+      },
+      generate_picture_images: true,
+      do_picture_classification: true,
+      do_picture_description: true,
+      generate_page_images: false,
+      images_scale: 2.0,
+      force_ocr: true,
+      accelerator_options: { device: 'mps', num_threads: 4 },
+    });
+
+    vi.mocked(join).mockImplementation((...args) => args.join('/'));
+
+    vi.mocked(LocalFileServer).mockImplementation(function () {
+      return {
+        start: vi.fn().mockResolvedValue('http://127.0.0.1:12345/test.pdf'),
+        stop: vi.fn().mockResolvedValue(undefined),
+      } as unknown as LocalFileServer;
+    });
+  });
+
+  describe('execute', () => {
+    test('should successfully execute conversion with http URL and cleanupAfterCallback=false', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      const result = await executor.execute(
+        'http://test.com/doc.pdf',
+        'report123',
+        onComplete,
+        false,
+        {},
+      );
+
+      expect(result).toBeNull();
+      expect(client.convertSourceAsync).toHaveBeenCalled();
+      expect(downloadTaskResult).toHaveBeenCalled();
+      expect(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).toHaveBeenCalledWith(
+        logger,
+        '/test/cwd/result.zip',
+        '/test/cwd/result_extracted',
+        '/test/cwd/output/report123',
+      );
+      expect(onComplete).toHaveBeenCalledWith('/test/cwd/output/report123');
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
+        force: true,
+      });
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
+        recursive: true,
+        force: true,
+      });
+      expect(rmSync).not.toHaveBeenCalledWith(
+        '/test/cwd/output/report123',
+        expect.any(Object),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Output preserved at:',
+        '/test/cwd/output/report123',
+      );
+    });
+
+    test('should cleanup output directory when cleanupAfterCallback=true', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report456',
+        onComplete,
+        true,
+        {},
+      );
+
+      expect(onComplete).toHaveBeenCalledWith('/test/cwd/output/report456');
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/output/report456', {
+        recursive: true,
+        force: true,
+      });
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Cleaning up output directory:',
+        '/test/cwd/output/report456',
+      );
+    });
+
+    test('should cleanup temporary files even if callback throws error', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockRejectedValue(new Error('Callback error'));
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report789',
+          onComplete,
+          false,
+          {},
+        ),
+      ).rejects.toThrow('Callback error');
+
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
+        force: true,
+      });
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    test('should handle non-existent files during cleanup', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report-no-files',
+        onComplete,
+        true,
+        {},
+      );
+
+      expect(rmSync).not.toHaveBeenCalled();
+    });
+
+    test('should handle conversion task failure', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(
+        new Error('Task failed: Processing failed'),
+      );
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report-fail',
+          vi.fn(),
+          false,
+          {},
+        ),
+      ).rejects.toThrow('Task failed: Processing failed');
+    });
+
+    test('should handle download failure', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(downloadTaskResult).mockRejectedValue(
+        new Error('Download failed'),
+      );
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report-download-fail',
+          vi.fn(),
+          false,
+          {},
+        ),
+      ).rejects.toThrow('Download failed');
+    });
+
+    test('should handle processing failure and cleanup', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockRejectedValue(new Error('Processing failed'));
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report-process-fail',
+          vi.fn(),
+          false,
+          {},
+        ),
+      ).rejects.toThrow('Processing failed');
+
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
+        force: true,
+      });
+      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
+        recursive: true,
+        force: true,
+      });
+    });
+
+    test('should log OCR languages and conversion info', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('OCR languages:'),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Converting document with Async Source API...',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Server will download from URL directly',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Results will be returned as ZIP to avoid memory limits',
+      );
+    });
+
+    test('should log completion time on success', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Conversion completed successfully!',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Total time:',
+        0,
+        'ms',
+      );
+    });
+  });
+
+  describe('resolveUrl', () => {
+    test('should start local server for file:// URLs', async () => {
+      const result = await executor.resolveUrl('file:///test/doc.pdf');
+
+      expect(LocalFileServer).toHaveBeenCalled();
+      expect(result.httpUrl).toBe('http://127.0.0.1:12345/test.pdf');
+      expect(result.server).toBeDefined();
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Started local file server:',
+        'http://127.0.0.1:12345/test.pdf',
+      );
+    });
+
+    test('should return http URL as-is', async () => {
+      const result = await executor.resolveUrl('http://test.com/doc.pdf');
+
+      expect(LocalFileServer).not.toHaveBeenCalled();
+      expect(result.httpUrl).toBe('http://test.com/doc.pdf');
+      expect(result.server).toBeUndefined();
+    });
+
+    test('should stop local server on execute error', async () => {
+      const mockStop = vi.fn().mockResolvedValue(undefined);
+      vi.mocked(LocalFileServer).mockImplementation(function () {
+        return {
+          start: vi.fn().mockResolvedValue('http://127.0.0.1:12345/test.pdf'),
+          stop: mockStop,
+        } as unknown as LocalFileServer;
+      });
+
+      const mockTask = createMockTask();
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(trackTaskProgress).mockRejectedValue(new Error('Task failed'));
+
+      await expect(
+        executor.execute(
+          'file:///test/doc.pdf',
+          'report-server-stop',
+          vi.fn(),
+          false,
+          {},
+        ),
+      ).rejects.toThrow('Task failed');
+
+      expect(mockStop).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Stopping local file server...',
+      );
+    });
+  });
+
+  describe('startConversionTask', () => {
+    test('should start conversion task and log task ID', async () => {
+      const mockTask = createMockTask();
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+
+      const result = await executor.startConversionTask(
+        'http://test.com/doc.pdf',
+        { to_formats: ['json'] },
+      );
+
+      expect(client.convertSourceAsync).toHaveBeenCalledWith({
+        sources: [{ kind: 'http', url: 'http://test.com/doc.pdf' }],
+        options: { to_formats: ['json'] },
+        target: { kind: 'zip' },
+      });
+      expect(result).toBe(mockTask);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Task created: task-123',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Polling for progress...',
+      );
+    });
+  });
+
+  describe('trackTaskProgress delegation', () => {
+    test('should call trackTaskProgress with showDetailedProgress', async () => {
+      const mockTask = createMockTask();
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(trackTaskProgress).toHaveBeenCalledWith(
+        mockTask,
+        DEFAULT_TIMEOUT,
+        logger,
+        '[PDFConverter]',
+        { showDetailedProgress: true },
+      );
+    });
+  });
+
+  describe('renderPageImages', () => {
+    test('should call renderAndUpdatePageImages for file:// URLs', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'file:///test/doc.pdf',
+        'report-render',
+        onComplete,
+        false,
+        {},
+      );
+
+      expect(renderAndUpdatePageImages).toHaveBeenCalledWith(
+        '/test/doc.pdf',
+        '/test/cwd/output/report-render',
+        logger,
+        '[PDFConverter]',
+      );
+    });
+
+    test('should skip rendering and log warning for http:// URLs', async () => {
+      const mockTask = createMockTask();
+      const onComplete = vi.fn().mockResolvedValue(undefined);
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report-skip-render',
+        onComplete,
+        false,
+        {},
+      );
+
+      expect(renderAndUpdatePageImages).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
+      );
+    });
+  });
+
+  describe('abort signal handling', () => {
+    test('should throw AbortError when aborted after docling task completes', async () => {
+      const abortController = new AbortController();
+      const mockTask = createMockTask();
+
+      vi.mocked(trackTaskProgress).mockImplementation(async () => {
+        abortController.abort();
+      });
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report-abort-docling',
+          vi.fn(),
+          false,
+          {},
+          abortController.signal,
+        ),
+      ).rejects.toThrow('PDF conversion was aborted');
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Conversion aborted after docling completion',
+      );
+    });
+
+    test('should throw AbortError when aborted before callback', async () => {
+      const mockTask = createMockTask();
+      const abortController = new AbortController();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockImplementation(async () => {
+        abortController.abort();
+      });
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await expect(
+        executor.execute(
+          'http://test.com/doc.pdf',
+          'report-abort-callback',
+          vi.fn(),
+          false,
+          {},
+          abortController.signal,
+        ),
+      ).rejects.toThrow('PDF conversion was aborted');
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[PDFConverter] Conversion aborted before callback',
+      );
+    });
+  });
+
+  describe('processConvertedFiles', () => {
+    test('should call ImageExtractor with correct paths', async () => {
+      const mockTask = createMockTask();
+
+      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
+      vi.mocked(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).mockResolvedValue(undefined);
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await executor.execute(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+      );
+
+      expect(
+        ImageExtractor.extractAndSaveDocumentsFromZip,
+      ).toHaveBeenCalledWith(
+        logger,
+        '/test/cwd/result.zip',
+        '/test/cwd/result_extracted',
+        '/test/cwd/output/report123',
+      );
+    });
+  });
+});

--- a/packages/pdf-parser/src/core/docling-conversion-executor.ts
+++ b/packages/pdf-parser/src/core/docling-conversion-executor.ts
@@ -1,0 +1,230 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type {
+  AsyncConversionTask,
+  ConversionOptions,
+  DoclingAPIClient,
+} from 'docling-sdk';
+
+import type {
+  ConversionCompleteCallback,
+  PDFConvertOptions,
+} from './pdf-converter';
+
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { ImageExtractor } from '../processors/image-extractor';
+import { downloadTaskResult } from '../utils/docling-result-downloader';
+import { LocalFileServer } from '../utils/local-file-server';
+import { renderAndUpdatePageImages } from '../utils/page-image-updater';
+import { trackTaskProgress } from '../utils/task-progress-tracker';
+import { buildConversionOptions } from './conversion-options-builder';
+
+/**
+ * Executes a single-pass Docling conversion: task -> poll -> download -> extract -> render.
+ */
+export class DoclingConversionExecutor {
+  constructor(
+    private readonly logger: LoggerMethods,
+    private readonly client: DoclingAPIClient,
+    private readonly timeout: number,
+  ) {}
+
+  /**
+   * Execute a full Docling conversion pipeline.
+   *
+   * Steps: resolve URL -> start task -> poll progress -> download result ->
+   * extract files -> render page images -> invoke callback -> cleanup.
+   */
+  async execute(
+    url: string,
+    reportId: string,
+    onComplete: ConversionCompleteCallback,
+    cleanupAfterCallback: boolean,
+    options: PDFConvertOptions,
+    abortSignal?: AbortSignal,
+  ): Promise<null> {
+    const startTime = Date.now();
+    const conversionOptions = buildConversionOptions(options);
+
+    this.logger.info(
+      `[PDFConverter] OCR languages: ${JSON.stringify(conversionOptions.ocr_options?.lang)}`,
+    );
+    this.logger.info(
+      '[PDFConverter] Converting document with Async Source API...',
+    );
+    this.logger.info('[PDFConverter] Server will download from URL directly');
+    this.logger.info(
+      '[PDFConverter] Results will be returned as ZIP to avoid memory limits',
+    );
+
+    // Resolve URL (start local server for file:// URLs)
+    const { httpUrl, server } = await this.resolveUrl(url);
+
+    try {
+      const task = await this.startConversionTask(httpUrl, conversionOptions);
+      await trackTaskProgress(
+        task,
+        this.timeout,
+        this.logger,
+        '[PDFConverter]',
+        {
+          showDetailedProgress: true,
+        },
+      );
+
+      // Check abort after docling task completes
+      if (abortSignal?.aborted) {
+        this.logger.info(
+          '[PDFConverter] Conversion aborted after docling completion',
+        );
+        const error = new Error('PDF conversion was aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+
+      const cwd = process.cwd();
+      const zipPath = join(cwd, 'result.zip');
+      await downloadTaskResult(
+        this.client,
+        task.taskId,
+        zipPath,
+        this.logger,
+        '[PDFConverter]',
+      );
+    } finally {
+      // Stop local file server if started
+      if (server) {
+        this.logger.info('[PDFConverter] Stopping local file server...');
+        await server.stop();
+      }
+    }
+
+    const cwd = process.cwd();
+    const zipPath = join(cwd, 'result.zip');
+    const extractDir = join(cwd, 'result_extracted');
+    const outputDir = join(cwd, 'output', reportId);
+
+    try {
+      await this.processConvertedFiles(zipPath, extractDir, outputDir);
+
+      // Render page images using ImageMagick (replaces Docling's page image generation)
+      if (url.startsWith('file://')) {
+        await renderAndUpdatePageImages(
+          url.slice(7),
+          outputDir,
+          this.logger,
+          '[PDFConverter]',
+        );
+      } else {
+        this.logger.warn(
+          '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
+        );
+      }
+
+      // Check abort before callback
+      if (abortSignal?.aborted) {
+        this.logger.info('[PDFConverter] Conversion aborted before callback');
+        const error = new Error('PDF conversion was aborted');
+        error.name = 'AbortError';
+        throw error;
+      }
+
+      // Execute callback with absolute output path
+      this.logger.info('[PDFConverter] Executing completion callback...');
+      await onComplete(outputDir);
+
+      const duration = Date.now() - startTime;
+      this.logger.info('[PDFConverter] Conversion completed successfully!');
+      this.logger.info('[PDFConverter] Total time:', duration, 'ms');
+    } finally {
+      // Clean up temporary files (always cleanup temp files)
+      this.logger.info('[PDFConverter] Cleaning up temporary files...');
+      if (existsSync(zipPath)) {
+        rmSync(zipPath, { force: true });
+      }
+      if (existsSync(extractDir)) {
+        rmSync(extractDir, { recursive: true, force: true });
+      }
+
+      // Cleanup output directory only if requested
+      if (cleanupAfterCallback) {
+        this.logger.info(
+          '[PDFConverter] Cleaning up output directory:',
+          outputDir,
+        );
+        if (existsSync(outputDir)) {
+          rmSync(outputDir, { recursive: true, force: true });
+        }
+      } else {
+        this.logger.info('[PDFConverter] Output preserved at:', outputDir);
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Start a local file server for file:// URLs.
+   *
+   * @param url URL to check (file:// or http://)
+   * @returns Object with httpUrl and optional server to stop later
+   */
+  async resolveUrl(
+    url: string,
+  ): Promise<{ httpUrl: string; server?: LocalFileServer }> {
+    if (url.startsWith('file://')) {
+      const filePath = url.slice(7); // Remove 'file://' prefix
+      const server = new LocalFileServer();
+      const httpUrl = await server.start(filePath);
+
+      this.logger.info('[PDFConverter] Started local file server:', httpUrl);
+
+      return { httpUrl, server };
+    }
+
+    return { httpUrl: url };
+  }
+
+  /**
+   * Start an async conversion task on the Docling server.
+   */
+  async startConversionTask(
+    url: string,
+    conversionOptions: ConversionOptions,
+  ): Promise<AsyncConversionTask> {
+    const task = await this.client.convertSourceAsync({
+      sources: [
+        {
+          kind: 'http',
+          url,
+        },
+      ],
+      options: conversionOptions,
+      target: {
+        kind: 'zip',
+      },
+    });
+
+    this.logger.info(`[PDFConverter] Task created: ${task.taskId}`);
+    this.logger.info('[PDFConverter] Polling for progress...');
+
+    return task;
+  }
+
+  /**
+   * Extract converted documents from ZIP and save to output directory.
+   */
+  private async processConvertedFiles(
+    zipPath: string,
+    extractDir: string,
+    outputDir: string,
+  ): Promise<void> {
+    await ImageExtractor.extractAndSaveDocumentsFromZip(
+      this.logger,
+      zipPath,
+      extractDir,
+      outputDir,
+    );
+  }
+}

--- a/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
@@ -2,37 +2,38 @@ import type { LoggerMethods } from '@heripo/logger';
 import type { DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { existsSync, rmSync } from 'node:fs';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { PageRenderer } from '../processors/page-renderer';
-import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
 import { PDFConverter } from './pdf-converter';
+import { StrategyResolver } from './strategy-resolver';
 import { VlmConversionPipeline } from './vlm-conversion-pipeline';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
-  rmSync: vi.fn(),
-}));
-
-vi.mock('node:path', () => ({
-  join: vi.fn((...args: string[]) => args.join('/')),
-}));
-
-vi.mock('../samplers/ocr-strategy-sampler', () => ({
-  OcrStrategySampler: vi.fn(),
-}));
-
-vi.mock('../processors/page-renderer', () => ({
-  PageRenderer: vi.fn(),
-}));
-
-vi.mock('../processors/pdf-text-extractor', () => ({
-  PdfTextExtractor: vi.fn(),
+vi.mock('./strategy-resolver', () => ({
+  StrategyResolver: vi.fn(),
 }));
 
 vi.mock('./vlm-conversion-pipeline', () => ({
   VlmConversionPipeline: vi.fn(),
+}));
+
+vi.mock('./docling-conversion-executor', () => ({
+  DoclingConversionExecutor: vi.fn(),
+}));
+
+vi.mock('./chunked-pdf-converter', () => ({
+  ChunkedPDFConverter: vi.fn(),
+}));
+
+vi.mock('./image-pdf-converter', () => ({
+  ImagePdfConverter: vi.fn(),
+}));
+
+vi.mock('../validators/document-type-validator', () => ({
+  DocumentTypeValidator: vi.fn(),
+}));
+
+vi.mock('../processors/pdf-text-extractor', () => ({
+  PdfTextExtractor: vi.fn(),
 }));
 
 const mockModel = { modelId: 'test-model' } as any;
@@ -43,7 +44,7 @@ describe('PDFConverter.convertWithStrategy', () => {
   let client: DoclingAPIClient;
   let converter: PDFConverter;
   let mockOnComplete: Mock;
-  let mockSamplerInstance: { sample: Mock };
+  let mockResolve: Mock;
   let mockWrapCallback: Mock;
 
   beforeEach(() => {
@@ -66,22 +67,15 @@ describe('PDFConverter.convertWithStrategy', () => {
 
     mockOnComplete = vi.fn();
 
-    vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
-
-    // Default: existsSync returns false (no cleanup needed)
-    vi.mocked(existsSync).mockReturnValue(false);
-
-    // Mock OcrStrategySampler constructor
-    mockSamplerInstance = {
-      sample: vi.fn().mockResolvedValue({
-        method: 'ocrmac',
-        reason: 'No Korean-Hanja mix detected',
-        sampledPages: 3,
-        totalPages: 10,
-      }),
-    };
-    vi.mocked(OcrStrategySampler).mockImplementation(function () {
-      return mockSamplerInstance as any;
+    // Mock StrategyResolver
+    mockResolve = vi.fn().mockResolvedValue({
+      method: 'ocrmac',
+      reason: 'Forced: ocrmac',
+      sampledPages: 0,
+      totalPages: 0,
+    });
+    vi.mocked(StrategyResolver).mockImplementation(function () {
+      return { resolve: mockResolve } as any;
     });
 
     // Mock VlmConversionPipeline
@@ -91,143 +85,9 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
   });
 
-  describe('strategy determination', () => {
-    test('uses forced method when forcedMethod is specified', async () => {
-      // Spy on convert to prevent actual Docling call
+  describe('strategy resolver integration', () => {
+    test('creates StrategyResolver with logger and calls resolve', async () => {
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      expect(result.strategy.method).toBe('vlm');
-      expect(result.strategy.reason).toBe('Forced: vlm');
-      expect(result.strategy.sampledPages).toBe(0);
-      // Should not call sampler
-      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
-
-      convertSpy.mockRestore();
-    });
-
-    test('uses forced ocrmac method', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'ocrmac' },
-      );
-
-      expect(result.strategy.method).toBe('ocrmac');
-      expect(result.strategy.reason).toBe('Forced: ocrmac');
-      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
-
-      convertSpy.mockRestore();
-    });
-
-    test('runs sampling for language detection when forcedMethod + strategySamplerModel provided', async () => {
-      mockSamplerInstance.sample.mockResolvedValue({
-        method: 'ocrmac',
-        reason: 'No Korean-Hanja mix detected',
-        sampledPages: 3,
-        totalPages: 10,
-        detectedLanguages: ['ko-KR'],
-      });
-
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/report.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          strategySamplerModel: mockModel,
-          vlmProcessorModel: mockFallbackModel,
-          forcedMethod: 'vlm',
-        },
-      );
-
-      // Sampler should be called even with forcedMethod
-      expect(mockSamplerInstance.sample).toHaveBeenCalled();
-      // Method should be overridden to forced value
-      expect(result.strategy.method).toBe('vlm');
-      // Reason should combine forced label with original sampling reason
-      expect(result.strategy.reason).toBe(
-        'Forced: vlm (No Korean-Hanja mix detected)',
-      );
-      // Detected languages from sampling should be preserved
-      expect(result.strategy.detectedLanguages).toEqual(['ko-KR']);
-      // Sampling metadata should be preserved
-      expect(result.strategy.sampledPages).toBe(3);
-      expect(result.strategy.totalPages).toBe(10);
-
-      convertSpy.mockRestore();
-    });
-
-    test('defaults to ocrmac when skipSampling is true', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { skipSampling: true, strategySamplerModel: mockModel },
-      );
-
-      expect(result.strategy.method).toBe('ocrmac');
-      expect(result.strategy.reason).toBe('Sampling skipped');
-      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
-
-      convertSpy.mockRestore();
-    });
-
-    test('defaults to ocrmac when no strategySamplerModel', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {},
-      );
-
-      expect(result.strategy.method).toBe('ocrmac');
-      expect(result.strategy.reason).toBe('Sampling skipped');
-
-      convertSpy.mockRestore();
-    });
-
-    test('defaults to ocrmac for non-local URL (http)', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'http://example.com/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { strategySamplerModel: mockModel },
-      );
-
-      expect(result.strategy.method).toBe('ocrmac');
-      expect(result.strategy.reason).toBe('Non-local URL, sampling skipped');
-      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
-
-      convertSpy.mockRestore();
-    });
-
-    test('calls OcrStrategySampler when strategySamplerModel is provided', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const aggregator = new LLMTokenUsageAggregator();
       const abortController = new AbortController();
 
       await converter.convertWithStrategy(
@@ -235,67 +95,40 @@ describe('PDFConverter.convertWithStrategy', () => {
         'report-1',
         mockOnComplete,
         false,
-        { strategySamplerModel: mockModel, aggregator },
+        { forcedMethod: 'ocrmac' },
         abortController.signal,
       );
 
-      expect(OcrStrategySampler).toHaveBeenCalledWith(
-        logger,
-        expect.any(Object),
-        expect.any(Object),
-      );
-      expect(PageRenderer).toHaveBeenCalledWith(logger);
-      expect(mockSamplerInstance.sample).toHaveBeenCalledWith(
+      expect(StrategyResolver).toHaveBeenCalledWith(logger);
+      expect(mockResolve).toHaveBeenCalledWith(
         '/tmp/test.pdf',
-        '/test/cwd/output/report-1/_sampling',
-        mockModel,
-        { aggregator, abortSignal: abortController.signal },
+        'report-1',
+        expect.objectContaining({ forcedMethod: 'ocrmac' }),
+        abortController.signal,
       );
 
       convertSpy.mockRestore();
     });
 
-    test('cleans up sampling directory after sampling', async () => {
+    test('passes null pdfPath for non-file:// URLs', async () => {
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
-      vi.mocked(existsSync).mockReturnValue(true);
-
       await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
+        'http://example.com/test.pdf',
         'report-1',
         mockOnComplete,
         false,
-        { strategySamplerModel: mockModel },
+        { forcedMethod: 'ocrmac' },
       );
 
-      expect(rmSync).toHaveBeenCalledWith(
-        '/test/cwd/output/report-1/_sampling',
-        { recursive: true, force: true },
+      expect(mockResolve).toHaveBeenCalledWith(
+        null,
+        'report-1',
+        expect.any(Object),
+        undefined,
       );
 
       convertSpy.mockRestore();
-    });
-
-    test('cleans up sampling directory even when sampling fails', async () => {
-      vi.mocked(existsSync).mockReturnValue(true);
-      mockSamplerInstance.sample.mockRejectedValue(
-        new Error('Sampling failed'),
-      );
-
-      await expect(
-        converter.convertWithStrategy(
-          'file:///tmp/test.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          { strategySamplerModel: mockModel },
-        ),
-      ).rejects.toThrow('Sampling failed');
-
-      expect(rmSync).toHaveBeenCalledWith(
-        '/test/cwd/output/report-1/_sampling',
-        { recursive: true, force: true },
-      );
     });
   });
 
@@ -336,7 +169,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         { forcedMethod: 'ocrmac' },
       );
 
-      // Forced ocrmac skips sampling, so aggregator has no data → null
       expect(result.tokenUsageReport).toBeNull();
 
       convertSpy.mockRestore();
@@ -344,11 +176,17 @@ describe('PDFConverter.convertWithStrategy', () => {
   });
 
   describe('VLM path', () => {
-    test('creates VlmConversionPipeline and calls wrapCallback with correct args', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-      const abortController = new AbortController();
+    beforeEach(() => {
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+    });
 
-      mockSamplerInstance.sample.mockResolvedValue({
+    test('creates VlmConversionPipeline and calls wrapCallback with correct args', async () => {
+      mockResolve.mockResolvedValue({
         method: 'vlm',
         reason: 'Korean-Hanja mix detected',
         sampledPages: 2,
@@ -356,6 +194,9 @@ describe('PDFConverter.convertWithStrategy', () => {
         detectedLanguages: ['ko-KR'],
         koreanHanjaMixPages: [1, 3],
       });
+
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
+      const abortController = new AbortController();
 
       await converter.convertWithStrategy(
         'file:///tmp/report.pdf',
@@ -399,7 +240,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
-      // convertWithStrategy delegates to convert() with the wrapped callback
       expect(convertSpy).toHaveBeenCalledWith(
         'file:///tmp/report.pdf',
         'report-1',
@@ -415,6 +255,13 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('throws error when URL is not a local file', async () => {
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+
       await expect(
         converter.convertWithStrategy(
           'http://example.com/test.pdf',
@@ -464,13 +311,18 @@ describe('PDFConverter.convertWithStrategy', () => {
 
   describe('token usage tracking', () => {
     test('creates internal aggregator and returns report when VLM tracks usage', async () => {
-      // Simulate wrapCallback populating the aggregator when the callback runs
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+
       mockWrapCallback.mockImplementation(
         (
           _pdfPath: string,
           options: { aggregator?: LLMTokenUsageAggregator },
         ) => {
-          // Populate aggregator to simulate VLM processing
           options.aggregator?.track({
             component: 'VlmTextCorrector',
             phase: 'text-correction',
@@ -506,124 +358,6 @@ describe('PDFConverter.convertWithStrategy', () => {
       convertSpy.mockRestore();
     });
 
-    test('returns token report with sampling usage on ocrmac path', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      // Simulate OcrStrategySampler calling aggregator.track() during sampling
-      mockSamplerInstance.sample.mockImplementation(
-        async (
-          _pdfPath: string,
-          _samplingDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
-        ) => {
-          opts.aggregator?.track({
-            component: 'OcrStrategySampler',
-            phase: 'korean-hanja-mix-detection',
-            model: 'primary',
-            modelName: 'sampler-model',
-            inputTokens: 1000,
-            outputTokens: 50,
-            totalTokens: 1050,
-          });
-          return {
-            method: 'ocrmac' as const,
-            reason: 'No Korean-Hanja mix detected',
-            sampledPages: 3,
-            totalPages: 10,
-          };
-        },
-      );
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { strategySamplerModel: mockModel },
-      );
-
-      expect(result.strategy.method).toBe('ocrmac');
-      expect(result.tokenUsageReport).not.toBeNull();
-      expect(result.tokenUsageReport!.components).toHaveLength(1);
-      expect(result.tokenUsageReport!.components[0].component).toBe(
-        'OcrStrategySampler',
-      );
-      expect(result.tokenUsageReport!.total.inputTokens).toBe(1000);
-      expect(result.tokenUsageReport!.total.outputTokens).toBe(50);
-
-      convertSpy.mockRestore();
-    });
-
-    test('returns combined report with both sampling and VLM usage', async () => {
-      // Simulate sampling tracking
-      mockSamplerInstance.sample.mockImplementation(
-        async (
-          _pdfPath: string,
-          _samplingDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
-        ) => {
-          opts.aggregator?.track({
-            component: 'OcrStrategySampler',
-            phase: 'korean-hanja-mix-detection',
-            model: 'primary',
-            modelName: 'sampler-model',
-            inputTokens: 800,
-            outputTokens: 30,
-            totalTokens: 830,
-          });
-          return {
-            method: 'vlm' as const,
-            reason: 'Korean-Hanja mix detected',
-            sampledPages: 3,
-            totalPages: 10,
-          };
-        },
-      );
-
-      // Simulate VLM pipeline populating aggregator during wrapCallback
-      mockWrapCallback.mockImplementation(
-        (
-          _pdfPath: string,
-          options: { aggregator?: LLMTokenUsageAggregator },
-        ) => {
-          options.aggregator?.track({
-            component: 'VlmTextCorrector',
-            phase: 'text-correction',
-            model: 'primary',
-            modelName: 'vlm-model',
-            inputTokens: 5000,
-            outputTokens: 1500,
-            totalTokens: 6500,
-          });
-          return vi.fn();
-        },
-      );
-
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          strategySamplerModel: mockModel,
-          vlmProcessorModel: mockFallbackModel,
-        },
-      );
-
-      expect(result.strategy.method).toBe('vlm');
-      expect(result.tokenUsageReport).not.toBeNull();
-      expect(result.tokenUsageReport!.components).toHaveLength(2);
-      expect(result.tokenUsageReport!.total.inputTokens).toBe(5800);
-      expect(result.tokenUsageReport!.total.outputTokens).toBe(1530);
-      expect(result.tokenUsageReport!.total.totalTokens).toBe(7330);
-
-      convertSpy.mockRestore();
-    });
-
     test('returns null tokenUsageReport when no LLM calls are tracked', async () => {
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
@@ -640,19 +374,15 @@ describe('PDFConverter.convertWithStrategy', () => {
       convertSpy.mockRestore();
     });
 
-    test('calls onTokenUsage after sampling phase with sampling report', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-      const onTokenUsage = vi.fn();
-
-      // Simulate OcrStrategySampler calling aggregator.track() during sampling
-      mockSamplerInstance.sample.mockImplementation(
+    test('calls onTokenUsage after strategy resolution when LLM calls were tracked', async () => {
+      // Simulate StrategyResolver populating aggregator during resolve
+      mockResolve.mockImplementation(
         async (
-          _pdfPath: string,
-          _samplingDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
+          _pdfPath: string | null,
+          _reportId: string,
+          options: { aggregator?: LLMTokenUsageAggregator },
         ) => {
-          opts.aggregator?.track({
+          options.aggregator?.track({
             component: 'OcrStrategySampler',
             phase: 'korean-hanja-mix-detection',
             model: 'primary',
@@ -670,6 +400,9 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
+      const onTokenUsage = vi.fn();
+
       await converter.convertWithStrategy(
         'file:///tmp/test.pdf',
         'report-1',
@@ -678,7 +411,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         { strategySamplerModel: mockModel, onTokenUsage },
       );
 
-      // onTokenUsage should be called after sampling completes
       expect(onTokenUsage).toHaveBeenCalledWith(
         expect.objectContaining({
           components: expect.arrayContaining([
@@ -691,7 +423,7 @@ describe('PDFConverter.convertWithStrategy', () => {
       convertSpy.mockRestore();
     });
 
-    test('does not call onTokenUsage after sampling when no LLM calls were tracked', async () => {
+    test('does not call onTokenUsage when no LLM calls were tracked', async () => {
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
       const onTokenUsage = vi.fn();
 
@@ -703,16 +435,21 @@ describe('PDFConverter.convertWithStrategy', () => {
         { forcedMethod: 'ocrmac', onTokenUsage },
       );
 
-      // Forced ocrmac skips sampling entirely → no LLM usage → onTokenUsage not called
       expect(onTokenUsage).not.toHaveBeenCalled();
 
       convertSpy.mockRestore();
     });
 
     test('uses externally provided aggregator instead of creating a new one', async () => {
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+
       const externalAggregator = new LLMTokenUsageAggregator();
 
-      // Simulate wrapCallback populating the external aggregator
       mockWrapCallback.mockImplementation(
         (
           _pdfPath: string,
@@ -745,7 +482,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
-      // External aggregator should have the tracked usage
       const report = externalAggregator.getReport();
       expect(report.components).toHaveLength(1);
       expect(report.total.totalTokens).toBe(150);
@@ -793,6 +529,13 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('logs VLM conversion completion', async () => {
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
       await converter.convertWithStrategy(
@@ -813,7 +556,7 @@ describe('PDFConverter.convertWithStrategy', () => {
 
   describe('detectedLanguages → ocr_lang passthrough', () => {
     test('VLM path passes detectedLanguages as ocr_lang to convert()', async () => {
-      mockSamplerInstance.sample.mockResolvedValue({
+      mockResolve.mockResolvedValue({
         method: 'vlm',
         reason: 'Korean-Hanja mix detected',
         sampledPages: 2,
@@ -847,6 +590,13 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('VLM path preserves existing options when detectedLanguages is undefined', async () => {
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm',
+        sampledPages: 0,
+        totalPages: 0,
+      });
+
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
       await converter.convertWithStrategy(
@@ -861,7 +611,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
-      // When detectedLanguages is undefined, original ocr_lang should be preserved
       expect(convertSpy).toHaveBeenCalledWith(
         'file:///tmp/test.pdf',
         'report-1',
@@ -875,7 +624,7 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('ocrmac path passes detectedLanguages as ocr_lang to convert()', async () => {
-      mockSamplerInstance.sample.mockResolvedValue({
+      mockResolve.mockResolvedValue({
         method: 'ocrmac',
         reason: 'No Korean-Hanja mix detected',
         sampledPages: 3,
@@ -929,9 +678,9 @@ describe('PDFConverter.convertWithStrategy', () => {
     });
 
     test('VLM path passes sampled detectedLanguages as ocr_lang when forcedMethod + strategySamplerModel', async () => {
-      mockSamplerInstance.sample.mockResolvedValue({
-        method: 'ocrmac',
-        reason: 'No Korean-Hanja mix detected',
+      mockResolve.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Forced: vlm (No Korean-Hanja mix detected)',
         sampledPages: 3,
         totalPages: 10,
         detectedLanguages: ['ko-KR'],
@@ -951,7 +700,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
-      // Sampling detectedLanguages should flow through as ocr_lang
       expect(convertSpy).toHaveBeenCalledWith(
         'file:///tmp/report.pdf',
         'report-1',

--- a/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter-strategy.test.ts
@@ -2,30 +2,21 @@ import type { LoggerMethods } from '@heripo/logger';
 import type { DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { copyFileSync, existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PageRenderer } from '../processors/page-renderer';
-import { PdfTextExtractor } from '../processors/pdf-text-extractor';
-import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
-import { runJqFileJson } from '../utils/jq';
 import { PDFConverter } from './pdf-converter';
+import { VlmConversionPipeline } from './vlm-conversion-pipeline';
 
 vi.mock('node:fs', () => ({
-  copyFileSync: vi.fn(),
   existsSync: vi.fn(),
   rmSync: vi.fn(),
-  createWriteStream: vi.fn(),
 }));
 
 vi.mock('node:path', () => ({
   join: vi.fn((...args: string[]) => args.join('/')),
-}));
-
-vi.mock('../utils/jq', () => ({
-  runJqFileToFile: vi.fn(),
-  runJqFileJson: vi.fn(),
 }));
 
 vi.mock('../samplers/ocr-strategy-sampler', () => ({
@@ -40,8 +31,8 @@ vi.mock('../processors/pdf-text-extractor', () => ({
   PdfTextExtractor: vi.fn(),
 }));
 
-vi.mock('../processors/vlm-text-corrector', () => ({
-  VlmTextCorrector: vi.fn(),
+vi.mock('./vlm-conversion-pipeline', () => ({
+  VlmConversionPipeline: vi.fn(),
 }));
 
 const mockModel = { modelId: 'test-model' } as any;
@@ -53,8 +44,7 @@ describe('PDFConverter.convertWithStrategy', () => {
   let converter: PDFConverter;
   let mockOnComplete: Mock;
   let mockSamplerInstance: { sample: Mock };
-  let mockCorrectorInstance: { correctAndSave: Mock };
-  let mockTextExtractorInstance: { extractText: Mock };
+  let mockWrapCallback: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -94,29 +84,11 @@ describe('PDFConverter.convertWithStrategy', () => {
       return mockSamplerInstance as any;
     });
 
-    // Mock VlmTextCorrector constructor
-    mockCorrectorInstance = {
-      correctAndSave: vi.fn().mockResolvedValue({
-        textCorrections: 0,
-        cellCorrections: 0,
-        pagesProcessed: 5,
-        pagesFailed: 0,
-      }),
-    };
-    vi.mocked(VlmTextCorrector).mockImplementation(function () {
-      return mockCorrectorInstance as any;
+    // Mock VlmConversionPipeline
+    mockWrapCallback = vi.fn().mockReturnValue(vi.fn());
+    vi.mocked(VlmConversionPipeline).mockImplementation(function () {
+      return { wrapCallback: mockWrapCallback } as any;
     });
-
-    // Mock PdfTextExtractor constructor
-    mockTextExtractorInstance = {
-      extractText: vi.fn().mockResolvedValue(new Map<number, string>()),
-    };
-    vi.mocked(PdfTextExtractor).mockImplementation(function () {
-      return mockTextExtractorInstance as any;
-    });
-
-    // Default: runJqFileJson returns page count of 1 for wrappedCallback
-    vi.mocked(runJqFileJson).mockResolvedValue(1);
   });
 
   describe('strategy determination', () => {
@@ -247,6 +219,7 @@ describe('PDFConverter.convertWithStrategy', () => {
 
       expect(result.strategy.method).toBe('ocrmac');
       expect(result.strategy.reason).toBe('Non-local URL, sampling skipped');
+      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
 
       convertSpy.mockRestore();
     });
@@ -371,8 +344,18 @@ describe('PDFConverter.convertWithStrategy', () => {
   });
 
   describe('VLM path', () => {
-    test('delegates to convert() with file URL when strategy is VLM', async () => {
+    test('creates VlmConversionPipeline and calls wrapCallback with correct args', async () => {
       const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
+      const abortController = new AbortController();
+
+      mockSamplerInstance.sample.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Korean-Hanja mix detected',
+        sampledPages: 2,
+        totalPages: 10,
+        detectedLanguages: ['ko-KR'],
+        koreanHanjaMixPages: [1, 3],
+      });
 
       await converter.convertWithStrategy(
         'file:///tmp/report.pdf',
@@ -382,15 +365,45 @@ describe('PDFConverter.convertWithStrategy', () => {
         {
           strategySamplerModel: mockModel,
           vlmProcessorModel: mockFallbackModel,
+        },
+        abortController.signal,
+      );
+
+      expect(VlmConversionPipeline).toHaveBeenCalledWith(logger);
+      expect(mockWrapCallback).toHaveBeenCalledWith(
+        '/tmp/report.pdf',
+        expect.objectContaining({ vlmProcessorModel: mockFallbackModel }),
+        mockOnComplete,
+        abortController.signal,
+        ['ko-KR'],
+        [1, 3],
+      );
+
+      convertSpy.mockRestore();
+    });
+
+    test('delegates to convert() with wrapped callback', async () => {
+      const wrappedFn = vi.fn();
+      mockWrapCallback.mockReturnValue(wrappedFn);
+
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
+
+      await converter.convertWithStrategy(
+        'file:///tmp/report.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        {
           forcedMethod: 'vlm',
+          vlmProcessorModel: mockFallbackModel,
         },
       );
 
-      // convertWithVlm delegates to convert() with the file URL
+      // convertWithStrategy delegates to convert() with the wrapped callback
       expect(convertSpy).toHaveBeenCalledWith(
         'file:///tmp/report.pdf',
         'report-1',
-        expect.any(Function), // wrapped callback
+        wrappedFn,
         false,
         expect.objectContaining({
           vlmProcessorModel: mockFallbackModel,
@@ -399,228 +412,6 @@ describe('PDFConverter.convertWithStrategy', () => {
       );
 
       convertSpy.mockRestore();
-    });
-
-    test('wrapped callback calls VlmTextCorrector then onComplete', async () => {
-      // Capture the wrapped callback passed to convert()
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          // Invoke the wrapped callback to test its behavior
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      // VlmTextCorrector should have been instantiated and called
-      expect(VlmTextCorrector).toHaveBeenCalledWith(logger);
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({
-          aggregator: expect.any(LLMTokenUsageAggregator),
-        }),
-      );
-
-      // Original onComplete should have been called after correction
-      expect(mockOnComplete).toHaveBeenCalledWith('/test/output');
-
-      convertSpy.mockRestore();
-    });
-
-    test('passes detectedLanguages to VlmTextCorrector as documentLanguages', async () => {
-      mockSamplerInstance.sample.mockResolvedValue({
-        method: 'vlm',
-        reason: 'Korean-Hanja mix detected',
-        sampledPages: 2,
-        totalPages: 10,
-        detectedLanguages: ['ko-KR'],
-      });
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/report.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          strategySamplerModel: mockModel,
-          vlmProcessorModel: mockFallbackModel,
-        },
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockFallbackModel,
-        expect.objectContaining({ documentLanguages: ['ko-KR'] }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('passes undefined documentLanguages when strategy has no detectedLanguages', async () => {
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        expect.any(String),
-        mockModel,
-        expect.objectContaining({ documentLanguages: undefined }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('passes aggregator and abortSignal to VlmTextCorrector', async () => {
-      const aggregator = new LLMTokenUsageAggregator();
-      const abortController = new AbortController();
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          forcedMethod: 'vlm',
-          vlmProcessorModel: mockModel,
-          aggregator,
-        },
-        abortController.signal,
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({
-          aggregator,
-          abortSignal: abortController.signal,
-        }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('forwards onTokenUsage callback to VlmTextCorrector', async () => {
-      const onTokenUsage = vi.fn();
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          forcedMethod: 'vlm',
-          vlmProcessorModel: mockModel,
-          onTokenUsage,
-        },
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        expect.any(String),
-        mockModel,
-        expect.objectContaining({ onTokenUsage }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('forwards vlmConcurrency to VlmTextCorrector as concurrency', async () => {
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        {
-          forcedMethod: 'vlm',
-          vlmProcessorModel: mockModel,
-          vlmConcurrency: 4,
-        },
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        expect.any(String),
-        mockModel,
-        expect.objectContaining({ concurrency: 4 }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('returns null tokenUsageReport for VLM path when no LLM calls tracked', async () => {
-      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
-
-      const result = await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      expect(result.strategy.method).toBe('vlm');
-      expect(result.tokenUsageReport).toBeNull();
-
-      convertSpy.mockRestore();
-    });
-
-    test('throws error when vlmProcessorModel is missing', async () => {
-      await expect(
-        converter.convertWithStrategy(
-          'file:///tmp/test.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          { forcedMethod: 'vlm' },
-        ),
-      ).rejects.toThrow(
-        'vlmProcessorModel is required when OCR strategy is VLM',
-      );
     });
 
     test('throws error when URL is not a local file', async () => {
@@ -653,27 +444,19 @@ describe('PDFConverter.convertWithStrategy', () => {
       convertSpy.mockRestore();
     });
 
-    test('propagates errors from VlmTextCorrector', async () => {
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
+    test('returns null tokenUsageReport for VLM path when no LLM calls tracked', async () => {
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
-      mockCorrectorInstance.correctAndSave.mockRejectedValue(
-        new Error('VLM correction failed'),
+      const result = await converter.convertWithStrategy(
+        'file:///tmp/test.pdf',
+        'report-1',
+        mockOnComplete,
+        false,
+        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
       );
 
-      await expect(
-        converter.convertWithStrategy(
-          'file:///tmp/test.pdf',
-          'report-1',
-          mockOnComplete,
-          false,
-          { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-        ),
-      ).rejects.toThrow('VLM correction failed');
+      expect(result.strategy.method).toBe('vlm');
+      expect(result.tokenUsageReport).toBeNull();
 
       convertSpy.mockRestore();
     });
@@ -681,14 +464,14 @@ describe('PDFConverter.convertWithStrategy', () => {
 
   describe('token usage tracking', () => {
     test('creates internal aggregator and returns report when VLM tracks usage', async () => {
-      // Simulate VlmTextCorrector calling aggregator.track() during processing
-      mockCorrectorInstance.correctAndSave.mockImplementation(
-        async (
-          _outputDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
+      // Simulate wrapCallback populating the aggregator when the callback runs
+      mockWrapCallback.mockImplementation(
+        (
+          _pdfPath: string,
+          options: { aggregator?: LLMTokenUsageAggregator },
         ) => {
-          opts.aggregator?.track({
+          // Populate aggregator to simulate VLM processing
+          options.aggregator?.track({
             component: 'VlmTextCorrector',
             phase: 'text-correction',
             model: 'primary',
@@ -697,21 +480,11 @@ describe('PDFConverter.convertWithStrategy', () => {
             outputTokens: 200,
             totalTokens: 700,
           });
-          return {
-            textCorrections: 1,
-            cellCorrections: 0,
-            pagesProcessed: 1,
-            pagesFailed: 0,
-          };
+          return vi.fn();
         },
       );
 
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
       const result = await converter.convertWithStrategy(
         'file:///tmp/test.pdf',
@@ -809,14 +582,13 @@ describe('PDFConverter.convertWithStrategy', () => {
         },
       );
 
-      // Simulate VlmTextCorrector tracking
-      mockCorrectorInstance.correctAndSave.mockImplementation(
-        async (
-          _outputDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
+      // Simulate VLM pipeline populating aggregator during wrapCallback
+      mockWrapCallback.mockImplementation(
+        (
+          _pdfPath: string,
+          options: { aggregator?: LLMTokenUsageAggregator },
         ) => {
-          opts.aggregator?.track({
+          options.aggregator?.track({
             component: 'VlmTextCorrector',
             phase: 'text-correction',
             model: 'primary',
@@ -825,21 +597,11 @@ describe('PDFConverter.convertWithStrategy', () => {
             outputTokens: 1500,
             totalTokens: 6500,
           });
-          return {
-            textCorrections: 3,
-            cellCorrections: 1,
-            pagesProcessed: 5,
-            pagesFailed: 0,
-          };
+          return vi.fn();
         },
       );
 
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
       const result = await converter.convertWithStrategy(
         'file:///tmp/test.pdf',
@@ -950,13 +712,13 @@ describe('PDFConverter.convertWithStrategy', () => {
     test('uses externally provided aggregator instead of creating a new one', async () => {
       const externalAggregator = new LLMTokenUsageAggregator();
 
-      mockCorrectorInstance.correctAndSave.mockImplementation(
-        async (
-          _outputDir: string,
-          _model: unknown,
-          opts: { aggregator?: LLMTokenUsageAggregator },
+      // Simulate wrapCallback populating the external aggregator
+      mockWrapCallback.mockImplementation(
+        (
+          _pdfPath: string,
+          options: { aggregator?: LLMTokenUsageAggregator },
         ) => {
-          opts.aggregator?.track({
+          options.aggregator?.track({
             component: 'VlmTextCorrector',
             phase: 'text-correction',
             model: 'primary',
@@ -965,21 +727,11 @@ describe('PDFConverter.convertWithStrategy', () => {
             outputTokens: 50,
             totalTokens: 150,
           });
-          return {
-            textCorrections: 0,
-            cellCorrections: 0,
-            pagesProcessed: 1,
-            pagesFailed: 0,
-          };
+          return vi.fn();
         },
       );
 
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
+      const convertSpy = vi.spyOn(converter, 'convert').mockResolvedValue(null);
 
       await converter.convertWithStrategy(
         'file:///tmp/test.pdf',
@@ -997,34 +749,6 @@ describe('PDFConverter.convertWithStrategy', () => {
       const report = externalAggregator.getReport();
       expect(report.components).toHaveLength(1);
       expect(report.total.totalTokens).toBe(150);
-
-      convertSpy.mockRestore();
-    });
-
-    test('creates internal aggregator when none provided and passes to VlmTextCorrector', async () => {
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      // VlmTextCorrector should receive an LLMTokenUsageAggregator instance
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({
-          aggregator: expect.any(LLMTokenUsageAggregator),
-        }),
-      );
 
       convertSpy.mockRestore();
     });
@@ -1081,113 +805,6 @@ describe('PDFConverter.convertWithStrategy', () => {
 
       expect(logger.info).toHaveBeenCalledWith(
         '[PDFConverter] VLM conversion completed successfully',
-      );
-
-      convertSpy.mockRestore();
-    });
-  });
-
-  describe('pdftotext extraction in VLM path', () => {
-    test('extracts text with PdfTextExtractor and passes pageTexts to VlmTextCorrector', async () => {
-      const pageTexts = new Map<number, string>();
-      pageTexts.set(1, 'extracted text page 1');
-      mockTextExtractorInstance.extractText.mockResolvedValue(pageTexts);
-
-      vi.mocked(runJqFileJson).mockResolvedValue(2);
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      // PdfTextExtractor should have been called with pdfPath and totalPages
-      expect(PdfTextExtractor).toHaveBeenCalledWith(logger);
-      expect(mockTextExtractorInstance.extractText).toHaveBeenCalledWith(
-        '/tmp/test.pdf',
-        2,
-      );
-
-      // VlmTextCorrector should receive the pageTexts
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({ pageTexts }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('proceeds without pageTexts when PdfTextExtractor fails', async () => {
-      mockTextExtractorInstance.extractText.mockRejectedValue(
-        new Error('pdftotext not found'),
-      );
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      // Should warn but not throw
-      expect(logger.warn).toHaveBeenCalledWith(
-        '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
-      );
-
-      // VlmTextCorrector should still be called with undefined pageTexts
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({ pageTexts: undefined }),
-      );
-
-      convertSpy.mockRestore();
-    });
-
-    test('proceeds without pageTexts when result.json read fails', async () => {
-      vi.mocked(runJqFileJson).mockRejectedValue(new Error('ENOENT'));
-
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      expect(logger.warn).toHaveBeenCalledWith(
-        '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
-      );
-
-      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
-        '/test/output',
-        mockModel,
-        expect.objectContaining({ pageTexts: undefined }),
       );
 
       convertSpy.mockRestore();
@@ -1343,38 +960,6 @@ describe('PDFConverter.convertWithStrategy', () => {
         expect.objectContaining({ ocr_lang: ['ko-KR'] }),
         undefined,
       );
-
-      convertSpy.mockRestore();
-    });
-  });
-
-  describe('OCR origin result saving', () => {
-    test('copies result.json to result_ocr_origin.json before VLM correction', async () => {
-      const convertSpy = vi
-        .spyOn(converter, 'convert')
-        .mockImplementation(async (_url, _id, callback) => {
-          await callback('/test/output');
-          return null;
-        });
-
-      await converter.convertWithStrategy(
-        'file:///tmp/test.pdf',
-        'report-1',
-        mockOnComplete,
-        false,
-        { forcedMethod: 'vlm', vlmProcessorModel: mockModel },
-      );
-
-      expect(copyFileSync).toHaveBeenCalledWith(
-        '/test/output/result.json',
-        '/test/output/result_ocr_origin.json',
-      );
-
-      // copyFileSync should be called before VlmTextCorrector.correctAndSave
-      const copyOrder = vi.mocked(copyFileSync).mock.invocationCallOrder[0];
-      const correctorOrder =
-        mockCorrectorInstance.correctAndSave.mock.invocationCallOrder[0];
-      expect(copyOrder).toBeLessThan(correctorOrder);
 
       convertSpy.mockRestore();
     });

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -1,26 +1,16 @@
 import type { LoggerMethods } from '@heripo/logger';
-import type { AsyncConversionTask, DoclingAPIClient } from 'docling-sdk';
+import type { DoclingAPIClient } from 'docling-sdk';
 
-import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
-import { ImageExtractor } from '../processors/image-extractor';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
-import { downloadTaskResult } from '../utils/docling-result-downloader';
-import { LocalFileServer } from '../utils/local-file-server';
-import { renderAndUpdatePageImages } from '../utils/page-image-updater';
-import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
-import { buildConversionOptions } from './conversion-options-builder';
+import { DoclingConversionExecutor } from './docling-conversion-executor';
 import { ImagePdfConverter } from './image-pdf-converter';
 import { PDFConverter } from './pdf-converter';
-
-vi.mock('./conversion-options-builder', () => ({
-  buildConversionOptions: vi.fn(),
-}));
 
 vi.mock('./chunked-pdf-converter', () => ({
   ChunkedPDFConverter: vi.fn(),
@@ -30,8 +20,8 @@ vi.mock('./image-pdf-converter', () => ({
   ImagePdfConverter: vi.fn(),
 }));
 
-vi.mock('../utils/local-file-server', () => ({
-  LocalFileServer: vi.fn(),
+vi.mock('./docling-conversion-executor', () => ({
+  DoclingConversionExecutor: vi.fn(),
 }));
 
 vi.mock('node:fs', () => ({
@@ -42,16 +32,6 @@ vi.mock('node:fs', () => ({
 
 vi.mock('node:path', () => ({
   join: vi.fn(),
-}));
-
-vi.mock('../utils/docling-result-downloader', () => ({
-  downloadTaskResult: vi.fn(),
-}));
-
-vi.mock('../processors/image-extractor', () => ({
-  ImageExtractor: {
-    extractAndSaveDocumentsFromZip: vi.fn(),
-  },
 }));
 
 vi.mock('../processors/pdf-text-extractor', () => ({
@@ -66,18 +46,23 @@ vi.mock('../utils/jq', () => ({
   runJqFileJson: vi.fn(),
 }));
 
-vi.mock('../utils/page-image-updater', () => ({
-  renderAndUpdatePageImages: vi.fn(),
+vi.mock('../processors/vlm-text-corrector', () => ({
+  VlmTextCorrector: vi.fn(),
 }));
 
-vi.mock('../utils/task-progress-tracker', () => ({
-  trackTaskProgress: vi.fn(),
+vi.mock('../samplers/ocr-strategy-sampler', () => ({
+  OcrStrategySampler: vi.fn(),
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
 }));
 
 describe('PDFConverter', () => {
   let logger: LoggerMethods;
   let client: DoclingAPIClient;
   let converter: PDFConverter;
+  let mockExecute: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     logger = {
@@ -95,36 +80,12 @@ describe('PDFConverter', () => {
 
     converter = new PDFConverter(logger, client);
 
-    vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
-    vi.spyOn(Date, 'now').mockReturnValue(1000000);
-
-    vi.mocked(buildConversionOptions).mockReturnValue({
-      to_formats: ['json', 'html'],
-      image_export_mode: 'embedded',
-      ocr_engine: 'ocrmac',
-      ocr_options: {
-        kind: 'ocrmac',
-        lang: ['ko-KR', 'en-US'],
-        recognition: 'accurate',
-        framework: 'livetext',
-      },
-      generate_picture_images: true,
-      do_picture_classification: true,
-      do_picture_description: true,
-      generate_page_images: false,
-      images_scale: 2.0,
-      force_ocr: true,
-      accelerator_options: { device: 'mps', num_threads: 4 },
-    });
-
     vi.mocked(join).mockImplementation((...args) => args.join('/'));
 
-    // Mock LocalFileServer
-    vi.mocked(LocalFileServer).mockImplementation(function () {
-      return {
-        start: vi.fn().mockResolvedValue('http://127.0.0.1:12345/test.pdf'),
-        stop: vi.fn().mockResolvedValue(undefined),
-      } as unknown as LocalFileServer;
+    // Mock DoclingConversionExecutor
+    mockExecute = vi.fn().mockResolvedValue(null);
+    vi.mocked(DoclingConversionExecutor).mockImplementation(function () {
+      return { execute: mockExecute } as any;
     });
 
     // Mock ImagePdfConverter (used by forceImagePdf and image PDF fallback)
@@ -204,9 +165,6 @@ describe('PDFConverter', () => {
       });
 
       test('does not use chunked conversion for non-file:// URLs', async () => {
-        const mockTask = createMockTask();
-        vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
         await converter.convert(
           'http://example.com/test.pdf',
           'report-1',
@@ -234,18 +192,8 @@ describe('PDFConverter', () => {
     });
 
     test('should validate document type for file:// URL with documentValidationModel', async () => {
-      const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
       const mockModel = {} as any;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
 
       await converter.convert(
         'file:///test/doc.pdf',
@@ -263,18 +211,8 @@ describe('PDFConverter', () => {
     });
 
     test('should skip validation for non-file:// URLs', async () => {
-      const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
       const mockModel = {} as any;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
 
       await converter.convert(
         'http://test.com/doc.pdf',
@@ -289,15 +227,8 @@ describe('PDFConverter', () => {
     });
 
     test('should only validate once per converter instance', async () => {
-      const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
       const mockModel = {} as any;
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
 
       // First call triggers validation
       await converter.convert(
@@ -309,8 +240,6 @@ describe('PDFConverter', () => {
       );
 
       expect(mockValidate).toHaveBeenCalledTimes(1);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(createMockTask());
 
       // Second call skips validation (already validated)
       await converter.convert(
@@ -325,17 +254,7 @@ describe('PDFConverter', () => {
     });
 
     test('should skip validation when documentValidationModel is not set', async () => {
-      const mockTask = createMockTask();
       const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
 
       await converter.convert(
         'file:///test/doc.pdf',
@@ -351,23 +270,59 @@ describe('PDFConverter', () => {
   });
 
   describe('convert', () => {
-    test('should successfully convert PDF with cleanupAfterCallback=false', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false);
+    test('should delegate to DoclingConversionExecutor for standard conversion', async () => {
+      const onComplete = vi.fn();
 
       await converter.convert(
         'http://test.com/doc.pdf',
         'report123',
         onComplete,
+        false,
+        {},
+      );
+
+      expect(DoclingConversionExecutor).toHaveBeenCalledWith(
+        logger,
+        client,
+        expect.any(Number),
+      );
+      expect(mockExecute).toHaveBeenCalledWith(
+        'http://test.com/doc.pdf',
+        'report123',
+        onComplete,
+        false,
+        {},
+        undefined,
+      );
+    });
+
+    test('should pass abortSignal to executor', async () => {
+      const abortController = new AbortController();
+
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        {},
+        abortController.signal,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'http://test.com/doc.pdf',
+        'report123',
+        expect.any(Function),
+        false,
+        {},
+        abortController.signal,
+      );
+    });
+
+    test('should log converting message', async () => {
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report123',
+        vi.fn(),
         false,
         {},
       );
@@ -376,341 +331,17 @@ describe('PDFConverter', () => {
         '[PDFConverter] Converting:',
         'http://test.com/doc.pdf',
       );
-      expect(client.convertSourceAsync).toHaveBeenCalled();
-      expect(downloadTaskResult).toHaveBeenCalled();
-      expect(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).toHaveBeenCalledWith(
-        logger,
-        '/test/cwd/result.zip',
-        '/test/cwd/result_extracted',
-        '/test/cwd/output/report123',
-      );
-      expect(onComplete).toHaveBeenCalledWith('/test/cwd/output/report123');
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
-        force: true,
-      });
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
-        recursive: true,
-        force: true,
-      });
-      expect(rmSync).not.toHaveBeenCalledWith(
-        '/test/cwd/output/report123',
-        expect.any(Object),
-      );
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Output preserved at:',
-        '/test/cwd/output/report123',
-      );
-    });
-
-    test('should successfully convert PDF with cleanupAfterCallback=true', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(true);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report456',
-        onComplete,
-        true,
-        {},
-      );
-
-      expect(onComplete).toHaveBeenCalledWith('/test/cwd/output/report456');
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
-        force: true,
-      });
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
-        recursive: true,
-        force: true,
-      });
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/output/report456', {
-        recursive: true,
-        force: true,
-      });
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Cleaning up output directory:',
-        '/test/cwd/output/report456',
-      );
-    });
-
-    test('should cleanup temporary files even if callback throws error', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockRejectedValue(new Error('Callback error'));
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(true);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report789',
-          onComplete,
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Callback error');
-
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
-        force: true,
-      });
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
-        recursive: true,
-        force: true,
-      });
-    });
-
-    test('should handle conversion task failure', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(trackTaskProgress).mockRejectedValue(
-        new Error('Task failed: Processing failed'),
-      );
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Task failed: Processing failed');
-
-      expect(logger.error).toHaveBeenCalledWith(
-        '[PDFConverter] Conversion failed:',
-        expect.any(Error),
-      );
-    });
-
-    test('should handle download failure', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(downloadTaskResult).mockRejectedValue(
-        new Error('Download failed'),
-      );
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-download-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Download failed');
-
-      expect(logger.error).toHaveBeenCalledWith(
-        '[PDFConverter] Conversion failed:',
-        expect.any(Error),
-      );
-    });
-
-    test('should handle processing failure and cleanup', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockRejectedValue(new Error('Processing failed'));
-      vi.mocked(existsSync).mockReturnValue(true);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-process-fail',
-          vi.fn(),
-          false,
-          {},
-        ),
-      ).rejects.toThrow('Processing failed');
-
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result.zip', {
-        force: true,
-      });
-      expect(rmSync).toHaveBeenCalledWith('/test/cwd/result_extracted', {
-        recursive: true,
-        force: true,
-      });
-    });
-
-    test('should handle non-existent files during cleanup', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report-no-files',
-        onComplete,
-        true,
-        {},
-      );
-
-      expect(rmSync).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('startConversionTask', () => {
-    test('should start conversion task and log task ID', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Task created: task-123',
-      );
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Polling for progress...',
-      );
-    });
-  });
-
-  describe('trackTaskProgress delegation', () => {
-    test('should call trackTaskProgress with showDetailedProgress', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(trackTaskProgress).toHaveBeenCalledWith(
-        mockTask,
-        expect.any(Number),
-        logger,
-        '[PDFConverter]',
-        { showDetailedProgress: true },
-      );
-    });
-  });
-
-  describe('processConvertedFiles', () => {
-    test('should call ImageExtractor with correct paths', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report123',
-        vi.fn(),
-        false,
-        {},
-      );
-
-      expect(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).toHaveBeenCalledWith(
-        logger,
-        '/test/cwd/result.zip',
-        '/test/cwd/result_extracted',
-        '/test/cwd/output/report123',
-      );
     });
   });
 
   describe('abort signal handling', () => {
-    test('should throw AbortError when aborted after docling task completes', async () => {
-      const abortController = new AbortController();
-      const mockTask = createMockTask();
-
-      // Simulate trackTaskProgress completing but abort being triggered during it
-      vi.mocked(trackTaskProgress).mockImplementation(async () => {
-        abortController.abort();
-      });
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-abort-docling',
-          vi.fn(),
-          false,
-          {},
-          abortController.signal,
-        ),
-      ).rejects.toThrow('PDF conversion was aborted');
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Conversion aborted after docling completion',
-      );
-    });
-
-    test('should throw AbortError when aborted before callback', async () => {
-      const mockTask = createMockTask();
-      const abortController = new AbortController();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-
-      // Abort after processConvertedFiles (ImageExtractor) completes
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockImplementation(async () => {
-        abortController.abort();
-      });
-      vi.mocked(existsSync).mockReturnValue(true);
-
-      await expect(
-        converter.convert(
-          'http://test.com/doc.pdf',
-          'report-abort-callback',
-          vi.fn(),
-          false,
-          {},
-          abortController.signal,
-        ),
-      ).rejects.toThrow('PDF conversion was aborted');
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[PDFConverter] Conversion aborted before callback',
-      );
-    });
-
     test('should not attempt fallback when aborted during initial conversion', async () => {
       const abortController = new AbortController();
       abortController.abort();
 
-      const mockTask = createMockTask();
-
-      // trackTaskProgress rejects (simulating task failure)
-      vi.mocked(trackTaskProgress).mockRejectedValue(
+      mockExecute.mockRejectedValue(
         new Error('Task failed: Processing failed'),
       );
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -732,10 +363,7 @@ describe('PDFConverter', () => {
 
   describe('image PDF fallback', () => {
     test('should not attempt fallback when enableImagePdfFallback is false', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(trackTaskProgress).mockRejectedValue(
+      mockExecute.mockRejectedValue(
         new Error('Task failed: Processing failed'),
       );
 
@@ -755,13 +383,10 @@ describe('PDFConverter', () => {
     });
 
     test('should attempt fallback when enableImagePdfFallback is true and original fails', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      // First call fails, second succeeds
-      vi.mocked(trackTaskProgress)
+      // First executor call fails, second succeeds
+      mockExecute
         .mockRejectedValueOnce(new Error('Task failed: Processing failed'))
-        .mockResolvedValueOnce(undefined);
+        .mockResolvedValueOnce(null);
 
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
@@ -770,11 +395,6 @@ describe('PDFConverter', () => {
       vi.mocked(ImagePdfConverter).mockImplementation(function () {
         return mockImagePdfConverter as any;
       });
-
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -803,10 +423,7 @@ describe('PDFConverter', () => {
     });
 
     test('should throw ImagePdfFallbackError when both original and fallback fail', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(trackTaskProgress).mockRejectedValue(
+      mockExecute.mockRejectedValue(
         new Error('Task failed: Processing failed'),
       );
 
@@ -839,10 +456,7 @@ describe('PDFConverter', () => {
     });
 
     test('should cleanup image PDF even when fallback conversion fails', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(trackTaskProgress).mockRejectedValue(
+      mockExecute.mockRejectedValue(
         new Error('Task failed: Processing failed'),
       );
 
@@ -873,13 +487,10 @@ describe('PDFConverter', () => {
     });
 
     test('should log success message when fallback succeeds', async () => {
-      const mockTask = createMockTask();
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      // First call fails, second succeeds
-      vi.mocked(trackTaskProgress)
+      // First executor call fails, second succeeds
+      mockExecute
         .mockRejectedValueOnce(new Error('Task failed: Processing failed'))
-        .mockResolvedValueOnce(undefined);
+        .mockResolvedValueOnce(null);
 
       const mockImagePdfConverter = {
         convert: vi.fn().mockResolvedValue('/tmp/test-image.pdf'),
@@ -888,11 +499,6 @@ describe('PDFConverter', () => {
       vi.mocked(ImagePdfConverter).mockImplementation(function () {
         return mockImagePdfConverter as any;
       });
-
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
 
       const converterWithFallback = new PDFConverter(logger, client, true);
 
@@ -910,64 +516,8 @@ describe('PDFConverter', () => {
     });
   });
 
-  describe('renderPageImages', () => {
-    test('should call renderAndUpdatePageImages for file:// URLs', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'file:///test/doc.pdf',
-        'report-render',
-        onComplete,
-        false,
-        {},
-      );
-
-      expect(renderAndUpdatePageImages).toHaveBeenCalledWith(
-        '/test/doc.pdf',
-        '/test/cwd/output/report-render',
-        logger,
-        '[PDFConverter]',
-      );
-    });
-
-    test('should skip rendering and log warning for http:// URLs', async () => {
-      const mockTask = createMockTask();
-      const onComplete = vi.fn().mockResolvedValue(undefined);
-
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(
-        ImageExtractor.extractAndSaveDocumentsFromZip,
-      ).mockResolvedValue(undefined);
-      vi.mocked(existsSync).mockReturnValue(false);
-
-      await converter.convert(
-        'http://test.com/doc.pdf',
-        'report-skip-render',
-        onComplete,
-        false,
-        {},
-      );
-
-      expect(renderAndUpdatePageImages).not.toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalledWith(
-        '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
-      );
-    });
-  });
-
   describe('forceImagePdf', () => {
     test('should convert via image PDF when forceImagePdf is true', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
       await converter.convert(
         'http://test.com/doc.pdf',
         'report-force-img',
@@ -983,10 +533,6 @@ describe('PDFConverter', () => {
     });
 
     test('should not convert via image PDF when forceImagePdf is false', async () => {
-      const mockTask = createMockTask();
-      vi.mocked(client.convertSourceAsync).mockResolvedValue(mockTask);
-      vi.mocked(existsSync).mockReturnValue(false);
-
       vi.mocked(ImagePdfConverter).mockClear();
 
       await converter.convert(
@@ -1018,24 +564,35 @@ describe('PDFConverter', () => {
         ),
       ).rejects.toThrow('convert failed');
     });
+
+    test('should delegate to DoclingConversionExecutor with image PDF URL', async () => {
+      const mockImagePdfConverter = {
+        convert: vi.fn().mockResolvedValue('/tmp/image.pdf'),
+        cleanup: vi.fn(),
+      };
+      vi.mocked(ImagePdfConverter).mockImplementation(function () {
+        return mockImagePdfConverter as any;
+      });
+
+      await converter.convert(
+        'http://test.com/doc.pdf',
+        'report-force-img',
+        vi.fn(),
+        false,
+        { forceImagePdf: true },
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'file:///tmp/image.pdf',
+        'report-force-img',
+        expect.any(Function),
+        false,
+        expect.objectContaining({ forceImagePdf: true }),
+        undefined,
+      );
+      expect(mockImagePdfConverter.cleanup).toHaveBeenCalledWith(
+        '/tmp/image.pdf',
+      );
+    });
   });
 });
-
-/**
- * Create a mock task that returns success on first poll.
- */
-function createMockTask(): AsyncConversionTask {
-  const task = {
-    taskId: 'task-123',
-    poll: vi.fn().mockResolvedValue({
-      task_id: 'task-123',
-      task_status: 'success',
-    }),
-    getResult: vi.fn().mockResolvedValue({
-      document: {},
-      status: 'success',
-      processing_time: 0,
-    }),
-  };
-  return task as unknown as AsyncConversionTask;
-}

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -26,7 +26,6 @@ vi.mock('./docling-conversion-executor', () => ({
 
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
-  copyFileSync: vi.fn(),
   rmSync: vi.fn(),
 }));
 
@@ -42,20 +41,8 @@ vi.mock('../validators/document-type-validator', () => ({
   DocumentTypeValidator: vi.fn(),
 }));
 
-vi.mock('../utils/jq', () => ({
-  runJqFileJson: vi.fn(),
-}));
-
-vi.mock('../processors/vlm-text-corrector', () => ({
-  VlmTextCorrector: vi.fn(),
-}));
-
-vi.mock('../samplers/ocr-strategy-sampler', () => ({
-  OcrStrategySampler: vi.fn(),
-}));
-
-vi.mock('../processors/page-renderer', () => ({
-  PageRenderer: vi.fn(),
+vi.mock('./vlm-conversion-pipeline', () => ({
+  VlmConversionPipeline: vi.fn(),
 }));
 
 describe('PDFConverter', () => {

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -1,11 +1,7 @@
 import type { LoggerMethods } from '@heripo/logger';
 import type { OcrStrategy, TokenUsageReport } from '@heripo/model';
 import type { LanguageModel } from 'ai';
-import type {
-  AsyncConversionTask,
-  ConversionOptions,
-  DoclingAPIClient,
-} from 'docling-sdk';
+import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
 import { copyFileSync, existsSync, rmSync } from 'node:fs';
@@ -13,19 +9,14 @@ import { join } from 'node:path';
 
 import { CHUNKED_CONVERSION, PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
-import { ImageExtractor } from '../processors/image-extractor';
 import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
-import { downloadTaskResult } from '../utils/docling-result-downloader';
 import { runJqFileJson } from '../utils/jq';
-import { LocalFileServer } from '../utils/local-file-server';
-import { renderAndUpdatePageImages } from '../utils/page-image-updater';
-import { trackTaskProgress } from '../utils/task-progress-tracker';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
-import { buildConversionOptions } from './conversion-options-builder';
+import { DoclingConversionExecutor } from './docling-conversion-executor';
 import { ImagePdfConverter } from './image-pdf-converter';
 
 /**
@@ -452,7 +443,12 @@ export class PDFConverter {
         localUrl,
       );
 
-      return await this.performConversion(
+      const executor = new DoclingConversionExecutor(
+        this.logger,
+        this.client,
+        this.timeout,
+      );
+      return await executor.execute(
         localUrl,
         reportId,
         onComplete,
@@ -482,7 +478,12 @@ export class PDFConverter {
     let originalError: Error | null = null;
 
     try {
-      return await this.performConversion(
+      const executor = new DoclingConversionExecutor(
+        this.logger,
+        this.client,
+        this.timeout,
+      );
+      return await executor.execute(
         url,
         reportId,
         onComplete,
@@ -516,7 +517,12 @@ export class PDFConverter {
       const localUrl = `file://${imagePdfPath}`;
       this.logger.info('[PDFConverter] Retrying with image PDF:', localUrl);
 
-      const report = await this.performConversion(
+      const fallbackExecutor = new DoclingConversionExecutor(
+        this.logger,
+        this.client,
+        this.timeout,
+      );
+      const report = await fallbackExecutor.execute(
         localUrl,
         reportId,
         onComplete,
@@ -539,192 +545,5 @@ export class PDFConverter {
         imagePdfConverter.cleanup(imagePdfPath);
       }
     }
-  }
-
-  private async performConversion(
-    url: string,
-    reportId: string,
-    onComplete: ConversionCompleteCallback,
-    cleanupAfterCallback: boolean,
-    options: PDFConvertOptions,
-    abortSignal?: AbortSignal,
-  ): Promise<TokenUsageReport | null> {
-    const startTime = Date.now();
-    const conversionOptions = buildConversionOptions(options);
-
-    this.logger.info(
-      `[PDFConverter] OCR languages: ${JSON.stringify(conversionOptions.ocr_options?.lang)}`,
-    );
-    this.logger.info(
-      '[PDFConverter] Converting document with Async Source API...',
-    );
-    this.logger.info('[PDFConverter] Server will download from URL directly');
-    this.logger.info(
-      '[PDFConverter] Results will be returned as ZIP to avoid memory limits',
-    );
-
-    // Resolve URL (start local server for file:// URLs)
-    const { httpUrl, server } = await this.resolveUrl(url);
-
-    try {
-      const task = await this.startConversionTask(httpUrl, conversionOptions);
-      await trackTaskProgress(
-        task,
-        this.timeout,
-        this.logger,
-        '[PDFConverter]',
-        {
-          showDetailedProgress: true,
-        },
-      );
-
-      // Check abort after docling task completes
-      if (abortSignal?.aborted) {
-        this.logger.info(
-          '[PDFConverter] Conversion aborted after docling completion',
-        );
-        const error = new Error('PDF conversion was aborted');
-        error.name = 'AbortError';
-        throw error;
-      }
-
-      const cwd = process.cwd();
-      const zipPath = join(cwd, 'result.zip');
-      await downloadTaskResult(
-        this.client,
-        task.taskId,
-        zipPath,
-        this.logger,
-        '[PDFConverter]',
-      );
-    } finally {
-      // Stop local file server if started
-      if (server) {
-        this.logger.info('[PDFConverter] Stopping local file server...');
-        await server.stop();
-      }
-    }
-
-    const cwd = process.cwd();
-    const zipPath = join(cwd, 'result.zip');
-    const extractDir = join(cwd, 'result_extracted');
-    const outputDir = join(cwd, 'output', reportId);
-
-    try {
-      await this.processConvertedFiles(zipPath, extractDir, outputDir);
-
-      // Render page images using ImageMagick (replaces Docling's page image generation)
-      if (url.startsWith('file://')) {
-        await renderAndUpdatePageImages(
-          url.slice(7),
-          outputDir,
-          this.logger,
-          '[PDFConverter]',
-        );
-      } else {
-        this.logger.warn(
-          '[PDFConverter] Page image rendering skipped: only supported for local files (file:// URLs)',
-        );
-      }
-
-      // Check abort before callback
-      if (abortSignal?.aborted) {
-        this.logger.info('[PDFConverter] Conversion aborted before callback');
-        const error = new Error('PDF conversion was aborted');
-        error.name = 'AbortError';
-        throw error;
-      }
-
-      // Execute callback with absolute output path
-      this.logger.info('[PDFConverter] Executing completion callback...');
-      await onComplete(outputDir);
-
-      const duration = Date.now() - startTime;
-      this.logger.info('[PDFConverter] Conversion completed successfully!');
-      this.logger.info('[PDFConverter] Total time:', duration, 'ms');
-    } finally {
-      // Clean up temporary files (always cleanup temp files)
-      this.logger.info('[PDFConverter] Cleaning up temporary files...');
-      if (existsSync(zipPath)) {
-        rmSync(zipPath, { force: true });
-      }
-      if (existsSync(extractDir)) {
-        rmSync(extractDir, { recursive: true, force: true });
-      }
-
-      // Cleanup output directory only if requested
-      if (cleanupAfterCallback) {
-        this.logger.info(
-          '[PDFConverter] Cleaning up output directory:',
-          outputDir,
-        );
-        if (existsSync(outputDir)) {
-          rmSync(outputDir, { recursive: true, force: true });
-        }
-      } else {
-        this.logger.info('[PDFConverter] Output preserved at:', outputDir);
-      }
-    }
-
-    return null;
-  }
-
-  private async startConversionTask(
-    url: string,
-    conversionOptions: ConversionOptions,
-  ): Promise<AsyncConversionTask> {
-    const task = await this.client.convertSourceAsync({
-      sources: [
-        {
-          kind: 'http',
-          url,
-        },
-      ],
-      options: conversionOptions,
-      target: {
-        kind: 'zip',
-      },
-    });
-
-    this.logger.info(`[PDFConverter] Task created: ${task.taskId}`);
-    this.logger.info('[PDFConverter] Polling for progress...');
-
-    return task;
-  }
-
-  /**
-   * Start a local file server for file:// URLs
-   *
-   * @param url URL to check (file:// or http://)
-   * @returns Object with httpUrl and optional server to stop later
-   */
-  private async resolveUrl(
-    url: string,
-  ): Promise<{ httpUrl: string; server?: LocalFileServer }> {
-    if (url.startsWith('file://')) {
-      const filePath = url.slice(7); // Remove 'file://' prefix
-      const server = new LocalFileServer();
-      const httpUrl = await server.start(filePath);
-
-      this.logger.info('[PDFConverter] Started local file server:', httpUrl);
-
-      return { httpUrl, server };
-    }
-
-    return { httpUrl: url };
-  }
-
-  private async processConvertedFiles(
-    zipPath: string,
-    extractDir: string,
-    outputDir: string,
-  ): Promise<void> {
-    // Extract and save documents with images
-    await ImageExtractor.extractAndSaveDocumentsFromZip(
-      this.logger,
-      zipPath,
-      extractDir,
-      outputDir,
-    );
   }
 }

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -4,20 +4,19 @@ import type { LanguageModel } from 'ai';
 import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { copyFileSync, existsSync, rmSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { CHUNKED_CONVERSION, PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
-import { VlmTextCorrector } from '../processors/vlm-text-corrector';
 import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
-import { runJqFileJson } from '../utils/jq';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { DoclingConversionExecutor } from './docling-conversion-executor';
 import { ImagePdfConverter } from './image-pdf-converter';
+import { VlmConversionPipeline } from './vlm-conversion-pipeline';
 
 /**
  * Callback function invoked after PDF conversion completes
@@ -229,16 +228,33 @@ export class PDFConverter {
 
     // Step 2: Execute conversion based on strategy
     if (strategy.method === 'vlm') {
-      await this.convertWithVlm(
+      if (!pdfPath) {
+        throw new Error('VLM conversion requires a local file (file:// URL)');
+      }
+
+      const pipeline = new VlmConversionPipeline(this.logger);
+      const wrappedCallback = pipeline.wrapCallback(
         pdfPath,
-        reportId,
-        onComplete,
-        cleanupAfterCallback,
         trackedOptions,
+        onComplete,
         abortSignal,
         strategy.detectedLanguages,
         strategy.koreanHanjaMixPages,
       );
+
+      const vlmOptions: PDFConvertOptions = strategy.detectedLanguages
+        ? { ...trackedOptions, ocr_lang: strategy.detectedLanguages }
+        : trackedOptions;
+      await this.convert(
+        url,
+        reportId,
+        wrappedCallback,
+        cleanupAfterCallback,
+        vlmOptions,
+        abortSignal,
+      );
+
+      this.logger.info('[PDFConverter] VLM conversion completed successfully');
       return {
         strategy,
         tokenUsageReport: this.buildTokenReport(aggregator),
@@ -337,84 +353,6 @@ export class PDFConverter {
         rmSync(samplingDir, { recursive: true, force: true });
       }
     }
-  }
-
-  /**
-   * Execute VLM-enhanced PDF conversion.
-   *
-   * Runs the standard OCR pipeline (Docling) first, then applies VLM text
-   * correction to fix garbled Chinese characters (漢字/Hanja) in OCR output.
-   */
-  private async convertWithVlm(
-    pdfPath: string | null,
-    reportId: string,
-    onComplete: ConversionCompleteCallback,
-    cleanupAfterCallback: boolean,
-    options: PDFConvertOptions,
-    abortSignal?: AbortSignal,
-    detectedLanguages?: string[],
-    koreanHanjaMixPages?: number[],
-  ): Promise<void> {
-    if (!options.vlmProcessorModel) {
-      throw new Error('vlmProcessorModel is required when OCR strategy is VLM');
-    }
-    if (!pdfPath) {
-      throw new Error('VLM conversion requires a local file (file:// URL)');
-    }
-
-    const url = `file://${pdfPath}`;
-
-    // Wrap the original callback with VLM text correction
-    const wrappedCallback: ConversionCompleteCallback = async (outputDir) => {
-      // Pre-extract text from PDF text layer for VLM reference
-      let pageTexts: Map<number, string> | undefined;
-      try {
-        const resultPath = join(outputDir, 'result.json');
-        // Use jq to extract only page count — avoids loading full JSON into memory
-        const totalPages = await runJqFileJson<number>(
-          '.pages | length',
-          resultPath,
-        );
-        const textExtractor = new PdfTextExtractor(this.logger);
-        pageTexts = await textExtractor.extractText(pdfPath, totalPages);
-      } catch {
-        this.logger.warn(
-          '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
-        );
-      }
-
-      // Save OCR-only result before VLM correction for debugging
-      const resultPath = join(outputDir, 'result.json');
-      const ocrOriginPath = join(outputDir, 'result_ocr_origin.json');
-      copyFileSync(resultPath, ocrOriginPath);
-
-      const corrector = new VlmTextCorrector(this.logger);
-      await corrector.correctAndSave(outputDir, options.vlmProcessorModel!, {
-        concurrency: options.vlmConcurrency,
-        aggregator: options.aggregator,
-        abortSignal,
-        onTokenUsage: options.onTokenUsage,
-        documentLanguages: detectedLanguages,
-        pageTexts,
-        koreanHanjaMixPages,
-      });
-      await onComplete(outputDir);
-    };
-
-    // Run the standard OCR pipeline, then apply VLM correction via the wrapped callback
-    const vlmOptions: PDFConvertOptions = detectedLanguages
-      ? { ...options, ocr_lang: detectedLanguages }
-      : options;
-    await this.convert(
-      url,
-      reportId,
-      wrappedCallback,
-      cleanupAfterCallback,
-      vlmOptions,
-      abortSignal,
-    );
-
-    this.logger.info('[PDFConverter] VLM conversion completed successfully');
   }
 
   /**

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -4,18 +4,15 @@ import type { LanguageModel } from 'ai';
 import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
-import { existsSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 
 import { CHUNKED_CONVERSION, PDF_CONVERTER } from '../config/constants';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
-import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
-import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
 import { DoclingConversionExecutor } from './docling-conversion-executor';
 import { ImagePdfConverter } from './image-pdf-converter';
+import { StrategyResolver } from './strategy-resolver';
 import { VlmConversionPipeline } from './vlm-conversion-pipeline';
 
 /**
@@ -208,7 +205,8 @@ export class PDFConverter {
     await this.validateDocumentType(url, trackedOptions, abortSignal);
 
     // Step 1: Determine OCR strategy
-    const strategy = await this.determineStrategy(
+    const strategyResolver = new StrategyResolver(this.logger);
+    const strategy = await strategyResolver.resolve(
       pdfPath,
       reportId,
       trackedOptions,
@@ -291,68 +289,6 @@ export class PDFConverter {
       return null;
     }
     return report;
-  }
-
-  /**
-   * Determine the OCR strategy based on options and page sampling.
-   *
-   * When sampling is possible (strategySamplerModel + local file), it always
-   * runs — even with forcedMethod — so that detectedLanguages are available
-   * for OCR engine configuration. The forced method simply overrides the
-   * sampled method choice.
-   */
-  private async determineStrategy(
-    pdfPath: string | null,
-    reportId: string,
-    options: PDFConvertOptions,
-    abortSignal?: AbortSignal,
-  ): Promise<OcrStrategy> {
-    // Cannot sample: skip, no sampler model, or non-local URL
-    if (options.skipSampling || !options.strategySamplerModel || !pdfPath) {
-      const method = options.forcedMethod ?? 'ocrmac';
-      const reason = options.forcedMethod
-        ? `Forced: ${options.forcedMethod}`
-        : !pdfPath
-          ? 'Non-local URL, sampling skipped'
-          : 'Sampling skipped';
-      return { method, reason, sampledPages: 0, totalPages: 0 };
-    }
-
-    // Sample pages to determine strategy (also detects languages)
-    const samplingDir = join(process.cwd(), 'output', reportId, '_sampling');
-    const sampler = new OcrStrategySampler(
-      this.logger,
-      new PageRenderer(this.logger),
-      new PdfTextExtractor(this.logger),
-    );
-
-    try {
-      const strategy = await sampler.sample(
-        pdfPath,
-        samplingDir,
-        options.strategySamplerModel,
-        {
-          aggregator: options.aggregator,
-          abortSignal,
-        },
-      );
-
-      // Override method when forced, preserving detected languages from sampling
-      if (options.forcedMethod) {
-        return {
-          ...strategy,
-          method: options.forcedMethod,
-          reason: `Forced: ${options.forcedMethod} (${strategy.reason})`,
-        };
-      }
-
-      return strategy;
-    } finally {
-      // Always clean up sampling temp directory
-      if (existsSync(samplingDir)) {
-        rmSync(samplingDir, { recursive: true, force: true });
-      }
-    }
   }
 
   /**

--- a/packages/pdf-parser/src/core/strategy-resolver.test.ts
+++ b/packages/pdf-parser/src/core/strategy-resolver.test.ts
@@ -1,0 +1,247 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { LLMTokenUsageAggregator } from '@heripo/shared';
+import { existsSync, rmSync } from 'node:fs';
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PageRenderer } from '../processors/page-renderer';
+import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
+import { StrategyResolver } from './strategy-resolver';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('../samplers/ocr-strategy-sampler', () => ({
+  OcrStrategySampler: vi.fn(),
+}));
+
+vi.mock('../processors/page-renderer', () => ({
+  PageRenderer: vi.fn(),
+}));
+
+vi.mock('../processors/pdf-text-extractor', () => ({
+  PdfTextExtractor: vi.fn(),
+}));
+
+const mockModel = { modelId: 'test-model' } as any;
+
+describe('StrategyResolver', () => {
+  let logger: LoggerMethods;
+  let resolver: StrategyResolver;
+  let mockSamplerInstance: { sample: Mock };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    resolver = new StrategyResolver(logger);
+
+    vi.spyOn(process, 'cwd').mockReturnValue('/test/cwd');
+
+    // Default: existsSync returns false (no cleanup needed)
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    // Mock OcrStrategySampler constructor
+    mockSamplerInstance = {
+      sample: vi.fn().mockResolvedValue({
+        method: 'ocrmac',
+        reason: 'No Korean-Hanja mix detected',
+        sampledPages: 3,
+        totalPages: 10,
+      }),
+    };
+    vi.mocked(OcrStrategySampler).mockImplementation(function () {
+      return mockSamplerInstance as any;
+    });
+  });
+
+  describe('skip sampling paths', () => {
+    test('uses forced method when forcedMethod is specified without sampler model', async () => {
+      const result = await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        forcedMethod: 'vlm',
+      });
+
+      expect(result.method).toBe('vlm');
+      expect(result.reason).toBe('Forced: vlm');
+      expect(result.sampledPages).toBe(0);
+      expect(result.totalPages).toBe(0);
+      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
+    });
+
+    test('uses forced ocrmac method', async () => {
+      const result = await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        forcedMethod: 'ocrmac',
+      });
+
+      expect(result.method).toBe('ocrmac');
+      expect(result.reason).toBe('Forced: ocrmac');
+      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
+    });
+
+    test('defaults to ocrmac when skipSampling is true', async () => {
+      const result = await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        skipSampling: true,
+        strategySamplerModel: mockModel,
+      });
+
+      expect(result.method).toBe('ocrmac');
+      expect(result.reason).toBe('Sampling skipped');
+      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
+    });
+
+    test('defaults to ocrmac when no strategySamplerModel', async () => {
+      const result = await resolver.resolve('/tmp/test.pdf', 'report-1', {});
+
+      expect(result.method).toBe('ocrmac');
+      expect(result.reason).toBe('Sampling skipped');
+    });
+
+    test('defaults to ocrmac for non-local URL (null pdfPath)', async () => {
+      const result = await resolver.resolve(null, 'report-1', {
+        strategySamplerModel: mockModel,
+      });
+
+      expect(result.method).toBe('ocrmac');
+      expect(result.reason).toBe('Non-local URL, sampling skipped');
+      expect(mockSamplerInstance.sample).not.toHaveBeenCalled();
+    });
+
+    test('uses forcedMethod for non-local URL when specified', async () => {
+      const result = await resolver.resolve(null, 'report-1', {
+        forcedMethod: 'vlm',
+      });
+
+      expect(result.method).toBe('vlm');
+      expect(result.reason).toBe('Forced: vlm');
+    });
+  });
+
+  describe('sampling path', () => {
+    test('calls OcrStrategySampler with correct arguments', async () => {
+      const aggregator = new LLMTokenUsageAggregator();
+      const abortController = new AbortController();
+
+      await resolver.resolve(
+        '/tmp/test.pdf',
+        'report-1',
+        { strategySamplerModel: mockModel, aggregator },
+        abortController.signal,
+      );
+
+      expect(OcrStrategySampler).toHaveBeenCalledWith(
+        logger,
+        expect.any(Object),
+        expect.any(Object),
+      );
+      expect(PageRenderer).toHaveBeenCalledWith(logger);
+      expect(mockSamplerInstance.sample).toHaveBeenCalledWith(
+        '/tmp/test.pdf',
+        '/test/cwd/output/report-1/_sampling',
+        mockModel,
+        { aggregator, abortSignal: abortController.signal },
+      );
+    });
+
+    test('returns sampler result directly when no forcedMethod', async () => {
+      mockSamplerInstance.sample.mockResolvedValue({
+        method: 'vlm',
+        reason: 'Korean-Hanja mix detected',
+        sampledPages: 2,
+        totalPages: 10,
+        detectedLanguages: ['ko-KR'],
+        koreanHanjaMixPages: [1, 3],
+      });
+
+      const result = await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        strategySamplerModel: mockModel,
+      });
+
+      expect(result.method).toBe('vlm');
+      expect(result.reason).toBe('Korean-Hanja mix detected');
+      expect(result.detectedLanguages).toEqual(['ko-KR']);
+      expect(result.koreanHanjaMixPages).toEqual([1, 3]);
+    });
+
+    test('overrides method when forcedMethod is specified with sampling', async () => {
+      mockSamplerInstance.sample.mockResolvedValue({
+        method: 'ocrmac',
+        reason: 'No Korean-Hanja mix detected',
+        sampledPages: 3,
+        totalPages: 10,
+        detectedLanguages: ['ko-KR'],
+      });
+
+      const result = await resolver.resolve('/tmp/report.pdf', 'report-1', {
+        strategySamplerModel: mockModel,
+        forcedMethod: 'vlm',
+      });
+
+      // Sampler should be called even with forcedMethod
+      expect(mockSamplerInstance.sample).toHaveBeenCalled();
+      // Method should be overridden to forced value
+      expect(result.method).toBe('vlm');
+      // Reason should combine forced label with original sampling reason
+      expect(result.reason).toBe('Forced: vlm (No Korean-Hanja mix detected)');
+      // Detected languages from sampling should be preserved
+      expect(result.detectedLanguages).toEqual(['ko-KR']);
+      // Sampling metadata should be preserved
+      expect(result.sampledPages).toBe(3);
+      expect(result.totalPages).toBe(10);
+    });
+  });
+
+  describe('sampling directory cleanup', () => {
+    test('cleans up sampling directory after successful sampling', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+
+      await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        strategySamplerModel: mockModel,
+      });
+
+      expect(rmSync).toHaveBeenCalledWith(
+        '/test/cwd/output/report-1/_sampling',
+        { recursive: true, force: true },
+      );
+    });
+
+    test('cleans up sampling directory even when sampling fails', async () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      mockSamplerInstance.sample.mockRejectedValue(
+        new Error('Sampling failed'),
+      );
+
+      await expect(
+        resolver.resolve('/tmp/test.pdf', 'report-1', {
+          strategySamplerModel: mockModel,
+        }),
+      ).rejects.toThrow('Sampling failed');
+
+      expect(rmSync).toHaveBeenCalledWith(
+        '/test/cwd/output/report-1/_sampling',
+        { recursive: true, force: true },
+      );
+    });
+
+    test('skips cleanup when sampling directory does not exist', async () => {
+      vi.mocked(existsSync).mockReturnValue(false);
+
+      await resolver.resolve('/tmp/test.pdf', 'report-1', {
+        strategySamplerModel: mockModel,
+      });
+
+      expect(rmSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/pdf-parser/src/core/strategy-resolver.ts
+++ b/packages/pdf-parser/src/core/strategy-resolver.ts
@@ -1,0 +1,77 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { OcrStrategy } from '@heripo/model';
+
+import type { PDFConvertOptions } from './pdf-converter';
+
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { PageRenderer } from '../processors/page-renderer';
+import { PdfTextExtractor } from '../processors/pdf-text-extractor';
+import { OcrStrategySampler } from '../samplers/ocr-strategy-sampler';
+
+/**
+ * Resolves the OCR strategy based on options and page sampling.
+ *
+ * When sampling is possible (strategySamplerModel + local file), it always
+ * runs — even with forcedMethod — so that detectedLanguages are available
+ * for OCR engine configuration. The forced method simply overrides the
+ * sampled method choice.
+ */
+export class StrategyResolver {
+  constructor(private readonly logger: LoggerMethods) {}
+
+  async resolve(
+    pdfPath: string | null,
+    reportId: string,
+    options: PDFConvertOptions,
+    abortSignal?: AbortSignal,
+  ): Promise<OcrStrategy> {
+    // Cannot sample: skip, no sampler model, or non-local URL
+    if (options.skipSampling || !options.strategySamplerModel || !pdfPath) {
+      const method = options.forcedMethod ?? 'ocrmac';
+      const reason = options.forcedMethod
+        ? `Forced: ${options.forcedMethod}`
+        : !pdfPath
+          ? 'Non-local URL, sampling skipped'
+          : 'Sampling skipped';
+      return { method, reason, sampledPages: 0, totalPages: 0 };
+    }
+
+    // Sample pages to determine strategy (also detects languages)
+    const samplingDir = join(process.cwd(), 'output', reportId, '_sampling');
+    const sampler = new OcrStrategySampler(
+      this.logger,
+      new PageRenderer(this.logger),
+      new PdfTextExtractor(this.logger),
+    );
+
+    try {
+      const strategy = await sampler.sample(
+        pdfPath,
+        samplingDir,
+        options.strategySamplerModel,
+        {
+          aggregator: options.aggregator,
+          abortSignal,
+        },
+      );
+
+      // Override method when forced, preserving detected languages from sampling
+      if (options.forcedMethod) {
+        return {
+          ...strategy,
+          method: options.forcedMethod,
+          reason: `Forced: ${options.forcedMethod} (${strategy.reason})`,
+        };
+      }
+
+      return strategy;
+    } finally {
+      // Always clean up sampling temp directory
+      if (existsSync(samplingDir)) {
+        rmSync(samplingDir, { recursive: true, force: true });
+      }
+    }
+  }
+}

--- a/packages/pdf-parser/src/core/vlm-conversion-pipeline.test.ts
+++ b/packages/pdf-parser/src/core/vlm-conversion-pipeline.test.ts
@@ -1,0 +1,328 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { LLMTokenUsageAggregator } from '@heripo/shared';
+import { copyFileSync } from 'node:fs';
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PdfTextExtractor } from '../processors/pdf-text-extractor';
+import { VlmTextCorrector } from '../processors/vlm-text-corrector';
+import { runJqFileJson } from '../utils/jq';
+import { VlmConversionPipeline } from './vlm-conversion-pipeline';
+
+vi.mock('node:fs', () => ({
+  copyFileSync: vi.fn(),
+}));
+
+vi.mock('node:path', () => ({
+  join: vi.fn((...args: string[]) => args.join('/')),
+}));
+
+vi.mock('../utils/jq', () => ({
+  runJqFileJson: vi.fn(),
+}));
+
+vi.mock('../processors/pdf-text-extractor', () => ({
+  PdfTextExtractor: vi.fn(),
+}));
+
+vi.mock('../processors/vlm-text-corrector', () => ({
+  VlmTextCorrector: vi.fn(),
+}));
+
+const mockModel = { modelId: 'test-model' } as any;
+
+describe('VlmConversionPipeline', () => {
+  let logger: LoggerMethods;
+  let pipeline: VlmConversionPipeline;
+  let mockCorrectorInstance: { correctAndSave: Mock };
+  let mockTextExtractorInstance: { extractText: Mock };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    pipeline = new VlmConversionPipeline(logger);
+
+    mockCorrectorInstance = {
+      correctAndSave: vi.fn().mockResolvedValue({
+        textCorrections: 0,
+        cellCorrections: 0,
+        pagesProcessed: 5,
+        pagesFailed: 0,
+      }),
+    };
+    vi.mocked(VlmTextCorrector).mockImplementation(function () {
+      return mockCorrectorInstance as any;
+    });
+
+    mockTextExtractorInstance = {
+      extractText: vi.fn().mockResolvedValue(new Map<number, string>()),
+    };
+    vi.mocked(PdfTextExtractor).mockImplementation(function () {
+      return mockTextExtractorInstance as any;
+    });
+
+    vi.mocked(runJqFileJson).mockResolvedValue(1);
+  });
+
+  describe('wrapCallback', () => {
+    test('throws error when vlmProcessorModel is missing', () => {
+      expect(() => pipeline.wrapCallback('/tmp/test.pdf', {}, vi.fn())).toThrow(
+        'vlmProcessorModel is required when OCR strategy is VLM',
+      );
+    });
+
+    test('returns a callback function', () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+      expect(typeof wrapped).toBe('function');
+    });
+
+    test('wrapped callback calls VlmTextCorrector then original callback', async () => {
+      const originalCallback = vi.fn();
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        originalCallback,
+      );
+
+      await wrapped('/test/output');
+
+      expect(VlmTextCorrector).toHaveBeenCalledWith(logger);
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({
+          aggregator: undefined,
+          abortSignal: undefined,
+        }),
+      );
+      expect(originalCallback).toHaveBeenCalledWith('/test/output');
+    });
+
+    test('wrapped callback extracts text with PdfTextExtractor and passes pageTexts', async () => {
+      const pageTexts = new Map<number, string>();
+      pageTexts.set(1, 'extracted text page 1');
+      mockTextExtractorInstance.extractText.mockResolvedValue(pageTexts);
+      vi.mocked(runJqFileJson).mockResolvedValue(2);
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(PdfTextExtractor).toHaveBeenCalledWith(logger);
+      expect(mockTextExtractorInstance.extractText).toHaveBeenCalledWith(
+        '/tmp/test.pdf',
+        2,
+      );
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ pageTexts }),
+      );
+    });
+
+    test('wrapped callback proceeds without pageTexts when extraction fails', async () => {
+      mockTextExtractorInstance.extractText.mockRejectedValue(
+        new Error('pdftotext not found'),
+      );
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
+      );
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ pageTexts: undefined }),
+      );
+    });
+
+    test('wrapped callback proceeds without pageTexts when jq fails', async () => {
+      vi.mocked(runJqFileJson).mockRejectedValue(new Error('ENOENT'));
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
+      );
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ pageTexts: undefined }),
+      );
+    });
+
+    test('copies result.json to result_ocr_origin.json before VLM correction', async () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(copyFileSync).toHaveBeenCalledWith(
+        '/test/output/result.json',
+        '/test/output/result_ocr_origin.json',
+      );
+
+      const copyOrder = vi.mocked(copyFileSync).mock.invocationCallOrder[0];
+      const correctorOrder =
+        mockCorrectorInstance.correctAndSave.mock.invocationCallOrder[0];
+      expect(copyOrder).toBeLessThan(correctorOrder);
+    });
+
+    test('passes detectedLanguages to VlmTextCorrector as documentLanguages', async () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+        undefined,
+        ['ko-KR'],
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ documentLanguages: ['ko-KR'] }),
+      );
+    });
+
+    test('passes undefined documentLanguages when detectedLanguages is not provided', async () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ documentLanguages: undefined }),
+      );
+    });
+
+    test('passes koreanHanjaMixPages to VlmTextCorrector', async () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+        undefined,
+        ['ko-KR'],
+        [1, 3, 5],
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ koreanHanjaMixPages: [1, 3, 5] }),
+      );
+    });
+
+    test('passes aggregator and abortSignal to VlmTextCorrector', async () => {
+      const aggregator = new LLMTokenUsageAggregator();
+      const abortController = new AbortController();
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel, aggregator },
+        vi.fn(),
+        abortController.signal,
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({
+          aggregator,
+          abortSignal: abortController.signal,
+        }),
+      );
+    });
+
+    test('forwards onTokenUsage callback to VlmTextCorrector', async () => {
+      const onTokenUsage = vi.fn();
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel, onTokenUsage },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ onTokenUsage }),
+      );
+    });
+
+    test('forwards vlmConcurrency to VlmTextCorrector as concurrency', async () => {
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel, vlmConcurrency: 4 },
+        vi.fn(),
+      );
+
+      await wrapped('/test/output');
+
+      expect(mockCorrectorInstance.correctAndSave).toHaveBeenCalledWith(
+        '/test/output',
+        mockModel,
+        expect.objectContaining({ concurrency: 4 }),
+      );
+    });
+
+    test('propagates errors from VlmTextCorrector', async () => {
+      mockCorrectorInstance.correctAndSave.mockRejectedValue(
+        new Error('VLM correction failed'),
+      );
+
+      const wrapped = pipeline.wrapCallback(
+        '/tmp/test.pdf',
+        { vlmProcessorModel: mockModel },
+        vi.fn(),
+      );
+
+      await expect(wrapped('/test/output')).rejects.toThrow(
+        'VLM correction failed',
+      );
+    });
+  });
+});

--- a/packages/pdf-parser/src/core/vlm-conversion-pipeline.ts
+++ b/packages/pdf-parser/src/core/vlm-conversion-pipeline.ts
@@ -1,0 +1,81 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { LanguageModel } from 'ai';
+
+import type {
+  ConversionCompleteCallback,
+  PDFConvertOptions,
+} from './pdf-converter';
+
+import { copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { PdfTextExtractor } from '../processors/pdf-text-extractor';
+import { VlmTextCorrector } from '../processors/vlm-text-corrector';
+import { runJqFileJson } from '../utils/jq';
+
+/**
+ * Wraps the standard OCR callback with VLM text correction.
+ *
+ * Runs the standard OCR pipeline (Docling) first, then applies VLM text
+ * correction to fix garbled Chinese characters (漢字/Hanja) in OCR output.
+ */
+export class VlmConversionPipeline {
+  constructor(private readonly logger: LoggerMethods) {}
+
+  /**
+   * Wrap the original callback with VLM text correction.
+   * Returns a new callback that runs VLM correction before calling the original.
+   */
+  wrapCallback(
+    pdfPath: string,
+    options: PDFConvertOptions,
+    originalCallback: ConversionCompleteCallback,
+    abortSignal?: AbortSignal,
+    detectedLanguages?: string[],
+    koreanHanjaMixPages?: number[],
+  ): ConversionCompleteCallback {
+    if (!options.vlmProcessorModel) {
+      throw new Error('vlmProcessorModel is required when OCR strategy is VLM');
+    }
+
+    return async (outputDir: string) => {
+      // Pre-extract text from PDF text layer for VLM reference
+      let pageTexts: Map<number, string> | undefined;
+      try {
+        const resultPath = join(outputDir, 'result.json');
+        // Use jq to extract only page count — avoids loading full JSON into memory
+        const totalPages = await runJqFileJson<number>(
+          '.pages | length',
+          resultPath,
+        );
+        const textExtractor = new PdfTextExtractor(this.logger);
+        pageTexts = await textExtractor.extractText(pdfPath, totalPages);
+      } catch {
+        this.logger.warn(
+          '[PDFConverter] pdftotext extraction failed, proceeding without text reference',
+        );
+      }
+
+      // Save OCR-only result before VLM correction for debugging
+      const resultPath = join(outputDir, 'result.json');
+      const ocrOriginPath = join(outputDir, 'result_ocr_origin.json');
+      copyFileSync(resultPath, ocrOriginPath);
+
+      const corrector = new VlmTextCorrector(this.logger);
+      await corrector.correctAndSave(
+        outputDir,
+        options.vlmProcessorModel as LanguageModel,
+        {
+          concurrency: options.vlmConcurrency,
+          aggregator: options.aggregator,
+          abortSignal,
+          onTokenUsage: options.onTokenUsage,
+          documentLanguages: detectedLanguages,
+          pageTexts,
+          koreanHanjaMixPages,
+        },
+      );
+      await originalCallback(outputDir);
+    };
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Decompose the monolithic `PDFConverter` class into focused, single-responsibility modules to improve maintainability and testability. Three new classes — `DoclingConversionExecutor`, `VlmConversionPipeline`, and `StrategyResolver` — now own the conversion execution, VLM pipeline orchestration, and OCR strategy determination logic respectively, while `PDFConverter` acts as a thin orchestrator.

## Changes

- Extract Docling conversion execution logic (`performConversion`, file server management, result downloading, image extraction) into `DoclingConversionExecutor` (`docling-conversion-executor.ts`)
- Extract VLM-related conversion flow (`convertWithVlm`, mixed-script correction orchestration) into `VlmConversionPipeline` (`vlm-conversion-pipeline.ts`)
- Extract OCR strategy determination and sampling logic into `StrategyResolver` (`strategy-resolver.ts`)
- Simplify `PDFConverter` to delegate to the new modules, removing inlined conversion and strategy code
- Add comprehensive unit tests for all three new classes (`docling-conversion-executor.test.ts`, `vlm-conversion-pipeline.test.ts`, `strategy-resolver.test.ts`)
- Refactor existing `pdf-converter.test.ts` and `pdf-converter-strategy.test.ts` to mock the extracted modules

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
