### PR TITLE
refactor(demo-web): conditionally apply weekly session lockout only in public mode

### DIFF
--- a/apps/demo-web/src/app/api/rate-limit/check/route.ts
+++ b/apps/demo-web/src/app/api/rate-limit/check/route.ts
@@ -1,18 +1,27 @@
 import { NextResponse } from 'next/server';
 
-import { getWeeklyLockoutStatus } from '~/lib/db/repositories/success-session-repository';
+import { publicModeConfig } from '~/lib/config/public-mode';
+import {
+  type WeeklyLockoutStatus,
+  getWeeklyLockoutStatus,
+} from '~/lib/db/repositories/success-session-repository';
 import {
   getNextResetTime,
   getUsageStatus,
 } from '~/lib/db/repositories/usage-repository';
 import { getOrCreateSessionId } from '~/lib/session';
 
+const UNLOCKED: WeeklyLockoutStatus = { locked: false, lockedUntil: null };
+
 export async function GET() {
   const sessionId = await getOrCreateSessionId();
   const status = getUsageStatus();
   const resetsAt = getNextResetTime().toISOString();
 
-  const lockout = getWeeklyLockoutStatus(sessionId);
+  const lockout =
+    publicModeConfig.isPublicMode && publicModeConfig.isOfficialDemo
+      ? getWeeklyLockoutStatus(sessionId)
+      : UNLOCKED;
 
   return NextResponse.json({
     canCreate: lockout.locked ? false : status.canCreate,

--- a/apps/demo-web/src/app/api/tasks/route.ts
+++ b/apps/demo-web/src/app/api/tasks/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from 'next/server';
 
 import { verifyTOTP } from '~/lib/auth/totp';
 import { isTurnstileTokenValid } from '~/lib/auth/turnstile';
+import { publicModeConfig } from '~/lib/config/public-mode';
 import {
   canAttemptOTP,
   recordOTPAttempt,
@@ -208,27 +209,29 @@ export async function POST(request: NextRequest) {
           );
         }
 
-        // Step 3: Check weekly session lockout (only for non-OTP users)
-        const lockoutStatus = getWeeklyLockoutStatus(sessionId);
-        if (lockoutStatus.locked) {
-          sendWebhookAsync(
-            createSessionWeeklyLockedPayload({
-              ...clientInfo,
-              sessionId,
-              filename: file.name,
-              lockedUntil: lockoutStatus.lockedUntil!,
-            }),
-          );
+        // Step 3: Check weekly session lockout (official demo + non-OTP only)
+        if (publicModeConfig.isPublicMode && publicModeConfig.isOfficialDemo) {
+          const lockoutStatus = getWeeklyLockoutStatus(sessionId);
+          if (lockoutStatus.locked) {
+            sendWebhookAsync(
+              createSessionWeeklyLockedPayload({
+                ...clientInfo,
+                sessionId,
+                filename: file.name,
+                lockedUntil: lockoutStatus.lockedUntil!,
+              }),
+            );
 
-          return NextResponse.json(
-            {
-              error:
-                'You have already completed a task this week. Please try again later.',
-              code: 'WEEKLY_SESSION_LOCKED',
-              lockedUntil: lockoutStatus.lockedUntil,
-            },
-            { status: 429 },
-          );
+            return NextResponse.json(
+              {
+                error:
+                  'You have already completed a task this week. Please try again later.',
+                code: 'WEEKLY_SESSION_LOCKED',
+                lockedUntil: lockoutStatus.lockedUntil,
+              },
+              { status: 429 },
+            );
+          }
         }
 
         // Step 4: Check rate limit (only for non-OTP users)

--- a/apps/demo-web/src/app/api/upload/complete/route.ts
+++ b/apps/demo-web/src/app/api/upload/complete/route.ts
@@ -15,6 +15,7 @@ import {
   extractBearerToken,
   verifyUploadSessionToken,
 } from '~/lib/auth/upload-session';
+import { publicModeConfig } from '~/lib/config/public-mode';
 import { getWeeklyLockoutStatus } from '~/lib/db/repositories/success-session-repository';
 import { createTask } from '~/lib/db/repositories/task-repository';
 import {
@@ -130,8 +131,12 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Re-validate weekly lockout at completion time (non-OTP only)
-    if (!uploadSession.isOtpBypass) {
+    // Re-validate weekly lockout at completion time (official demo + non-OTP only)
+    if (
+      publicModeConfig.isPublicMode &&
+      publicModeConfig.isOfficialDemo &&
+      !uploadSession.isOtpBypass
+    ) {
       const lockoutStatus = getWeeklyLockoutStatus(uploadSession.sessionId);
       if (lockoutStatus.locked) {
         updateUploadSessionStatus(payload.uploadId, 'expired');

--- a/apps/demo-web/src/app/api/upload/session/route.ts
+++ b/apps/demo-web/src/app/api/upload/session/route.ts
@@ -10,6 +10,7 @@ import {
   type UploadSessionPayload,
   createUploadSessionToken,
 } from '~/lib/auth/upload-session';
+import { publicModeConfig } from '~/lib/config/public-mode';
 import {
   canAttemptOTP,
   recordOTPAttempt,
@@ -188,27 +189,29 @@ export async function POST(request: NextRequest) {
           );
         }
 
-        // Step 3: Check weekly session lockout (only for non-OTP users)
-        const lockoutStatus = getWeeklyLockoutStatus(sessionId);
-        if (lockoutStatus.locked) {
-          sendWebhookAsync(
-            createSessionWeeklyLockedPayload({
-              ...clientInfo,
-              sessionId,
-              filename,
-              lockedUntil: lockoutStatus.lockedUntil!,
-            }),
-          );
+        // Step 3: Check weekly session lockout (official demo + non-OTP only)
+        if (publicModeConfig.isPublicMode && publicModeConfig.isOfficialDemo) {
+          const lockoutStatus = getWeeklyLockoutStatus(sessionId);
+          if (lockoutStatus.locked) {
+            sendWebhookAsync(
+              createSessionWeeklyLockedPayload({
+                ...clientInfo,
+                sessionId,
+                filename,
+                lockedUntil: lockoutStatus.lockedUntil!,
+              }),
+            );
 
-          return NextResponse.json(
-            {
-              error:
-                'You have already completed a task this week. Please try again later.',
-              code: 'WEEKLY_SESSION_LOCKED',
-              lockedUntil: lockoutStatus.lockedUntil,
-            },
-            { status: 429 },
-          );
+            return NextResponse.json(
+              {
+                error:
+                  'You have already completed a task this week. Please try again later.',
+                code: 'WEEKLY_SESSION_LOCKED',
+                lockedUntil: lockoutStatus.lockedUntil,
+              },
+              { status: 429 },
+            );
+          }
         }
 
         // Step 4: Check rate limit (only for non-OTP users)


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Update the weekly session lockout logic so it only applies when running in public mode with the official demo configuration. Previously, the lockout was enforced unconditionally for all non-OTP users, which unnecessarily restricted self-hosted or private deployments.

## Changes

- Add `publicModeConfig.isPublicMode && publicModeConfig.isOfficialDemo` guard to weekly lockout check in `rate-limit/check/route.ts`, returning an `UNLOCKED` constant when conditions are not met
- Wrap weekly lockout enforcement in `tasks/route.ts` POST handler (Step 3) with the public mode guard
- Add public mode guard to `upload/session/route.ts` POST handler (Step 3) for session creation lockout check
- Add public mode guard to `upload/complete/route.ts` POST handler for re-validation at upload completion time
- Import `publicModeConfig` from `~/lib/config/public-mode` in all four affected route files
- Import `WeeklyLockoutStatus` type in `rate-limit/check/route.ts` for the `UNLOCKED` constant

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
