### PR TITLE
chore: update GitHub Actions to use latest action versions

### DIFF
--- a/.github/workflows/cd-demo-web.yml
+++ b/.github/workflows/cd-demo-web.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: org-mac
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Backup existing data
         run: |
@@ -154,7 +154,7 @@ jobs:
           echo "✅ Application restarted"
 
       - name: Slack notification
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@v3
         if: always()
         with:
           method: chat.postMessage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Upgrade GitHub Actions dependencies to their latest major versions for improved compatibility and reliability. This keeps the CI/CD pipeline up to date with upstream action releases.

## Changes

- Upgrade `actions/checkout` from v4 to v6 in `ci.yml` and `cd-demo-web.yml`
- Upgrade `slackapi/slack-github-action` from v2 to v3 in `cd-demo-web.yml`

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
