### PR TITLE
refactor(pdf-parser): centralize system checks and simplify initialization/parsing flow

### DIFF
--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -892,7 +892,7 @@ describe('PDFParser', () => {
     });
   });
 
-  describe('strategy-based flow (parseWithStrategy)', () => {
+  describe('strategy-based flow', () => {
     test('parse routes to strategy flow when strategySamplerModel is provided', async () => {
       vi.mocked(platform).mockReturnValue('darwin');
       vi.mocked(execSync as any).mockImplementation((cmd: string) => {

--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -1,18 +1,15 @@
 import * as DoclingSdk from 'docling-sdk';
-import { execSync } from 'node:child_process';
-import { platform } from 'node:os';
 import { describe, expect, test, vi } from 'vitest';
 
 import * as EnvMod from '../environment/docling-environment';
+import * as SystemChecks from '../utils/system-checks';
 import * as ConvMod from './pdf-converter';
 import { PDFParser } from './pdf-parser';
 
-vi.mock('node:os', () => ({
-  platform: vi.fn(() => 'darwin'),
-}));
-
-vi.mock('node:child_process', () => ({
-  execSync: vi.fn(() => ''),
+vi.mock('../utils/system-checks', () => ({
+  checkCommandExists: vi.fn(),
+  checkOperatingSystem: vi.fn(),
+  checkMacOSVersion: vi.fn(),
 }));
 
 vi.mock('docling-sdk', () => {
@@ -75,13 +72,6 @@ const convertWithStrategyMock = (ConvMod as any)
 
 describe('PDFParser', () => {
   test('init with external server (baseUrl) succeeds and waits for health', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      // Return a non-matching version string to cover the versionMatch === null branch
-      if (cmd.startsWith('sw_vers')) return 'unknown-version-output';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
 
     const logger = makeLogger();
@@ -92,6 +82,16 @@ describe('PDFParser', () => {
     });
     await parser.init();
 
+    expect(SystemChecks.checkOperatingSystem).toHaveBeenCalled();
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'jq',
+      expect.any(String),
+    );
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'pdftotext',
+      expect.any(String),
+    );
+    expect(SystemChecks.checkMacOSVersion).toHaveBeenCalled();
     expect(Docling).toHaveBeenCalledWith({
       api: { baseUrl: 'http://example.com', timeout: 123 },
     });
@@ -99,12 +99,6 @@ describe('PDFParser', () => {
   });
 
   test('init with local server succeeds (environment setup and client ready)', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '13.5.1';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
     vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
@@ -130,12 +124,6 @@ describe('PDFParser', () => {
   });
 
   test('init with local server wraps environment setup error', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '13.0.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     vi.mocked(envMocks.setupMock).mockRejectedValueOnce(new Error('boom'));
 
     const logger = makeLogger();
@@ -149,12 +137,6 @@ describe('PDFParser', () => {
 
   test('waitForServerReady times out after maximum attempts (logs throttled)', async () => {
     vi.useFakeTimers();
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.3';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockRejectedValue(new Error('down'));
 
     const logger = makeLogger();
@@ -170,8 +152,12 @@ describe('PDFParser', () => {
     vi.useRealTimers();
   });
 
-  test('throws on non-macOS platforms', async () => {
-    vi.mocked(platform).mockReturnValue('linux');
+  test('init propagates checkOperatingSystem error', async () => {
+    vi.mocked(SystemChecks.checkOperatingSystem).mockImplementationOnce(() => {
+      throw new Error(
+        'PDFParser is only supported on macOS. Current platform: linux',
+      );
+    });
     const logger = makeLogger();
     const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
     await expect(parser.init()).rejects.toThrow(
@@ -179,12 +165,12 @@ describe('PDFParser', () => {
     );
   });
 
-  test('throws when jq is not installed', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('which jq')) throw new Error('not found');
-      return '';
-    });
+  test('init propagates checkCommandExists error for jq', async () => {
+    vi.mocked(SystemChecks.checkCommandExists).mockImplementationOnce(
+      (_cmd, msg) => {
+        throw new Error(msg);
+      },
+    );
     const logger = makeLogger();
     const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
     await expect(parser.init()).rejects.toThrow(
@@ -192,13 +178,13 @@ describe('PDFParser', () => {
     );
   });
 
-  test('throws when poppler is not installed', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('which pdftotext')) throw new Error('not found');
-      return '';
-    });
+  test('init propagates checkCommandExists error for poppler', async () => {
+    // First call (jq) succeeds, second call (pdftotext) throws
+    vi.mocked(SystemChecks.checkCommandExists)
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce((_cmd, msg) => {
+        throw new Error(msg);
+      });
     const logger = makeLogger();
     const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
     await expect(parser.init()).rejects.toThrow(
@@ -206,12 +192,11 @@ describe('PDFParser', () => {
     );
   });
 
-  test('throws when macOS version is below 10.15', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('sw_vers')) return '10.14.6';
-      return '';
+  test('init propagates checkMacOSVersion error', async () => {
+    vi.mocked(SystemChecks.checkMacOSVersion).mockImplementationOnce(() => {
+      throw new Error(
+        'macOS 10.15 or later is required. Current version: 10.14.6',
+      );
     });
     const logger = makeLogger();
     const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
@@ -220,28 +205,37 @@ describe('PDFParser', () => {
     );
   });
 
-  test('throws when macOS version check fails unexpectedly', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('sw_vers')) throw new Error('boom');
-      return '';
-    });
+  test('init checks ImageMagick and Ghostscript when enableImagePdfFallback on local server', async () => {
+    doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+
     const logger = makeLogger();
-    const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
-    await expect(parser.init()).rejects.toThrow(
-      'Failed to check macOS version',
+    const parser = new PDFParser({
+      logger,
+      port: 5001,
+      enableImagePdfFallback: true,
+    });
+    await parser.init();
+
+    // jq, pdftotext, magick, gs = 4 calls
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'magick',
+      expect.stringContaining('ImageMagick'),
+    );
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'gs',
+      expect.stringContaining('Ghostscript'),
     );
   });
 
-  test('throws when ImageMagick is not installed with enableImagePdfFallback on local server', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '13.0.0';
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('which magick')) throw new Error('not found');
-      return '';
-    });
+  test('init propagates ImageMagick check error with enableImagePdfFallback on local server', async () => {
+    // jq ok, pdftotext ok, magick throws
+    vi.mocked(SystemChecks.checkCommandExists)
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce((_cmd, msg) => {
+        throw new Error(msg);
+      });
     const logger = makeLogger();
     const parser = new PDFParser({
       logger,
@@ -254,15 +248,15 @@ describe('PDFParser', () => {
     );
   });
 
-  test('throws when Ghostscript is not installed with enableImagePdfFallback on local server', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '13.0.0';
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('which magick')) return '';
-      if (cmd.startsWith('which gs')) throw new Error('not found');
-      return '';
-    });
+  test('init propagates Ghostscript check error with enableImagePdfFallback on local server', async () => {
+    // jq ok, pdftotext ok, magick ok, gs throws
+    vi.mocked(SystemChecks.checkCommandExists)
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce((_cmd, msg) => {
+        throw new Error(msg);
+      });
     const logger = makeLogger();
     const parser = new PDFParser({
       logger,
@@ -275,16 +269,7 @@ describe('PDFParser', () => {
     );
   });
 
-  test('does not check ImageMagick/Ghostscript when enableImagePdfFallback is false', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '13.0.0';
-      if (cmd.startsWith('which jq')) return '';
-      // magick and gs would throw if called, but they should not be called
-      if (cmd.startsWith('which magick')) throw new Error('not found');
-      if (cmd.startsWith('which gs')) throw new Error('not found');
-      return '';
-    });
+  test('init does not check ImageMagick/Ghostscript when enableImagePdfFallback is false', async () => {
     doclingClient.health.mockResolvedValueOnce();
 
     const logger = makeLogger();
@@ -293,8 +278,10 @@ describe('PDFParser', () => {
       baseUrl: 'http://example.com',
       enableImagePdfFallback: false,
     });
-    // Should not throw because ImageMagick/Ghostscript checks are skipped
     await expect(parser.init()).resolves.toBeUndefined();
+
+    // Only jq and pdftotext should be checked
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledTimes(2);
   });
 
   test('parse throws if called before init', async () => {
@@ -308,12 +295,6 @@ describe('PDFParser', () => {
   });
 
   test('parse delegates to PDFConverter.convert after init', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce('OK');
 
@@ -330,8 +311,6 @@ describe('PDFParser', () => {
       { num_threads: 4 },
     );
 
-    // Third argument is false because baseUrl is used (external server)
-    // Fourth argument is the timeout value (defaults to PDF_PARSER.DEFAULT_TIMEOUT_MS)
     expect(PDFConverter).toHaveBeenCalledWith(
       logger,
       expect.any(Object),
@@ -350,12 +329,6 @@ describe('PDFParser', () => {
   });
 
   test('parse returns TokenUsageReport from converter via strategy flow', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
 
     const mockReport = {
@@ -406,12 +379,6 @@ describe('PDFParser', () => {
   });
 
   test('parse returns null when converter returns null', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce(null);
 
@@ -430,47 +397,47 @@ describe('PDFParser', () => {
     expect(result).toBeNull();
   });
 
-  test('parse checks ImageMagick and Ghostscript when forceImagePdf is true on local server', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    const whichCalls: string[] = [];
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which')) {
-        whichCalls.push(cmd);
-        return '';
-      }
-      return '';
-    });
+  test('parse calls checkCommandExists for magick and gs when forceImagePdf is true on local server', async () => {
     doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce('OK');
 
     const logger = makeLogger();
     const parser = new PDFParser({ logger, port: 5001 });
     await parser.init();
 
+    // Clear mock calls from init
+    vi.mocked(SystemChecks.checkCommandExists).mockClear();
+
     await parser.parse('http://file.pdf', 'report-1', vi.fn(), false, {
       num_threads: 4,
       forceImagePdf: true,
     });
 
-    // Should check for ImageMagick and Ghostscript during parse
-    expect(whichCalls).toContain('which magick');
-    expect(whichCalls).toContain('which gs');
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'magick',
+      expect.stringContaining('ImageMagick'),
+    );
+    expect(SystemChecks.checkCommandExists).toHaveBeenCalledWith(
+      'gs',
+      expect.stringContaining('Ghostscript'),
+    );
   });
 
-  test('parse throws when ImageMagick is missing with forceImagePdf on local server', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      if (cmd.startsWith('which magick')) throw new Error('not found');
-      return '';
-    });
+  test('parse propagates checkCommandExists error when forceImagePdf and magick missing', async () => {
     doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
     const logger = makeLogger();
     const parser = new PDFParser({ logger, port: 5001 });
     await parser.init();
+
+    // After init, make checkCommandExists throw for magick
+    vi.mocked(SystemChecks.checkCommandExists).mockImplementation(
+      (cmd, msg) => {
+        if (cmd === 'magick') throw new Error(msg);
+      },
+    );
 
     await expect(
       parser.parse('http://file.pdf', 'report-1', vi.fn(), false, {
@@ -481,16 +448,6 @@ describe('PDFParser', () => {
   });
 
   test('parse skips forceImagePdf dependency check when using external server', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    const whichCalls: string[] = [];
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which')) {
-        whichCalls.push(cmd);
-        return '';
-      }
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce('OK');
 
@@ -498,27 +455,21 @@ describe('PDFParser', () => {
     const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
     await parser.init();
 
-    // Reset whichCalls after init
-    whichCalls.length = 0;
+    // Clear mock calls from init
+    vi.mocked(SystemChecks.checkCommandExists).mockClear();
 
     await parser.parse('http://file.pdf', 'report-1', vi.fn(), false, {
       num_threads: 4,
       forceImagePdf: true,
     });
 
-    // Should NOT check for magick/gs since external server is used
-    expect(whichCalls).not.toContain('which magick');
-    expect(whichCalls).not.toContain('which gs');
+    // Should NOT call checkCommandExists during parse since external server
+    expect(SystemChecks.checkCommandExists).not.toHaveBeenCalled();
   });
 
   test('parse passes enableImagePdfFallback=true when local server and option enabled', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which')) return ''; // jq, magick, gs all found
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce('OK');
 
     const logger = makeLogger();
@@ -534,8 +485,6 @@ describe('PDFParser', () => {
       num_threads: 4,
     });
 
-    // Third argument is true because local server mode and fallback is enabled
-    // Fourth argument is the timeout value
     expect(PDFConverter).toHaveBeenCalledWith(
       logger,
       expect.any(Object),
@@ -545,12 +494,6 @@ describe('PDFParser', () => {
   });
 
   test('parse passes enableImagePdfFallback=false when external server even if option enabled', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
     convertMock.mockResolvedValueOnce('OK');
 
@@ -567,8 +510,6 @@ describe('PDFParser', () => {
       num_threads: 4,
     });
 
-    // Third argument is false because external server mode disables fallback
-    // Fourth argument is the timeout value
     expect(PDFConverter).toHaveBeenCalledWith(
       logger,
       expect.any(Object),
@@ -582,12 +523,6 @@ describe('PDFParser', () => {
   });
 
   test('dispose with external server destroys client without killing local process', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
 
     const logger = makeLogger();
@@ -603,13 +538,8 @@ describe('PDFParser', () => {
   });
 
   test('dispose with local server kills process and destroys client', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
     const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
     killSpy.mockResolvedValueOnce();
 
@@ -623,13 +553,8 @@ describe('PDFParser', () => {
   });
 
   test('dispose swallows kill errors but still destroys client', async () => {
-    vi.mocked(platform).mockReturnValue('darwin');
-    vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-      if (cmd.startsWith('sw_vers')) return '12.6.0';
-      if (cmd.startsWith('which jq')) return '';
-      return '';
-    });
     doclingClient.health.mockResolvedValueOnce();
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
     const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
     killSpy.mockRejectedValueOnce(new Error('kill failed'));
 
@@ -644,13 +569,8 @@ describe('PDFParser', () => {
 
   describe('server recovery', () => {
     test('parse recovers from ECONNREFUSED error on local server', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
@@ -691,12 +611,6 @@ describe('PDFParser', () => {
     });
 
     test('parse does not recover from ECONNREFUSED error on external server', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
 
       const econnRefusedError = new Error(
@@ -719,13 +633,8 @@ describe('PDFParser', () => {
     });
 
     test('parse throws after recovery attempt fails', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
@@ -763,13 +672,8 @@ describe('PDFParser', () => {
     });
 
     test('parse throws non-ECONNREFUSED errors without recovery', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
       convertMock.mockRejectedValueOnce(new Error('Some other error'));
 
@@ -788,13 +692,8 @@ describe('PDFParser', () => {
     });
 
     test('isConnectionRefusedError returns false for non-Error objects', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
       // Throw a non-Error object
       convertMock.mockRejectedValueOnce('string error');
@@ -814,13 +713,8 @@ describe('PDFParser', () => {
     });
 
     test('parse recovers from ECONNREFUSED in error cause chain (ofetch style)', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
@@ -856,13 +750,8 @@ describe('PDFParser', () => {
     });
 
     test('parse throws immediately when abortSignal is already aborted', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
@@ -894,12 +783,6 @@ describe('PDFParser', () => {
 
   describe('strategy-based flow', () => {
     test('parse routes to strategy flow when strategySamplerModel is provided', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
 
       const mockReport = {
@@ -943,12 +826,6 @@ describe('PDFParser', () => {
     });
 
     test('parse routes to strategy flow when forcedMethod is provided', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
 
       convertWithStrategyMock.mockResolvedValueOnce({
@@ -979,12 +856,6 @@ describe('PDFParser', () => {
     });
 
     test('parse returns null tokenUsageReport from strategy flow', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
 
       convertWithStrategyMock.mockResolvedValueOnce({
@@ -1013,13 +884,8 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow recovers from ECONNREFUSED on local server', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
@@ -1066,12 +932,6 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow does not recover on external server', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
 
       const econnRefusedError = new Error(
@@ -1093,13 +953,8 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow throws immediately when abortSignal is aborted', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
       const abortError = new Error('Aborted');
       abortError.name = 'AbortError';
@@ -1127,13 +982,8 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow throws after recovery attempt exhausted', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
       const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
       killSpy.mockResolvedValue(undefined);
 
@@ -1164,13 +1014,8 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow passes enableImagePdfFallback=true for local server', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
 
       convertWithStrategyMock.mockResolvedValueOnce({
         strategy: {
@@ -1204,12 +1049,6 @@ describe('PDFParser', () => {
     });
 
     test('strategy flow uses legacy flow when neither strategySamplerModel nor forcedMethod set', async () => {
-      vi.mocked(platform).mockReturnValue('darwin');
-      vi.mocked(execSync as any).mockImplementation((cmd: string) => {
-        if (cmd.startsWith('sw_vers')) return '12.6.0';
-        if (cmd.startsWith('which jq')) return '';
-        return '';
-      });
       doclingClient.health.mockResolvedValueOnce();
       convertMock.mockResolvedValueOnce('legacy-result');
 

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -359,99 +359,17 @@ export class PDFParser {
       options.strategySamplerModel !== undefined ||
       options.forcedMethod !== undefined;
 
-    if (useStrategyFlow) {
-      return this.parseWithStrategy(
-        url,
-        reportId,
-        onComplete,
-        cleanupAfterCallback,
-        options,
-        abortSignal,
+    return this.executeWithRecovery(async () => {
+      const effectiveFallbackEnabled =
+        this.enableImagePdfFallback && !this.baseUrl;
+      const converter = new PDFConverter(
+        this.logger,
+        this.client!,
+        effectiveFallbackEnabled,
+        this.timeout,
       );
-    }
 
-    // Enable recovery only for local server mode
-    const canRecover = !this.baseUrl && this.port !== undefined;
-    const maxAttempts = PDF_PARSER.MAX_SERVER_RECOVERY_ATTEMPTS;
-    let attempt = 0;
-
-    while (attempt <= maxAttempts) {
-      try {
-        // Enable fallback only for local server mode
-        const effectiveFallbackEnabled =
-          this.enableImagePdfFallback && !this.baseUrl;
-        const converter = new PDFConverter(
-          this.logger,
-          this.client,
-          effectiveFallbackEnabled,
-          this.timeout,
-        );
-        return await converter.convert(
-          url,
-          reportId,
-          onComplete,
-          cleanupAfterCallback,
-          options,
-          abortSignal,
-        );
-      } catch (error) {
-        // If aborted, don't retry - re-throw immediately
-        if (abortSignal?.aborted) {
-          throw error;
-        }
-
-        // Attempt server recovery on ECONNREFUSED (server crashed)
-        if (
-          canRecover &&
-          this.isConnectionRefusedError(error) &&
-          attempt < maxAttempts
-        ) {
-          this.logger.warn(
-            '[PDFParser] Connection refused, attempting server recovery...',
-          );
-          await this.restartServer();
-          attempt++;
-          continue;
-        }
-        throw error;
-      }
-    }
-
-    /* v8 ignore start */
-    return null;
-    /* v8 ignore stop */
-  }
-
-  /**
-   * Parse a PDF using OCR strategy sampling to decide between ocrmac and VLM.
-   * Delegates to PDFConverter.convertWithStrategy() and returns the token usage report.
-   *
-   * Server recovery (restart on ECONNREFUSED) is preserved because
-   * the ocrmac path still uses the Docling server.
-   */
-  private async parseWithStrategy(
-    url: string,
-    reportId: string,
-    onComplete: ConversionCompleteCallback,
-    cleanupAfterCallback: boolean,
-    options: PDFConvertOptions,
-    abortSignal?: AbortSignal,
-  ): Promise<TokenUsageReport | null> {
-    // Enable recovery only for local server mode
-    const canRecover = !this.baseUrl && this.port !== undefined;
-    const maxAttempts = PDF_PARSER.MAX_SERVER_RECOVERY_ATTEMPTS;
-    let attempt = 0;
-
-    while (attempt <= maxAttempts) {
-      try {
-        const effectiveFallbackEnabled =
-          this.enableImagePdfFallback && !this.baseUrl;
-        const converter = new PDFConverter(
-          this.logger,
-          this.client!,
-          effectiveFallbackEnabled,
-          this.timeout,
-        );
+      if (useStrategyFlow) {
         const result = await converter.convertWithStrategy(
           url,
           reportId,
@@ -461,13 +379,36 @@ export class PDFParser {
           abortSignal,
         );
         return result.tokenUsageReport;
-      } catch (error) {
-        // If aborted, don't retry - re-throw immediately
-        if (abortSignal?.aborted) {
-          throw error;
-        }
+      }
 
-        // Attempt server recovery on ECONNREFUSED (server crashed)
+      return converter.convert(
+        url,
+        reportId,
+        onComplete,
+        cleanupAfterCallback,
+        options,
+        abortSignal,
+      );
+    }, abortSignal);
+  }
+
+  /**
+   * Execute a function with automatic server recovery on ECONNREFUSED errors.
+   * Recovery is only attempted in local server mode (no baseUrl, port defined).
+   */
+  private async executeWithRecovery<T>(
+    fn: () => Promise<T>,
+    abortSignal?: AbortSignal,
+  ): Promise<T> {
+    const canRecover = !this.baseUrl && this.port !== undefined;
+    const maxAttempts = PDF_PARSER.MAX_SERVER_RECOVERY_ATTEMPTS;
+    let attempt = 0;
+
+    while (attempt <= maxAttempts) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (abortSignal?.aborted) throw error;
         if (
           canRecover &&
           this.isConnectionRefusedError(error) &&
@@ -485,7 +426,7 @@ export class PDFParser {
     }
 
     /* v8 ignore start */
-    return null;
+    return null as T;
     /* v8 ignore stop */
   }
 

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -3,12 +3,15 @@ import type { TokenUsageReport } from '@heripo/model';
 import type { DoclingAPIClient } from 'docling-sdk';
 
 import { Docling } from 'docling-sdk';
-import { execSync } from 'node:child_process';
-import { platform } from 'node:os';
 import { join } from 'node:path';
 
 import { PDF_PARSER } from '../config/constants';
 import { DoclingEnvironment } from '../environment/docling-environment';
+import {
+  checkCommandExists,
+  checkMacOSVersion,
+  checkOperatingSystem,
+} from '../utils/system-checks';
 import {
   type ConversionCompleteCallback,
   type PDFConvertOptions,
@@ -119,15 +122,29 @@ export class PDFParser {
   async init(): Promise<void> {
     this.logger.info('[PDFParser] Initializing...');
 
-    this.checkOperatingSystem();
-    this.checkJqInstalled();
-    this.checkPopplerInstalled();
-    this.checkMacOSVersion();
+    checkOperatingSystem();
+    checkCommandExists(
+      'jq',
+      'jq is not installed. Please install jq using: brew install jq',
+    );
+    checkCommandExists(
+      'pdftotext',
+      'poppler is not installed. Please install poppler using: brew install poppler',
+    );
+    checkMacOSVersion();
 
     // Check ImageMagick/Ghostscript only for local server mode with fallback enabled
     if (this.enableImagePdfFallback && !this.baseUrl) {
-      this.checkImageMagickInstalled();
-      this.checkGhostscriptInstalled();
+      checkCommandExists(
+        'magick',
+        'ImageMagick is not installed but enableImagePdfFallback is enabled. ' +
+          'Please install ImageMagick using: brew install imagemagick',
+      );
+      checkCommandExists(
+        'gs',
+        'Ghostscript is not installed but enableImagePdfFallback is enabled. ' +
+          'Please install Ghostscript using: brew install ghostscript',
+      );
     } else if (this.enableImagePdfFallback && this.baseUrl) {
       this.logger.warn(
         '[PDFParser] enableImagePdfFallback is ignored when using external server (baseUrl)',
@@ -167,79 +184,6 @@ export class PDFParser {
     } catch (error) {
       this.logger.error('[PDFParser] Initialization failed:', error);
       throw new Error(`Failed to initialize PDFParser: ${error}`);
-    }
-  }
-
-  private checkOperatingSystem(): void {
-    if (platform() !== 'darwin') {
-      throw new Error(
-        'PDFParser is only supported on macOS. Current platform: ' + platform(),
-      );
-    }
-  }
-
-  private checkJqInstalled(): void {
-    try {
-      execSync('which jq', { stdio: 'ignore' });
-    } catch {
-      throw new Error(
-        'jq is not installed. Please install jq using: brew install jq',
-      );
-    }
-  }
-
-  private checkPopplerInstalled(): void {
-    try {
-      execSync('which pdftotext', { stdio: 'ignore' });
-    } catch {
-      throw new Error(
-        'poppler is not installed. Please install poppler using: brew install poppler',
-      );
-    }
-  }
-
-  private checkMacOSVersion(): void {
-    try {
-      const versionOutput = execSync('sw_vers -productVersion', {
-        encoding: 'utf-8',
-      }).trim();
-      const versionMatch = versionOutput.match(/^(\d+)\.(\d+)/);
-      if (versionMatch) {
-        const major = parseInt(versionMatch[1]);
-        const minor = parseInt(versionMatch[2]);
-        if (major < 10 || (major === 10 && minor < 15)) {
-          throw new Error(
-            `macOS 10.15 or later is required. Current version: ${versionOutput}`,
-          );
-        }
-      }
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('macOS 10.15')) {
-        throw error;
-      }
-      throw new Error('Failed to check macOS version');
-    }
-  }
-
-  private checkImageMagickInstalled(): void {
-    try {
-      execSync('which magick', { stdio: 'ignore' });
-    } catch {
-      throw new Error(
-        'ImageMagick is not installed but enableImagePdfFallback is enabled. ' +
-          'Please install ImageMagick using: brew install imagemagick',
-      );
-    }
-  }
-
-  private checkGhostscriptInstalled(): void {
-    try {
-      execSync('which gs', { stdio: 'ignore' });
-    } catch {
-      throw new Error(
-        'Ghostscript is not installed but enableImagePdfFallback is enabled. ' +
-          'Please install Ghostscript using: brew install ghostscript',
-      );
     }
   }
 
@@ -350,8 +294,16 @@ export class PDFParser {
 
     // Check ImageMagick/Ghostscript for forceImagePdf (lazy check at parse time)
     if (options.forceImagePdf && !this.baseUrl) {
-      this.checkImageMagickInstalled();
-      this.checkGhostscriptInstalled();
+      checkCommandExists(
+        'magick',
+        'ImageMagick is not installed but enableImagePdfFallback is enabled. ' +
+          'Please install ImageMagick using: brew install imagemagick',
+      );
+      checkCommandExists(
+        'gs',
+        'Ghostscript is not installed but enableImagePdfFallback is enabled. ' +
+          'Please install Ghostscript using: brew install ghostscript',
+      );
     }
 
     // Use strategy-based flow when new options are provided

--- a/packages/pdf-parser/src/utils/system-checks.test.ts
+++ b/packages/pdf-parser/src/utils/system-checks.test.ts
@@ -1,0 +1,86 @@
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  checkCommandExists,
+  checkMacOSVersion,
+  checkOperatingSystem,
+} from './system-checks';
+
+vi.mock('node:os', () => ({
+  platform: vi.fn(() => 'darwin'),
+}));
+
+vi.mock('node:child_process', () => ({
+  execSync: vi.fn(() => ''),
+}));
+
+describe('checkCommandExists', () => {
+  test('does not throw when command is found', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('');
+    expect(() => checkCommandExists('jq', 'jq is not installed')).not.toThrow();
+    expect(execSync).toHaveBeenCalledWith('which jq', { stdio: 'ignore' });
+  });
+
+  test('throws with the provided error message when command is not found', () => {
+    vi.mocked(execSync as any).mockImplementationOnce(() => {
+      throw new Error('not found');
+    });
+    expect(() => checkCommandExists('jq', 'jq is not installed')).toThrow(
+      'jq is not installed',
+    );
+  });
+});
+
+describe('checkOperatingSystem', () => {
+  test('does not throw on macOS', () => {
+    vi.mocked(platform).mockReturnValue('darwin');
+    expect(() => checkOperatingSystem()).not.toThrow();
+  });
+
+  test('throws on non-macOS platforms', () => {
+    vi.mocked(platform).mockReturnValue('linux');
+    expect(() => checkOperatingSystem()).toThrow(
+      'PDFParser is only supported on macOS. Current platform: linux',
+    );
+  });
+});
+
+describe('checkMacOSVersion', () => {
+  test('does not throw for macOS 10.15 or later', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('13.5.1');
+    expect(() => checkMacOSVersion()).not.toThrow();
+  });
+
+  test('does not throw for macOS 10.15 exactly', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('10.15.0');
+    expect(() => checkMacOSVersion()).not.toThrow();
+  });
+
+  test('throws when macOS version is below 10.15', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('10.14.6');
+    expect(() => checkMacOSVersion()).toThrow(
+      'macOS 10.15 or later is required. Current version: 10.14.6',
+    );
+  });
+
+  test('does not throw when version string does not match pattern', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('unknown-version');
+    expect(() => checkMacOSVersion()).not.toThrow();
+  });
+
+  test('throws when sw_vers command fails', () => {
+    vi.mocked(execSync as any).mockImplementationOnce(() => {
+      throw new Error('command not found');
+    });
+    expect(() => checkMacOSVersion()).toThrow('Failed to check macOS version');
+  });
+
+  test('re-throws macOS version requirement error from catch block', () => {
+    vi.mocked(execSync as any).mockReturnValueOnce('10.14.6');
+    expect(() => checkMacOSVersion()).toThrow(
+      'macOS 10.15 or later is required',
+    );
+  });
+});

--- a/packages/pdf-parser/src/utils/system-checks.ts
+++ b/packages/pdf-parser/src/utils/system-checks.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process';
+import { platform } from 'node:os';
+
+/**
+ * Check that a command-line tool is installed (via `which`).
+ * @throws Error with the provided error message if not found
+ */
+export function checkCommandExists(
+  command: string,
+  errorMessage: string,
+): void {
+  try {
+    execSync(`which ${command}`, { stdio: 'ignore' });
+  } catch {
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Check that the operating system is macOS.
+ */
+export function checkOperatingSystem(): void {
+  if (platform() !== 'darwin') {
+    throw new Error(
+      'PDFParser is only supported on macOS. Current platform: ' + platform(),
+    );
+  }
+}
+
+/**
+ * Check that macOS version is 10.15 (Catalina) or later.
+ */
+export function checkMacOSVersion(): void {
+  try {
+    const versionOutput = execSync('sw_vers -productVersion', {
+      encoding: 'utf-8',
+    }).trim();
+    const versionMatch = versionOutput.match(/^(\d+)\.(\d+)/);
+    if (versionMatch) {
+      const major = parseInt(versionMatch[1]);
+      const minor = parseInt(versionMatch[2]);
+      if (major < 10 || (major === 10 && minor < 15)) {
+        throw new Error(
+          `macOS 10.15 or later is required. Current version: ${versionOutput}`,
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('macOS 10.15')) {
+      throw error;
+    }
+    throw new Error('Failed to check macOS version');
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract inline OS/command validation logic from `PDFParser` into a dedicated `system-checks` utility module, and replace inline server recovery/fallback handling with a reusable `executeWithRecovery` method. These changes reduce complexity in the main parser class and improve testability by isolating platform-specific checks and recovery logic.

## Changes

- Add `packages/pdf-parser/src/utils/system-checks.ts` with `checkCommandExists`, `checkOperatingSystem`, and `checkMacOSVersion` utility functions
- Add `packages/pdf-parser/src/utils/system-checks.test.ts` with full test coverage for the new utilities
- Simplify `PDFParser.init()` by replacing inline `platform()`, `execSync('which ...')`, and `sw_vers` calls with the new system-check utilities
- Introduce `executeWithRecovery` private method in `PDFParser` to consolidate server restart and retry logic previously duplicated in `parseWithStrategy`
- Streamline `parseWithStrategy` by delegating recovery/fallback handling to `executeWithRecovery`
- Update `pdf-parser.test.ts` to mock the new `system-checks` module instead of `node:os` and `node:child_process`, significantly reducing test boilerplate

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
