### PR TITLE
refactor(pdf-parser): add tests for PythonEnvironment and DoclingServer setup flow

### DIFF
--- a/packages/pdf-parser/src/environment/docling-environment.test.ts
+++ b/packages/pdf-parser/src/environment/docling-environment.test.ts
@@ -1,26 +1,24 @@
 import type { LoggerMethods } from '@heripo/logger';
-import type { SpawnResult } from '@heripo/shared';
-import type { ChildProcess } from 'node:child_process';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { DoclingEnvironment } from './docling-environment';
 
-vi.mock('node:child_process', () => ({
-  spawn: vi.fn(),
+vi.mock('./python-environment', () => ({
+  PythonEnvironment: vi.fn(),
 }));
 
-vi.mock('@heripo/shared', () => ({
-  spawnAsync: vi.fn(),
-}));
+vi.mock('./docling-server', () => {
+  const DoclingServer = vi.fn();
+  (DoclingServer as any).killProcessOnPort = vi.fn();
+  return { DoclingServer };
+});
 
-vi.useFakeTimers();
+const { PythonEnvironment } = await import('./python-environment');
+const MockPythonEnvironment = vi.mocked(PythonEnvironment);
 
-const { spawn } = await import('node:child_process');
-const mockSpawn = vi.mocked(spawn);
-
-const { spawnAsync } = await import('@heripo/shared');
-const mockSpawnAsync = vi.mocked(spawnAsync);
+const { DoclingServer } = await import('./docling-server');
+const MockDoclingServer = vi.mocked(DoclingServer);
 
 function createMockLogger(): LoggerMethods {
   return {
@@ -31,88 +29,18 @@ function createMockLogger(): LoggerMethods {
   };
 }
 
-function createMockProcess(): Partial<ChildProcess> {
-  return {
-    stdout: {
-      on: vi.fn(),
-    } as any,
-    stderr: {
-      on: vi.fn(),
-    } as any,
-    on: vi.fn(),
-    unref: vi.fn(),
-  };
-}
-
-function setupProcessMock(
-  mockProcess: Partial<ChildProcess>,
-  callbacks: {
-    stdout?: string;
-    stderr?: string;
-    code?: number;
-    error?: Error;
-  },
-): void {
-  if (callbacks.stdout || callbacks.stderr) {
-    const stdoutOn = mockProcess.stdout?.on as any;
-    const stderrOn = mockProcess.stderr?.on as any;
-
-    stdoutOn?.mockImplementation(
-      (event: string, handler: (data: Buffer) => void) => {
-        if (event === 'data' && callbacks.stdout) {
-          handler(Buffer.from(callbacks.stdout));
-        }
-      },
-    );
-
-    stderrOn?.mockImplementation(
-      (event: string, handler: (data: Buffer) => void) => {
-        if (event === 'data' && callbacks.stderr) {
-          handler(Buffer.from(callbacks.stderr));
-        }
-      },
-    );
-  }
-
-  const processOn = mockProcess.on as any;
-  processOn?.mockImplementation(
-    (event: string, handler: (arg?: any) => void) => {
-      if (event === 'close' && callbacks.code !== undefined) {
-        handler(callbacks.code);
-      }
-      if (event === 'error' && callbacks.error) {
-        handler(callbacks.error);
-      }
-    },
-  );
-}
-
-/**
- * Helper to create spawnAsync mock result
- */
-function createSpawnResult(options: {
-  stdout?: string;
-  stderr?: string;
-  code?: number;
-}): SpawnResult {
-  return {
-    stdout: options.stdout ?? '',
-    stderr: options.stderr ?? '',
-    code: options.code ?? 0,
-  };
-}
-
 describe('DoclingEnvironment', () => {
   let logger: LoggerMethods;
 
   beforeEach(() => {
     logger = createMockLogger();
-    mockSpawn.mockReset();
-    mockSpawnAsync.mockReset();
+    MockPythonEnvironment.mockClear();
+    MockDoclingServer.mockClear();
+    (MockDoclingServer as any).killProcessOnPort.mockClear();
   });
 
   describe('constructor', () => {
-    test('should store all options', () => {
+    test('should create PythonEnvironment and DoclingServer with correct params', () => {
       const env = new DoclingEnvironment({
         logger,
         venvPath: '/test/venv',
@@ -121,57 +49,29 @@ describe('DoclingEnvironment', () => {
       });
 
       expect(env).toBeDefined();
+      expect(MockPythonEnvironment).toHaveBeenCalledWith(logger, '/test/venv');
+      expect(MockDoclingServer).toHaveBeenCalledWith(
+        logger,
+        '/test/venv',
+        8080,
+      );
     });
   });
 
   describe('setup', () => {
-    test('should complete full setup when port is not in use', async () => {
-      // spawnAsync mocks (checkPythonVersion, setupPythonEnvironment, verifyVenvPythonVersion, upgradePip, installSetuptools, installPyArrow, installDoclingServe, isPortInUse)
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // checkPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // setupPythonEnvironment
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // verifyVenvPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // upgradePip
-        .mockResolvedValueOnce(createSpawnResult({})) // installSetuptools
-        .mockResolvedValueOnce(createSpawnResult({})) // installPyArrow
-        .mockResolvedValueOnce(createSpawnResult({})) // installDoclingServe
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 })); // isPortInUse (port not in use)
+    test('should setup python env and start server when port is not in use', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn().mockResolvedValue(false),
+        start: vi.fn(),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
 
-      // spawn mock for startDoclingServe
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
       });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Setting up Python environment...',
-      );
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Setup completed',
-      );
-    });
-
-    test('should reuse existing server when port is in use and killExistingProcess is false', async () => {
-      // spawnAsync mocks
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // checkPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // setupPythonEnvironment
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // verifyVenvPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // upgradePip
-        .mockResolvedValueOnce(createSpawnResult({})) // installSetuptools
-        .mockResolvedValueOnce(createSpawnResult({})) // installPyArrow
-        .mockResolvedValueOnce(createSpawnResult({})) // installDoclingServe
-        .mockResolvedValueOnce(createSpawnResult({ stdout: '12345', code: 0 })); // isPortInUse (port in use)
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
@@ -182,37 +82,60 @@ describe('DoclingEnvironment', () => {
 
       await env.setup();
 
+      expect(mockPythonInstance.setup).toHaveBeenCalled();
+      expect(mockServerInstance.isPortInUse).toHaveBeenCalled();
+      expect(mockServerInstance.start).toHaveBeenCalledWith(false);
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Setting up Python environment...',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Setup completed',
+      );
+    });
+
+    test('should reuse existing server when port is in use and killExistingProcess is false', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn().mockResolvedValue(true),
+        start: vi.fn(),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
+
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
+
+      const env = new DoclingEnvironment({
+        logger,
+        venvPath: '/test/venv',
+        port: 8080,
+        killExistingProcess: false,
+      });
+
+      await env.setup();
+
+      expect(mockServerInstance.start).not.toHaveBeenCalled();
       expect(logger.info).toHaveBeenCalledWith(
         '[DoclingEnvironment] Reusing existing server on port',
         8080,
       );
     });
 
-    test('should kill existing process and start new server when killExistingProcess is true', async () => {
-      // spawnAsync mocks
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // checkPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // setupPythonEnvironment
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // verifyVenvPythonVersion
-        .mockResolvedValueOnce(createSpawnResult({})) // upgradePip
-        .mockResolvedValueOnce(createSpawnResult({})) // installSetuptools
-        .mockResolvedValueOnce(createSpawnResult({})) // installPyArrow
-        .mockResolvedValueOnce(createSpawnResult({})) // installDoclingServe
-        .mockResolvedValueOnce(createSpawnResult({ stdout: '12345', code: 0 })); // isPortInUse (port in use)
+    test('should start server when port is in use and killExistingProcess is true', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn().mockResolvedValue(true),
+        start: vi.fn(),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
 
-      // spawn mocks for killProcessOnPort and startDoclingServe
-      const lsofKillProcess = createMockProcess();
-      const killProcess = createMockProcess();
-      const doclingServeProcess = createMockProcess();
-
-      setupProcessMock(lsofKillProcess, { stdout: '12345', code: 0 });
-      setupProcessMock(killProcess, { code: 0 });
-      setupProcessMock(doclingServeProcess, {});
-
-      mockSpawn
-        .mockReturnValueOnce(lsofKillProcess as any)
-        .mockReturnValueOnce(killProcess as any)
-        .mockReturnValueOnce(doclingServeProcess as any);
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
@@ -221,34 +144,26 @@ describe('DoclingEnvironment', () => {
         killExistingProcess: true,
       });
 
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
+      await env.setup();
 
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Killing process',
-        '12345',
-        'on port',
-        8080,
-      );
+      expect(mockServerInstance.start).toHaveBeenCalledWith(true);
     });
-  });
 
-  describe('checkPythonVersion', () => {
-    test('should accept Python 3.9', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+    test('should propagate python setup error', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn(),
+        start: vi.fn(),
+      };
+      const mockPythonInstance = {
+        setup: vi.fn().mockRejectedValue(new Error('Python setup failed')),
+      };
 
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
@@ -257,30 +172,22 @@ describe('DoclingEnvironment', () => {
         killExistingProcess: false,
       });
 
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Python version:',
-        '3.9',
-      );
+      await expect(env.setup()).rejects.toThrow('Python setup failed');
     });
 
-    test('should accept Python 3.12', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+    test('should propagate server start error', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn().mockResolvedValue(false),
+        start: vi.fn().mockRejectedValue(new Error('Server start failed')),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
 
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
@@ -289,756 +196,50 @@ describe('DoclingEnvironment', () => {
         killExistingProcess: false,
       });
 
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Python version:',
-        '3.12',
-      );
-    });
-
-    test('should reject Python 3.13 or higher', async () => {
-      mockSpawnAsync.mockResolvedValueOnce(
-        createSpawnResult({ stdout: 'Python 3.13.0' }),
-      );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Python 3.13 is too new. docling-serve requires Python 3.11 or 3.12.',
-      );
-
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Python 3.13+ is not compatible. Install 3.11 or 3.12 with: pyenv install 3.12.0 && pyenv global 3.12.0',
-      );
-    });
-
-    test('should reject Python versions below 3.9', async () => {
-      mockSpawnAsync.mockResolvedValueOnce(
-        createSpawnResult({ stdout: 'Python 3.8.0' }),
-      );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Python 3.9 or higher is required',
-      );
-    });
-
-    test('should reject Python 2.x', async () => {
-      mockSpawnAsync.mockResolvedValueOnce(
-        createSpawnResult({ stdout: 'Python 2.7.0' }),
-      );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Python 3.9 or higher is required',
-      );
-    });
-
-    test('should handle version parsing failure', async () => {
-      mockSpawnAsync.mockResolvedValueOnce(
-        createSpawnResult({ stdout: 'Invalid output' }),
-      );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Could not parse Python version',
-      );
-    });
-
-    test('should handle python check failure with non-zero exit code', async () => {
-      mockSpawnAsync.mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to check Python version',
-      );
-    });
-
-    test('should handle python process error event', async () => {
-      mockSpawnAsync.mockRejectedValueOnce(new Error('Command not found'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Command not found');
-    });
-
-    test('should read version from stderr if needed', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stderr: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Python version:',
-        '3.11',
-      );
-    });
-  });
-
-  describe('setupPythonEnvironment', () => {
-    test('should handle venv creation failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to create Python virtual environment',
-      );
-    });
-
-    test('should handle venv creation process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockRejectedValueOnce(new Error('Venv creation failed'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Venv creation failed');
-    });
-  });
-
-  describe('verifyVenvPythonVersion', () => {
-    test('should reject venv with Python 3.13+', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.13.0' }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Venv Python 3.13 is too new. docling-serve requires Python 3.11 or 3.12.',
-      );
-    });
-
-    test('should reject venv with Python below 3.9', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.8.0' }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Python 3.9 or higher is required',
-      );
-    });
-
-    test('should handle venv version check failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to verify venv Python version',
-      );
-    });
-
-    test('should handle venv version parsing failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Invalid' }));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Could not parse venv Python version',
-      );
-    });
-
-    test('should handle venv version check process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockRejectedValueOnce(new Error('Venv check error'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Venv check error');
-    });
-
-    test('should read venv version from stderr', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stderr: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Setup completed',
-      );
-    });
-  });
-
-  describe('upgradePip', () => {
-    test('should handle pip upgrade failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(
-          createSpawnResult({ stderr: 'Pip upgrade error', code: 1 }),
-        );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to upgrade pip. Exit code: 1',
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to upgrade pip:',
-        'Pip upgrade error',
-      );
-    });
-
-    test('should handle pip upgrade process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockRejectedValueOnce(new Error('Pip error'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Pip error');
-    });
-  });
-
-  describe('installSetuptools', () => {
-    test('should handle setuptools installation failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(
-          createSpawnResult({ stderr: 'Setuptools error', code: 1 }),
-        );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to install setuptools. Exit code: 1',
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to install setuptools:',
-        'Setuptools error',
-      );
-    });
-
-    test('should handle setuptools installation process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockRejectedValueOnce(new Error('Setuptools error'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Setuptools error');
-    });
-  });
-
-  describe('installPyArrow', () => {
-    test('should handle pyarrow installation failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(
-          createSpawnResult({ stderr: 'PyArrow error', code: 1 }),
-        );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to install pyarrow. Exit code: 1',
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to install pyarrow:',
-        'PyArrow error',
-      );
-    });
-
-    test('should handle pyarrow installation process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockRejectedValueOnce(new Error('PyArrow error'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('PyArrow error');
-    });
-  });
-
-  describe('installDoclingServe', () => {
-    test('should handle docling-serve installation failure', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(
-          createSpawnResult({ stderr: 'Docling error', code: 1 }),
-        );
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow(
-        'Failed to install docling-serve. Exit code: 1',
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to install docling-serve:',
-        'Docling error',
-      );
-    });
-
-    test('should handle docling-serve installation process error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockRejectedValueOnce(new Error('Docling error'));
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Docling error');
-    });
-  });
-
-  describe('isPortInUse', () => {
-    test('should return false when port is not in use', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Starting docling-serve on port',
-        8080,
-      );
-    });
-
-    test('should return false when lsof returns no pid', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: '', code: 0 }));
-
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Starting docling-serve on port',
-        8080,
-      );
-    });
-
-    test('should return false when lsof has error', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockRejectedValueOnce(new Error('lsof error'));
-
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      const setupPromise = env.setup();
-      await vi.advanceTimersByTimeAsync(2000);
-      await setupPromise;
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Starting docling-serve on port',
-        8080,
-      );
-    });
-  });
-
-  describe('killProcessOnPort', () => {
-    test('should kill processes on port successfully', async () => {
-      const lsofProcess = createMockProcess();
-      const killProcess = createMockProcess();
-
-      setupProcessMock(lsofProcess, { stdout: '12345\n67890', code: 0 });
-      setupProcessMock(killProcess, { code: 0 });
-
-      mockSpawn
-        .mockReturnValueOnce(lsofProcess as any)
-        .mockReturnValueOnce(killProcess as any)
-        .mockReturnValueOnce(killProcess as any);
-
-      await DoclingEnvironment.killProcessOnPort(logger, 8080);
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Killing process',
-        '12345, 67890',
-        'on port',
-        8080,
-      );
-    });
-
-    test('should handle when no processes are found', async () => {
-      const lsofProcess = createMockProcess();
-      setupProcessMock(lsofProcess, { stdout: '', code: 1 });
-
-      mockSpawn.mockReturnValueOnce(lsofProcess as any);
-
-      await DoclingEnvironment.killProcessOnPort(logger, 8080);
-
-      expect(logger.info).not.toHaveBeenCalledWith(
-        expect.stringContaining('Killing process'),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-      );
-    });
-
-    test('should handle kill process failure', async () => {
-      const lsofProcess = createMockProcess();
-      const killProcess = createMockProcess();
-
-      setupProcessMock(lsofProcess, { stdout: '12345', code: 0 });
-      setupProcessMock(killProcess, { code: 1 });
-
-      mockSpawn
-        .mockReturnValueOnce(lsofProcess as any)
-        .mockReturnValueOnce(killProcess as any);
-
-      await DoclingEnvironment.killProcessOnPort(logger, 8080);
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to kill process',
-        '12345',
-      );
-    });
-
-    test('should handle kill process error event', async () => {
-      const lsofProcess = createMockProcess();
-      const killProcess = createMockProcess();
-      const error = new Error('Kill failed');
-
-      setupProcessMock(lsofProcess, { stdout: '12345', code: 0 });
-      setupProcessMock(killProcess, { error });
-
-      mockSpawn
-        .mockReturnValueOnce(lsofProcess as any)
-        .mockReturnValueOnce(killProcess as any);
-
-      await DoclingEnvironment.killProcessOnPort(logger, 8080);
-
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to kill process',
-        error,
-      );
-    });
-
-    test('should handle lsof error event', async () => {
-      const lsofProcess = createMockProcess();
-      setupProcessMock(lsofProcess, { error: new Error('lsof error') });
-
-      mockSpawn.mockReturnValueOnce(lsofProcess as any);
-
-      await DoclingEnvironment.killProcessOnPort(logger, 8080);
-
-      expect(logger.info).not.toHaveBeenCalledWith(
-        expect.stringContaining('Killing process'),
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-      );
-    });
-  });
-
-  describe('startDoclingServe', () => {
-    test('should handle docling-serve error event', async () => {
-      mockSpawnAsync
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({}))
-        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
-
-      const doclingServeProcess = createMockProcess();
-      const error = new Error('Docling serve error');
-      setupProcessMock(doclingServeProcess, { error });
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
-
-      const env = new DoclingEnvironment({
-        logger,
-        venvPath: '/test/venv',
-        port: 8080,
-        killExistingProcess: false,
-      });
-
-      await expect(env.setup()).rejects.toThrow('Docling serve error');
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] docling-serve error:',
-        error,
-      );
+      await expect(env.setup()).rejects.toThrow('Server start failed');
     });
   });
 
   describe('startServer', () => {
-    test('should start docling-serve without full setup', async () => {
-      const doclingServeProcess = createMockProcess();
-      setupProcessMock(doclingServeProcess, {});
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+    test('should delegate to server.start with killExistingProcess flag', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn(),
+        start: vi.fn(),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
+
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
         venvPath: '/test/venv',
         port: 8080,
-        killExistingProcess: false,
+        killExistingProcess: true,
       });
 
-      const startPromise = env.startServer();
-      await vi.advanceTimersByTimeAsync(2000);
-      await startPromise;
+      await env.startServer();
 
-      expect(logger.info).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Starting docling-serve on port',
-        8080,
-      );
-      expect(mockSpawn).toHaveBeenCalledWith(
-        '/test/venv/bin/docling-serve',
-        ['run', '--port', '8080'],
-        {
-          detached: true,
-          stdio: 'ignore',
-          env: expect.objectContaining({
-            DOCLING_SERVE_ENABLE_REMOTE_SERVICES: 'true',
-          }),
-        },
-      );
+      expect(mockServerInstance.start).toHaveBeenCalledWith(true);
     });
 
-    test('should handle error during startServer', async () => {
-      const doclingServeProcess = createMockProcess();
-      const error = new Error('Server start failed');
-      setupProcessMock(doclingServeProcess, { error });
-      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+    test('should propagate error from server.start', async () => {
+      const mockServerInstance = {
+        isPortInUse: vi.fn(),
+        start: vi.fn().mockRejectedValue(new Error('Start failed')),
+      };
+      const mockPythonInstance = { setup: vi.fn() };
+
+      MockPythonEnvironment.mockImplementation(function () {
+        return mockPythonInstance as any;
+      });
+      MockDoclingServer.mockImplementation(function () {
+        return mockServerInstance as any;
+      });
 
       const env = new DoclingEnvironment({
         logger,
@@ -1047,10 +248,17 @@ describe('DoclingEnvironment', () => {
         killExistingProcess: false,
       });
 
-      await expect(env.startServer()).rejects.toThrow('Server start failed');
-      expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] docling-serve error:',
-        error,
+      await expect(env.startServer()).rejects.toThrow('Start failed');
+    });
+  });
+
+  describe('killProcessOnPort', () => {
+    test('should delegate to DoclingServer.killProcessOnPort', async () => {
+      await DoclingEnvironment.killProcessOnPort(logger, 8080);
+
+      expect((MockDoclingServer as any).killProcessOnPort).toHaveBeenCalledWith(
+        logger,
+        8080,
       );
     });
   });

--- a/packages/pdf-parser/src/environment/docling-environment.ts
+++ b/packages/pdf-parser/src/environment/docling-environment.ts
@@ -1,21 +1,13 @@
 import type { LoggerMethods } from '@heripo/logger';
 
-import { spawnAsync } from '@heripo/shared';
-import { spawn } from 'node:child_process';
-import { join } from 'node:path';
-
-import { DOCLING_ENVIRONMENT } from '../config/constants';
-import {
-  PythonVersionError,
-  type PythonVersionInfo,
-  parsePythonVersion,
-  validatePythonVersion,
-} from '../utils/python-version';
+import { DoclingServer } from './docling-server';
+import { PythonEnvironment } from './python-environment';
 
 export class DoclingEnvironment {
   private readonly logger: LoggerMethods;
-  private readonly venvPath: string;
   private readonly port: number;
+  private readonly pythonEnv: PythonEnvironment;
+  private readonly server: DoclingServer;
   private readonly killExistingProcess: boolean;
 
   constructor(options: {
@@ -25,174 +17,32 @@ export class DoclingEnvironment {
     killExistingProcess: boolean;
   }) {
     this.logger = options.logger;
-    this.venvPath = options.venvPath;
     this.port = options.port;
+    this.pythonEnv = new PythonEnvironment(options.logger, options.venvPath);
+    this.server = new DoclingServer(
+      options.logger,
+      options.venvPath,
+      options.port,
+    );
     this.killExistingProcess = options.killExistingProcess;
   }
 
   async setup(): Promise<void> {
     this.logger.info('[DoclingEnvironment] Setting up Python environment...');
 
-    await this.checkPythonVersion();
-    await this.setupPythonEnvironment();
-    await this.upgradePip();
-    await this.installSetuptools();
-    await this.installPyArrow();
-    await this.installDoclingServe();
+    await this.pythonEnv.setup();
 
-    // Check if server is already running
-    const portInUse = await this.isPortInUse(this.port);
-
+    const portInUse = await this.server.isPortInUse();
     if (portInUse && !this.killExistingProcess) {
       this.logger.info(
         '[DoclingEnvironment] Reusing existing server on port',
         this.port,
       );
     } else {
-      await this.startDoclingServe();
+      await this.server.start(this.killExistingProcess);
     }
 
     this.logger.info('[DoclingEnvironment] Setup completed');
-  }
-
-  private async checkPythonVersion(): Promise<PythonVersionInfo> {
-    const result = await spawnAsync('python3', ['--version']);
-
-    if (result.code !== 0) {
-      throw new Error('Failed to check Python version');
-    }
-
-    const output = result.stdout + result.stderr;
-    const version = parsePythonVersion(output);
-
-    if (!version) {
-      throw new Error('Could not parse Python version');
-    }
-
-    this.logger.info(
-      '[DoclingEnvironment] Python version:',
-      version.versionString,
-    );
-
-    try {
-      validatePythonVersion(version, 'system');
-    } catch (error) {
-      if (error instanceof PythonVersionError && version.minor >= 13) {
-        this.logger.error(
-          '[DoclingEnvironment] Python 3.13+ is not compatible. Install 3.11 or 3.12 with: pyenv install 3.12.0 && pyenv global 3.12.0',
-        );
-      }
-      throw error;
-    }
-
-    return version;
-  }
-
-  private async setupPythonEnvironment(): Promise<void> {
-    const result = await spawnAsync('python3', ['-m', 'venv', this.venvPath]);
-
-    if (result.code !== 0) {
-      throw new Error('Failed to create Python virtual environment');
-    }
-
-    await this.verifyVenvPythonVersion();
-  }
-
-  private async verifyVenvPythonVersion(): Promise<void> {
-    const pythonPath = join(this.venvPath, 'bin', 'python');
-    const result = await spawnAsync(pythonPath, ['--version']);
-
-    if (result.code !== 0) {
-      throw new Error('Failed to verify venv Python version');
-    }
-
-    const output = result.stdout + result.stderr;
-    const version = parsePythonVersion(output);
-
-    if (!version) {
-      throw new Error('Could not parse venv Python version');
-    }
-
-    validatePythonVersion(version, 'venv');
-  }
-
-  private async upgradePip(): Promise<void> {
-    const pipPath = join(this.venvPath, 'bin', 'pip');
-    const result = await spawnAsync(pipPath, ['install', '--upgrade', 'pip']);
-
-    if (result.code !== 0) {
-      this.logger.error(
-        '[DoclingEnvironment] Failed to upgrade pip:',
-        result.stderr,
-      );
-      throw new Error(`Failed to upgrade pip. Exit code: ${result.code}`);
-    }
-  }
-
-  private async installSetuptools(): Promise<void> {
-    const pipPath = join(this.venvPath, 'bin', 'pip');
-    const result = await spawnAsync(pipPath, [
-      'install',
-      '--upgrade',
-      'setuptools',
-      'wheel',
-    ]);
-
-    if (result.code !== 0) {
-      this.logger.error(
-        '[DoclingEnvironment] Failed to install setuptools:',
-        result.stderr,
-      );
-      throw new Error(
-        `Failed to install setuptools. Exit code: ${result.code}`,
-      );
-    }
-  }
-
-  private async installPyArrow(): Promise<void> {
-    const pipPath = join(this.venvPath, 'bin', 'pip');
-    const result = await spawnAsync(pipPath, [
-      'install',
-      '--only-binary',
-      ':all:',
-      'pyarrow',
-    ]);
-
-    if (result.code !== 0) {
-      this.logger.error(
-        '[DoclingEnvironment] Failed to install pyarrow:',
-        result.stderr,
-      );
-      throw new Error(`Failed to install pyarrow. Exit code: ${result.code}`);
-    }
-  }
-
-  private async installDoclingServe(): Promise<void> {
-    const pipPath = join(this.venvPath, 'bin', 'pip');
-    const result = await spawnAsync(pipPath, [
-      'install',
-      '--upgrade',
-      'docling-serve',
-    ]);
-
-    if (result.code !== 0) {
-      this.logger.error(
-        '[DoclingEnvironment] Failed to install docling-serve:',
-        result.stderr,
-      );
-      throw new Error(
-        `Failed to install docling-serve. Exit code: ${result.code}`,
-      );
-    }
-  }
-
-  private async isPortInUse(port: number): Promise<boolean> {
-    try {
-      const result = await spawnAsync('lsof', ['-ti', `:${port}`]);
-      return result.code === 0 && !!result.stdout.trim();
-    } catch {
-      return false;
-    }
   }
 
   /**
@@ -200,98 +50,13 @@ export class DoclingEnvironment {
    * Useful for restarting the server after it has crashed.
    */
   public async startServer(): Promise<void> {
-    await this.startDoclingServe();
+    await this.server.start(this.killExistingProcess);
   }
 
-  // Process-killing logic is provided as a static method to allow reuse without instantiation
   public static async killProcessOnPort(
     logger: LoggerMethods,
     port: number,
   ): Promise<void> {
-    return new Promise((resolve) => {
-      const lsof = spawn('lsof', ['-ti', `:${port}`]);
-      const pids: string[] = [];
-
-      lsof.stdout?.on('data', (data) => {
-        const txt: string = data.toString();
-        pids.push(
-          ...txt
-            .split(/\s+/)
-            .map((s) => s.trim())
-            .filter(Boolean),
-        );
-      });
-
-      lsof.on('close', () => {
-        if (pids.length === 0) return resolve();
-
-        let remaining = pids.length;
-        const done = () => {
-          if (--remaining <= 0) resolve();
-        };
-
-        logger.info(
-          '[DoclingEnvironment] Killing process',
-          pids.join(', '),
-          'on port',
-          port,
-        );
-        for (const pid of pids) {
-          const killProc = spawn('kill', ['-9', pid]);
-
-          killProc.on('close', (killCode) => {
-            if (killCode !== 0) {
-              logger.info('[DoclingEnvironment] Failed to kill process', pid);
-            }
-            done();
-          });
-          killProc.on('error', (Error) => {
-            logger.info('[DoclingEnvironment] Failed to kill process', Error);
-            done();
-          });
-        }
-      });
-
-      lsof.on('error', () => resolve());
-    });
-  }
-
-  private async startDoclingServe(): Promise<void> {
-    return new Promise(async (resolve, reject) => {
-      // Kill any existing process on the port if option is enabled
-      if (this.killExistingProcess) {
-        await DoclingEnvironment.killProcessOnPort(this.logger, this.port);
-      }
-
-      const venvPath = this.venvPath;
-      const doclingServePath = join(venvPath, 'bin', 'docling-serve');
-      const args = ['run', '--port', this.port.toString()];
-
-      this.logger.info(
-        '[DoclingEnvironment] Starting docling-serve on port',
-        this.port,
-      );
-      const doclingProcess = spawn(doclingServePath, args, {
-        detached: true, // Detached from parent process
-        stdio: 'ignore', // Remove stdio pipes to prevent event loop from hanging
-        env: {
-          ...process.env,
-          // Enable remote API calls for API VLM models
-          DOCLING_SERVE_ENABLE_REMOTE_SERVICES: 'true',
-        },
-      });
-
-      doclingProcess.unref(); // Parent doesn't wait for child process to exit
-
-      doclingProcess.on('error', (error) => {
-        this.logger.error('[DoclingEnvironment] docling-serve error:', error);
-        reject(error);
-      });
-
-      // Give docling-serve time to start
-      setTimeout(() => {
-        resolve();
-      }, DOCLING_ENVIRONMENT.STARTUP_DELAY_MS);
-    });
+    return DoclingServer.killProcessOnPort(logger, port);
   }
 }

--- a/packages/pdf-parser/src/environment/docling-server.test.ts
+++ b/packages/pdf-parser/src/environment/docling-server.test.ts
@@ -1,0 +1,319 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { SpawnResult } from '@heripo/shared';
+import type { ChildProcess } from 'node:child_process';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { DoclingServer } from './docling-server';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock('@heripo/shared', () => ({
+  spawnAsync: vi.fn(),
+}));
+
+vi.useFakeTimers();
+
+const { spawn } = await import('node:child_process');
+const mockSpawn = vi.mocked(spawn);
+
+const { spawnAsync } = await import('@heripo/shared');
+const mockSpawnAsync = vi.mocked(spawnAsync);
+
+function createMockLogger(): LoggerMethods {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createMockProcess(): Partial<ChildProcess> {
+  return {
+    stdout: {
+      on: vi.fn(),
+    } as any,
+    stderr: {
+      on: vi.fn(),
+    } as any,
+    on: vi.fn(),
+    unref: vi.fn(),
+  };
+}
+
+function setupProcessMock(
+  mockProcess: Partial<ChildProcess>,
+  callbacks: {
+    stdout?: string;
+    stderr?: string;
+    code?: number;
+    error?: Error;
+  },
+): void {
+  if (callbacks.stdout || callbacks.stderr) {
+    const stdoutOn = mockProcess.stdout?.on as any;
+    const stderrOn = mockProcess.stderr?.on as any;
+
+    stdoutOn?.mockImplementation(
+      (event: string, handler: (data: Buffer) => void) => {
+        if (event === 'data' && callbacks.stdout) {
+          handler(Buffer.from(callbacks.stdout));
+        }
+      },
+    );
+
+    stderrOn?.mockImplementation(
+      (event: string, handler: (data: Buffer) => void) => {
+        if (event === 'data' && callbacks.stderr) {
+          handler(Buffer.from(callbacks.stderr));
+        }
+      },
+    );
+  }
+
+  const processOn = mockProcess.on as any;
+  processOn?.mockImplementation(
+    (event: string, handler: (arg?: any) => void) => {
+      if (event === 'close' && callbacks.code !== undefined) {
+        handler(callbacks.code);
+      }
+      if (event === 'error' && callbacks.error) {
+        handler(callbacks.error);
+      }
+    },
+  );
+}
+
+function createSpawnResult(options: {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+}): SpawnResult {
+  return {
+    stdout: options.stdout ?? '',
+    stderr: options.stderr ?? '',
+    code: options.code ?? 0,
+  };
+}
+
+describe('DoclingServer', () => {
+  let logger: LoggerMethods;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    mockSpawn.mockReset();
+    mockSpawnAsync.mockReset();
+  });
+
+  describe('isPortInUse', () => {
+    test('should return true when port is in use', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: '12345', code: 0 }),
+      );
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const result = await server.isPortInUse();
+
+      expect(result).toBe(true);
+      expect(mockSpawnAsync).toHaveBeenCalledWith('lsof', ['-ti', ':8080']);
+    });
+
+    test('should return false when port is not in use', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const result = await server.isPortInUse();
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false when lsof returns no pid', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: '', code: 0 }),
+      );
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const result = await server.isPortInUse();
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false when lsof has error', async () => {
+      mockSpawnAsync.mockRejectedValueOnce(new Error('lsof error'));
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const result = await server.isPortInUse();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('start', () => {
+    test('should start docling-serve without killing existing process', async () => {
+      const doclingServeProcess = createMockProcess();
+      setupProcessMock(doclingServeProcess, {});
+      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const startPromise = server.start(false);
+      await vi.advanceTimersByTimeAsync(2000);
+      await startPromise;
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Starting docling-serve on port',
+        8080,
+      );
+      expect(mockSpawn).toHaveBeenCalledWith(
+        '/test/venv/bin/docling-serve',
+        ['run', '--port', '8080'],
+        {
+          detached: true,
+          stdio: 'ignore',
+          env: expect.objectContaining({
+            DOCLING_SERVE_ENABLE_REMOTE_SERVICES: 'true',
+          }),
+        },
+      );
+    });
+
+    test('should kill existing process before starting when killExistingProcess is true', async () => {
+      const lsofProcess = createMockProcess();
+      const killProcess = createMockProcess();
+      const doclingServeProcess = createMockProcess();
+
+      setupProcessMock(lsofProcess, { stdout: '12345', code: 0 });
+      setupProcessMock(killProcess, { code: 0 });
+      setupProcessMock(doclingServeProcess, {});
+
+      mockSpawn
+        .mockReturnValueOnce(lsofProcess as any)
+        .mockReturnValueOnce(killProcess as any)
+        .mockReturnValueOnce(doclingServeProcess as any);
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+      const startPromise = server.start(true);
+      await vi.advanceTimersByTimeAsync(2000);
+      await startPromise;
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Killing process',
+        '12345',
+        'on port',
+        8080,
+      );
+    });
+
+    test('should handle docling-serve error event', async () => {
+      const doclingServeProcess = createMockProcess();
+      const error = new Error('Docling serve error');
+      setupProcessMock(doclingServeProcess, { error });
+      mockSpawn.mockReturnValueOnce(doclingServeProcess as any);
+
+      const server = new DoclingServer(logger, '/test/venv', 8080);
+
+      await expect(server.start(false)).rejects.toThrow('Docling serve error');
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] docling-serve error:',
+        error,
+      );
+    });
+  });
+
+  describe('killProcessOnPort', () => {
+    test('should kill processes on port successfully', async () => {
+      const lsofProcess = createMockProcess();
+      const killProcess = createMockProcess();
+
+      setupProcessMock(lsofProcess, { stdout: '12345\n67890', code: 0 });
+      setupProcessMock(killProcess, { code: 0 });
+
+      mockSpawn
+        .mockReturnValueOnce(lsofProcess as any)
+        .mockReturnValueOnce(killProcess as any)
+        .mockReturnValueOnce(killProcess as any);
+
+      await DoclingServer.killProcessOnPort(logger, 8080);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Killing process',
+        '12345, 67890',
+        'on port',
+        8080,
+      );
+    });
+
+    test('should handle when no processes are found', async () => {
+      const lsofProcess = createMockProcess();
+      setupProcessMock(lsofProcess, { stdout: '', code: 1 });
+
+      mockSpawn.mockReturnValueOnce(lsofProcess as any);
+
+      await DoclingServer.killProcessOnPort(logger, 8080);
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('Killing process'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    test('should handle kill process failure', async () => {
+      const lsofProcess = createMockProcess();
+      const killProcess = createMockProcess();
+
+      setupProcessMock(lsofProcess, { stdout: '12345', code: 0 });
+      setupProcessMock(killProcess, { code: 1 });
+
+      mockSpawn
+        .mockReturnValueOnce(lsofProcess as any)
+        .mockReturnValueOnce(killProcess as any);
+
+      await DoclingServer.killProcessOnPort(logger, 8080);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to kill process',
+        '12345',
+      );
+    });
+
+    test('should handle kill process error event', async () => {
+      const lsofProcess = createMockProcess();
+      const killProcess = createMockProcess();
+      const error = new Error('Kill failed');
+
+      setupProcessMock(lsofProcess, { stdout: '12345', code: 0 });
+      setupProcessMock(killProcess, { error });
+
+      mockSpawn
+        .mockReturnValueOnce(lsofProcess as any)
+        .mockReturnValueOnce(killProcess as any);
+
+      await DoclingServer.killProcessOnPort(logger, 8080);
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to kill process',
+        error,
+      );
+    });
+
+    test('should handle lsof error event', async () => {
+      const lsofProcess = createMockProcess();
+      setupProcessMock(lsofProcess, { error: new Error('lsof error') });
+
+      mockSpawn.mockReturnValueOnce(lsofProcess as any);
+
+      await DoclingServer.killProcessOnPort(logger, 8080);
+
+      expect(logger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('Killing process'),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/packages/pdf-parser/src/environment/docling-server.ts
+++ b/packages/pdf-parser/src/environment/docling-server.ts
@@ -1,0 +1,111 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { spawnAsync } from '@heripo/shared';
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+
+import { DOCLING_ENVIRONMENT } from '../config/constants';
+
+export class DoclingServer {
+  constructor(
+    private readonly logger: LoggerMethods,
+    private readonly venvPath: string,
+    private readonly port: number,
+  ) {}
+
+  async isPortInUse(): Promise<boolean> {
+    try {
+      const result = await spawnAsync('lsof', ['-ti', `:${this.port}`]);
+      return result.code === 0 && !!result.stdout.trim();
+    } catch {
+      return false;
+    }
+  }
+
+  async start(killExistingProcess: boolean): Promise<void> {
+    return new Promise(async (resolve, reject) => {
+      if (killExistingProcess) {
+        await DoclingServer.killProcessOnPort(this.logger, this.port);
+      }
+
+      const doclingServePath = join(this.venvPath, 'bin', 'docling-serve');
+      const args = ['run', '--port', this.port.toString()];
+
+      this.logger.info(
+        '[DoclingEnvironment] Starting docling-serve on port',
+        this.port,
+      );
+      const doclingProcess = spawn(doclingServePath, args, {
+        detached: true,
+        stdio: 'ignore',
+        env: {
+          ...process.env,
+          DOCLING_SERVE_ENABLE_REMOTE_SERVICES: 'true',
+        },
+      });
+
+      doclingProcess.unref();
+
+      doclingProcess.on('error', (error) => {
+        this.logger.error('[DoclingEnvironment] docling-serve error:', error);
+        reject(error);
+      });
+
+      setTimeout(() => {
+        resolve();
+      }, DOCLING_ENVIRONMENT.STARTUP_DELAY_MS);
+    });
+  }
+
+  static async killProcessOnPort(
+    logger: LoggerMethods,
+    port: number,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const lsof = spawn('lsof', ['-ti', `:${port}`]);
+      const pids: string[] = [];
+
+      lsof.stdout?.on('data', (data) => {
+        const txt: string = data.toString();
+        pids.push(
+          ...txt
+            .split(/\s+/)
+            .map((s) => s.trim())
+            .filter(Boolean),
+        );
+      });
+
+      lsof.on('close', () => {
+        if (pids.length === 0) return resolve();
+
+        let remaining = pids.length;
+        const done = () => {
+          if (--remaining <= 0) resolve();
+        };
+
+        logger.info(
+          '[DoclingEnvironment] Killing process',
+          pids.join(', '),
+          'on port',
+          port,
+        );
+        for (const pid of pids) {
+          const killProc = spawn('kill', ['-9', pid]);
+
+          killProc.on('close', (killCode) => {
+            if (killCode !== 0) {
+              logger.info('[DoclingEnvironment] Failed to kill process', pid);
+            }
+            done();
+          });
+          killProc.on('error', (Error) => {
+            logger.info('[DoclingEnvironment] Failed to kill process', Error);
+            done();
+          });
+        }
+      });
+
+      lsof.on('error', () => resolve());
+    });
+  }
+}

--- a/packages/pdf-parser/src/environment/python-environment.test.ts
+++ b/packages/pdf-parser/src/environment/python-environment.test.ts
@@ -1,0 +1,478 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { SpawnResult } from '@heripo/shared';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PythonEnvironment } from './python-environment';
+
+vi.mock('@heripo/shared', () => ({
+  spawnAsync: vi.fn(),
+}));
+
+const { spawnAsync } = await import('@heripo/shared');
+const mockSpawnAsync = vi.mocked(spawnAsync);
+
+function createMockLogger(): LoggerMethods {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createSpawnResult(options: {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+}): SpawnResult {
+  return {
+    stdout: options.stdout ?? '',
+    stderr: options.stderr ?? '',
+    code: options.code ?? 0,
+  };
+}
+
+describe('PythonEnvironment', () => {
+  let logger: LoggerMethods;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+    mockSpawnAsync.mockReset();
+  });
+
+  describe('setup', () => {
+    test('should run all setup steps in order', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // checkPythonVersion
+        .mockResolvedValueOnce(createSpawnResult({})) // setupPythonEnvironment
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' })) // verifyVenvPythonVersion
+        .mockResolvedValueOnce(createSpawnResult({})) // upgradePip
+        .mockResolvedValueOnce(createSpawnResult({})) // installSetuptools
+        .mockResolvedValueOnce(createSpawnResult({})) // installPyArrow
+        .mockResolvedValueOnce(createSpawnResult({})); // installDoclingServe
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+      await env.setup();
+
+      expect(mockSpawnAsync).toHaveBeenCalledTimes(7);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(1, 'python3', [
+        '--version',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(2, 'python3', [
+        '-m',
+        'venv',
+        '/test/venv',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(
+        3,
+        '/test/venv/bin/python',
+        ['--version'],
+      );
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(4, '/test/venv/bin/pip', [
+        'install',
+        '--upgrade',
+        'pip',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(5, '/test/venv/bin/pip', [
+        'install',
+        '--upgrade',
+        'setuptools',
+        'wheel',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(6, '/test/venv/bin/pip', [
+        'install',
+        '--only-binary',
+        ':all:',
+        'pyarrow',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(7, '/test/venv/bin/pip', [
+        'install',
+        '--upgrade',
+        'docling-serve',
+      ]);
+    });
+  });
+
+  describe('checkPythonVersion', () => {
+    test('should accept Python 3.9', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+      await env.setup();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Python version:',
+        '3.9',
+      );
+    });
+
+    test('should accept Python 3.12', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+      await env.setup();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Python version:',
+        '3.12',
+      );
+    });
+
+    test('should reject Python 3.13 or higher with specific message', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: 'Python 3.13.0' }),
+      );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Python 3.13 is too new. docling-serve requires Python 3.11 or 3.12.',
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Python 3.13+ is not compatible. Install 3.11 or 3.12 with: pyenv install 3.12.0 && pyenv global 3.12.0',
+      );
+    });
+
+    test('should reject Python versions below 3.9', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: 'Python 3.8.0' }),
+      );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Python 3.9 or higher is required',
+      );
+    });
+
+    test('should reject Python 2.x', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: 'Python 2.7.0' }),
+      );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Python 3.9 or higher is required',
+      );
+    });
+
+    test('should handle version parsing failure', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(
+        createSpawnResult({ stdout: 'Invalid output' }),
+      );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Could not parse Python version',
+      );
+    });
+
+    test('should handle python check failure with non-zero exit code', async () => {
+      mockSpawnAsync.mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to check Python version',
+      );
+    });
+
+    test('should handle python process error event', async () => {
+      mockSpawnAsync.mockRejectedValueOnce(new Error('Command not found'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Command not found');
+    });
+
+    test('should read version from stderr if needed', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stderr: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+      await env.setup();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Python version:',
+        '3.11',
+      );
+    });
+  });
+
+  describe('setupPythonEnvironment', () => {
+    test('should handle venv creation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to create Python virtual environment',
+      );
+    });
+
+    test('should handle venv creation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockRejectedValueOnce(new Error('Venv creation failed'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Venv creation failed');
+    });
+  });
+
+  describe('verifyVenvPythonVersion', () => {
+    test('should reject venv with Python 3.13+', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.13.0' }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Venv Python 3.13 is too new. docling-serve requires Python 3.11 or 3.12.',
+      );
+    });
+
+    test('should reject venv with Python below 3.9', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.8.0' }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Python 3.9 or higher is required',
+      );
+    });
+
+    test('should handle venv version check failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ code: 1 }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to verify venv Python version',
+      );
+    });
+
+    test('should handle venv version parsing failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Invalid' }));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Could not parse venv Python version',
+      );
+    });
+
+    test('should handle venv version check process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('Venv check error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Venv check error');
+    });
+
+    test('should read venv version from stderr', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stderr: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+      await env.setup();
+
+      expect(mockSpawnAsync).toHaveBeenCalledTimes(7);
+    });
+  });
+
+  describe('upgradePip', () => {
+    test('should handle pip upgrade failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'Pip upgrade error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to upgrade pip. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to upgrade pip:',
+        'Pip upgrade error',
+      );
+    });
+
+    test('should handle pip upgrade process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockRejectedValueOnce(new Error('Pip error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Pip error');
+    });
+  });
+
+  describe('installSetuptools', () => {
+    test('should handle setuptools installation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'Setuptools error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to install setuptools. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to install setuptools:',
+        'Setuptools error',
+      );
+    });
+
+    test('should handle setuptools installation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('Setuptools error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Setuptools error');
+    });
+  });
+
+  describe('installPyArrow', () => {
+    test('should handle pyarrow installation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'PyArrow error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to install pyarrow. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to install pyarrow:',
+        'PyArrow error',
+      );
+    });
+
+    test('should handle pyarrow installation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('PyArrow error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('PyArrow error');
+    });
+  });
+
+  describe('installDoclingServe', () => {
+    test('should handle docling-serve installation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'Docling error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to install docling-serve. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to install docling-serve:',
+        'Docling error',
+      );
+    });
+
+    test('should handle docling-serve installation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('Docling error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Docling error');
+    });
+  });
+});

--- a/packages/pdf-parser/src/environment/python-environment.ts
+++ b/packages/pdf-parser/src/environment/python-environment.ts
@@ -1,0 +1,158 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { spawnAsync } from '@heripo/shared';
+import { join } from 'node:path';
+
+import {
+  PythonVersionError,
+  type PythonVersionInfo,
+  parsePythonVersion,
+  validatePythonVersion,
+} from '../utils/python-version';
+
+export class PythonEnvironment {
+  constructor(
+    private readonly logger: LoggerMethods,
+    private readonly venvPath: string,
+  ) {}
+
+  async setup(): Promise<void> {
+    await this.checkPythonVersion();
+    await this.setupPythonEnvironment();
+    await this.upgradePip();
+    await this.installSetuptools();
+    await this.installPyArrow();
+    await this.installDoclingServe();
+  }
+
+  private async checkPythonVersion(): Promise<PythonVersionInfo> {
+    const result = await spawnAsync('python3', ['--version']);
+
+    if (result.code !== 0) {
+      throw new Error('Failed to check Python version');
+    }
+
+    const output = result.stdout + result.stderr;
+    const version = parsePythonVersion(output);
+
+    if (!version) {
+      throw new Error('Could not parse Python version');
+    }
+
+    this.logger.info(
+      '[DoclingEnvironment] Python version:',
+      version.versionString,
+    );
+
+    try {
+      validatePythonVersion(version, 'system');
+    } catch (error) {
+      if (error instanceof PythonVersionError && version.minor >= 13) {
+        this.logger.error(
+          '[DoclingEnvironment] Python 3.13+ is not compatible. Install 3.11 or 3.12 with: pyenv install 3.12.0 && pyenv global 3.12.0',
+        );
+      }
+      throw error;
+    }
+
+    return version;
+  }
+
+  private async setupPythonEnvironment(): Promise<void> {
+    const result = await spawnAsync('python3', ['-m', 'venv', this.venvPath]);
+
+    if (result.code !== 0) {
+      throw new Error('Failed to create Python virtual environment');
+    }
+
+    await this.verifyVenvPythonVersion();
+  }
+
+  private async verifyVenvPythonVersion(): Promise<void> {
+    const pythonPath = join(this.venvPath, 'bin', 'python');
+    const result = await spawnAsync(pythonPath, ['--version']);
+
+    if (result.code !== 0) {
+      throw new Error('Failed to verify venv Python version');
+    }
+
+    const output = result.stdout + result.stderr;
+    const version = parsePythonVersion(output);
+
+    if (!version) {
+      throw new Error('Could not parse venv Python version');
+    }
+
+    validatePythonVersion(version, 'venv');
+  }
+
+  private async upgradePip(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, ['install', '--upgrade', 'pip']);
+
+    if (result.code !== 0) {
+      this.logger.error(
+        '[DoclingEnvironment] Failed to upgrade pip:',
+        result.stderr,
+      );
+      throw new Error(`Failed to upgrade pip. Exit code: ${result.code}`);
+    }
+  }
+
+  private async installSetuptools(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, [
+      'install',
+      '--upgrade',
+      'setuptools',
+      'wheel',
+    ]);
+
+    if (result.code !== 0) {
+      this.logger.error(
+        '[DoclingEnvironment] Failed to install setuptools:',
+        result.stderr,
+      );
+      throw new Error(
+        `Failed to install setuptools. Exit code: ${result.code}`,
+      );
+    }
+  }
+
+  private async installPyArrow(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, [
+      'install',
+      '--only-binary',
+      ':all:',
+      'pyarrow',
+    ]);
+
+    if (result.code !== 0) {
+      this.logger.error(
+        '[DoclingEnvironment] Failed to install pyarrow:',
+        result.stderr,
+      );
+      throw new Error(`Failed to install pyarrow. Exit code: ${result.code}`);
+    }
+  }
+
+  private async installDoclingServe(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, [
+      'install',
+      '--upgrade',
+      'docling-serve',
+    ]);
+
+    if (result.code !== 0) {
+      this.logger.error(
+        '[DoclingEnvironment] Failed to install docling-serve:',
+        result.stderr,
+      );
+      throw new Error(
+        `Failed to install docling-serve. Exit code: ${result.code}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Extract `PythonEnvironment` and `DoclingServer` classes from the monolithic `DoclingEnvironment` and add dedicated unit tests for each. This continues the refactoring effort to decompose `DoclingEnvironment` into smaller, independently testable components with clear responsibilities.

## Changes

- Extract `PythonEnvironment` class into `python-environment.ts` — handles Python version checks, venv creation, pip/setuptools/pyarrow/docling-serve installation
- Extract `DoclingServer` class into `docling-server.ts` — handles port checking, process killing, and Docling server lifecycle
- Add comprehensive tests in `python-environment.test.ts` (478 lines) covering setup steps, version validation, install failures, and error scenarios
- Add comprehensive tests in `docling-server.test.ts` (319 lines) covering port detection, process killing, server start/ready flow, and timeout handling
- Simplify `docling-environment.test.ts` from ~1000+ lines to ~150 lines by mocking `PythonEnvironment` and `DoclingServer` instead of low-level `spawn`/`spawnAsync` calls
- Simplify `docling-environment.ts` to delegate to the extracted classes

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
