### PR TITLE
refactor(pdf-parser): improve code clarity with iterative patterns and modular retry logic

### DIFF
--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -102,25 +102,29 @@ export class ChunkedPDFConverter {
 
     try {
       // Step 4: Process each chunk sequentially
-      for (let i = 0; i < chunks.length; i++) {
-        this.checkAbort(abortSignal);
+      const docs = await chunks.reduce(
+        async (accPromise, [start, end], i) => {
+          const acc = await accPromise;
+          this.checkAbort(abortSignal);
 
-        const [start, end] = chunks[i];
-        const chunkDir = join(chunksBaseDir, `_chunk_${i}`);
-        mkdirSync(chunkDir, { recursive: true });
+          const chunkDir = join(chunksBaseDir, `_chunk_${i}`);
+          mkdirSync(chunkDir, { recursive: true });
 
-        const doc = await this.convertChunk(
-          i,
-          chunks.length,
-          start,
-          end,
-          httpUrl,
-          chunkDir,
-          options,
-        );
+          const doc = await this.convertChunk(
+            i,
+            chunks.length,
+            start,
+            end,
+            httpUrl,
+            chunkDir,
+            options,
+          );
 
-        chunkDocuments.push(doc);
-      }
+          return [...acc, doc];
+        },
+        Promise.resolve([] as DoclingDocument[]),
+      );
+      chunkDocuments.push(...docs);
     } finally {
       // Always stop the local file server
       this.logger.info('[ChunkedPDFConverter] Stopping local file server...');
@@ -213,103 +217,126 @@ export class ChunkedPDFConverter {
     options: PDFConvertOptions,
   ): Promise<DoclingDocument> {
     const chunkLabel = `Chunk ${chunkIndex + 1}/${totalChunks} (pages ${startPage}-${endPage})`;
+    return this.convertChunkWithRetry(
+      chunkLabel,
+      0,
+      startPage,
+      endPage,
+      httpUrl,
+      chunkDir,
+      options,
+    );
+  }
 
-    for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
-      try {
-        if (attempt > 0) {
-          this.logger.info(
-            `[ChunkedPDFConverter] ${chunkLabel}: retrying (${attempt}/${this.config.maxRetries})...`,
-          );
-        } else {
-          this.logger.info(
-            `[ChunkedPDFConverter] ${chunkLabel}: converting...`,
-          );
-        }
-
-        const startTime = Date.now();
-
-        // Build conversion options with page_range
-        const conversionOptions = buildConversionOptions({
-          ...options,
-          page_range: [startPage, endPage],
-        });
-
-        // Start conversion task
-        const task = await this.client.convertSourceAsync({
-          sources: [{ kind: 'http', url: httpUrl }],
-          options: conversionOptions,
-          target: { kind: 'zip' },
-        });
-
-        // Poll until completion
-        await trackTaskProgress(
-          task,
-          this.timeout,
-          this.logger,
-          '[ChunkedPDFConverter]',
-          {
-            errorPrefix: '[ChunkedPDFConverter] Chunk task ',
-          },
+  /**
+   * Recursive retry logic for chunk conversion.
+   */
+  private async convertChunkWithRetry(
+    chunkLabel: string,
+    attempt: number,
+    startPage: number,
+    endPage: number,
+    httpUrl: string,
+    chunkDir: string,
+    options: PDFConvertOptions,
+  ): Promise<DoclingDocument> {
+    try {
+      if (attempt > 0) {
+        this.logger.info(
+          `[ChunkedPDFConverter] ${chunkLabel}: retrying (${attempt}/${this.config.maxRetries})...`,
         );
+      } else {
+        this.logger.info(`[ChunkedPDFConverter] ${chunkLabel}: converting...`);
+      }
 
-        // Download ZIP result
-        const zipPath = join(chunkDir, 'result.zip');
-        await downloadTaskResult(
-          this.client,
-          task.taskId,
-          zipPath,
-          this.logger,
-          '[ChunkedPDFConverter]',
+      const startTime = Date.now();
+
+      // Build conversion options with page_range
+      const conversionOptions = buildConversionOptions({
+        ...options,
+        page_range: [startPage, endPage],
+      });
+
+      // Start conversion task
+      const task = await this.client.convertSourceAsync({
+        sources: [{ kind: 'http', url: httpUrl }],
+        options: conversionOptions,
+        target: { kind: 'zip' },
+      });
+
+      // Poll until completion
+      await trackTaskProgress(
+        task,
+        this.timeout,
+        this.logger,
+        '[ChunkedPDFConverter]',
+        {
+          errorPrefix: '[ChunkedPDFConverter] Chunk task ',
+        },
+      );
+
+      // Download ZIP result
+      const zipPath = join(chunkDir, 'result.zip');
+      await downloadTaskResult(
+        this.client,
+        task.taskId,
+        zipPath,
+        this.logger,
+        '[ChunkedPDFConverter]',
+      );
+
+      // Extract ZIP and process images
+      const extractDir = join(chunkDir, 'extracted');
+      const chunkOutputDir = join(chunkDir, 'output');
+      await ImageExtractor.extractAndSaveDocumentsFromZip(
+        this.logger,
+        zipPath,
+        extractDir,
+        chunkOutputDir,
+      );
+
+      // Parse result.json into a DoclingDocument object
+      const resultJsonPath = join(chunkOutputDir, 'result.json');
+      const doc = await runJqFileJson<DoclingDocument>('.', resultJsonPath);
+
+      // Cleanup chunk temp files (ZIP + extracted)
+      if (existsSync(zipPath)) rmSync(zipPath, { force: true });
+      if (existsSync(extractDir)) {
+        rmSync(extractDir, { recursive: true, force: true });
+      }
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      if (attempt > 0) {
+        this.logger.info(
+          `[ChunkedPDFConverter] ${chunkLabel}: completed on retry ${attempt} (${elapsed}s)`,
         );
-
-        // Extract ZIP and process images
-        const extractDir = join(chunkDir, 'extracted');
-        const chunkOutputDir = join(chunkDir, 'output');
-        await ImageExtractor.extractAndSaveDocumentsFromZip(
-          this.logger,
-          zipPath,
-          extractDir,
-          chunkOutputDir,
-        );
-
-        // Parse result.json into a DoclingDocument object
-        const resultJsonPath = join(chunkOutputDir, 'result.json');
-        const doc = await runJqFileJson<DoclingDocument>('.', resultJsonPath);
-
-        // Cleanup chunk temp files (ZIP + extracted)
-        if (existsSync(zipPath)) rmSync(zipPath, { force: true });
-        if (existsSync(extractDir)) {
-          rmSync(extractDir, { recursive: true, force: true });
-        }
-
-        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-        if (attempt > 0) {
-          this.logger.info(
-            `[ChunkedPDFConverter] ${chunkLabel}: completed on retry ${attempt} (${elapsed}s)`,
-          );
-        } else {
-          this.logger.info(
-            `[ChunkedPDFConverter] ${chunkLabel}: completed (${elapsed}s)`,
-          );
-        }
-
-        return doc;
-      } catch (error) {
-        if (attempt >= this.config.maxRetries) {
-          this.logger.error(
-            `[ChunkedPDFConverter] ${chunkLabel}: failed after ${this.config.maxRetries} retries`,
-          );
-          throw error;
-        }
-        this.logger.warn(
-          `[ChunkedPDFConverter] ${chunkLabel}: failed, retrying (${attempt + 1}/${this.config.maxRetries})...`,
+      } else {
+        this.logger.info(
+          `[ChunkedPDFConverter] ${chunkLabel}: completed (${elapsed}s)`,
         );
       }
-    }
 
-    /* v8 ignore start -- unreachable: loop always returns or throws */
-    throw new Error('Unreachable');
-    /* v8 ignore stop */
+      return doc;
+    } catch (error) {
+      if (attempt >= this.config.maxRetries) {
+        this.logger.error(
+          `[ChunkedPDFConverter] ${chunkLabel}: failed after ${this.config.maxRetries} retries`,
+        );
+        throw error;
+      }
+      this.logger.warn(
+        `[ChunkedPDFConverter] ${chunkLabel}: failed, retrying (${attempt + 1}/${this.config.maxRetries})...`,
+      );
+      return this.convertChunkWithRetry(
+        chunkLabel,
+        attempt + 1,
+        startPage,
+        endPage,
+        httpUrl,
+        chunkDir,
+        options,
+      );
+    }
   }
 
   /** Calculate page ranges for chunks */
@@ -318,12 +345,12 @@ export class ChunkedPDFConverter {
       throw new Error('[ChunkedPDFConverter] chunkSize must be positive');
     }
 
-    const ranges: PageRange[] = [];
-    for (let start = 1; start <= totalPages; start += this.config.chunkSize) {
+    const numChunks = Math.ceil(totalPages / this.config.chunkSize);
+    return Array.from({ length: numChunks }, (_, i) => {
+      const start = i * this.config.chunkSize + 1;
       const end = Math.min(start + this.config.chunkSize - 1, totalPages);
-      ranges.push([start, end]);
-    }
-    return ranges;
+      return [start, end] as PageRange;
+    });
   }
 
   /** Get total page count using pdfinfo */
@@ -345,16 +372,17 @@ export class ChunkedPDFConverter {
     totalChunks: number,
     imagesDir: string,
   ): void {
+    const chunkIndices = Array.from({ length: totalChunks }, (_, i) => i);
+
     // 1. Relocate pic_ files (JSON base64 images)
-    let picGlobalIndex = 0;
-    for (let i = 0; i < totalChunks; i++) {
+    const picGlobalIndex = chunkIndices.reduce((globalIndex, i) => {
       const chunkImagesDir = join(
         chunksBaseDir,
         `_chunk_${i}`,
         'output',
         'images',
       );
-      if (!existsSync(chunkImagesDir)) continue;
+      if (!existsSync(chunkImagesDir)) return globalIndex;
 
       const picFiles = readdirSync(chunkImagesDir)
         .filter((f) => f.startsWith('pic_') && f.endsWith('.png'))
@@ -364,24 +392,24 @@ export class ChunkedPDFConverter {
           return numA - numB;
         });
 
-      for (const file of picFiles) {
+      picFiles.forEach((file, fileIdx) => {
         const src = join(chunkImagesDir, file);
-        const dest = join(imagesDir, `pic_${picGlobalIndex}.png`);
+        const dest = join(imagesDir, `pic_${globalIndex + fileIdx}.png`);
         copyFileSync(src, dest);
-        picGlobalIndex++;
-      }
-    }
+      });
+
+      return globalIndex + picFiles.length;
+    }, 0);
 
     // 2. Relocate image_ files (HTML content images)
-    let imageGlobalIndex = 0;
-    for (let i = 0; i < totalChunks; i++) {
+    const imageGlobalIndex = chunkIndices.reduce((globalIndex, i) => {
       const chunkImagesDir = join(
         chunksBaseDir,
         `_chunk_${i}`,
         'output',
         'images',
       );
-      if (!existsSync(chunkImagesDir)) continue;
+      if (!existsSync(chunkImagesDir)) return globalIndex;
 
       const imageFiles = readdirSync(chunkImagesDir)
         .filter((f) => f.startsWith('image_') && f.endsWith('.png'))
@@ -397,13 +425,14 @@ export class ChunkedPDFConverter {
           return numA - numB;
         });
 
-      for (const file of imageFiles) {
+      imageFiles.forEach((file, fileIdx) => {
         const src = join(chunkImagesDir, file);
-        const dest = join(imagesDir, `image_${imageGlobalIndex}.png`);
+        const dest = join(imagesDir, `image_${globalIndex + fileIdx}.png`);
         copyFileSync(src, dest);
-        imageGlobalIndex++;
-      }
-    }
+      });
+
+      return globalIndex + imageFiles.length;
+    }, 0);
 
     this.logger.info(
       `[ChunkedPDFConverter] Relocated ${picGlobalIndex} pic + ${imageGlobalIndex} image files to ${imagesDir}`,
@@ -418,28 +447,24 @@ export class ChunkedPDFConverter {
    */
   private cleanupOrphanedPicFiles(resultPath: string, imagesDir: string): void {
     const content = readFileSync(resultPath, 'utf-8');
-    const referencedPics = new Set<string>();
-    const picPattern = /images\/pic_\d+\.png/g;
-    let match;
-    while ((match = picPattern.exec(content)) !== null) {
-      referencedPics.add(match[0].replace('images/', ''));
-    }
+    const referencedPics = new Set(
+      [...content.matchAll(/images\/pic_\d+\.png/g)].map((m) =>
+        m[0].replace('images/', ''),
+      ),
+    );
 
     const picFiles = readdirSync(imagesDir).filter(
       (f) => f.startsWith('pic_') && f.endsWith('.png'),
     );
 
-    let removedCount = 0;
-    for (const file of picFiles) {
-      if (!referencedPics.has(file)) {
-        rmSync(join(imagesDir, file), { force: true });
-        removedCount++;
-      }
-    }
+    const orphanedFiles = picFiles.filter((file) => !referencedPics.has(file));
+    orphanedFiles.forEach((file) => {
+      rmSync(join(imagesDir, file), { force: true });
+    });
 
-    if (removedCount > 0) {
+    if (orphanedFiles.length > 0) {
       this.logger.info(
-        `[ChunkedPDFConverter] Cleaned up ${removedCount} orphaned pic_ files (${referencedPics.size} referenced, kept)`,
+        `[ChunkedPDFConverter] Cleaned up ${orphanedFiles.length} orphaned pic_ files (${referencedPics.size} referenced, kept)`,
       );
     }
   }
@@ -452,18 +477,21 @@ export class ChunkedPDFConverter {
     chunksBaseDir: string,
     totalChunks: number,
   ): number[] {
-    const offsets: number[] = [];
-    let cumulative = 0;
-    for (let i = 0; i < totalChunks; i++) {
-      offsets.push(cumulative);
-      const dir = join(chunksBaseDir, `_chunk_${i}`, 'output', 'images');
-      const count = existsSync(dir)
-        ? readdirSync(dir).filter(
-            (f) => f.startsWith('pic_') && f.endsWith('.png'),
-          ).length
-        : 0;
-      cumulative += count;
-    }
+    const { offsets } = Array.from({ length: totalChunks }, (_, i) => i).reduce(
+      (acc, i) => {
+        const dir = join(chunksBaseDir, `_chunk_${i}`, 'output', 'images');
+        const count = existsSync(dir)
+          ? readdirSync(dir).filter(
+              (f) => f.startsWith('pic_') && f.endsWith('.png'),
+            ).length
+          : 0;
+        return {
+          offsets: [...acc.offsets, acc.cumulative],
+          cumulative: acc.cumulative + count,
+        };
+      },
+      { offsets: [] as number[], cumulative: 0 },
+    );
     return offsets;
   }
 

--- a/packages/pdf-parser/src/core/chunked-pdf-converter.ts
+++ b/packages/pdf-parser/src/core/chunked-pdf-converter.ts
@@ -102,29 +102,25 @@ export class ChunkedPDFConverter {
 
     try {
       // Step 4: Process each chunk sequentially
-      const docs = await chunks.reduce(
-        async (accPromise, [start, end], i) => {
-          const acc = await accPromise;
-          this.checkAbort(abortSignal);
+      for (let i = 0; i < chunks.length; i++) {
+        const [start, end] = chunks[i];
+        this.checkAbort(abortSignal);
 
-          const chunkDir = join(chunksBaseDir, `_chunk_${i}`);
-          mkdirSync(chunkDir, { recursive: true });
+        const chunkDir = join(chunksBaseDir, `_chunk_${i}`);
+        mkdirSync(chunkDir, { recursive: true });
 
-          const doc = await this.convertChunk(
-            i,
-            chunks.length,
-            start,
-            end,
-            httpUrl,
-            chunkDir,
-            options,
-          );
+        const doc = await this.convertChunk(
+          i,
+          chunks.length,
+          start,
+          end,
+          httpUrl,
+          chunkDir,
+          options,
+        );
 
-          return [...acc, doc];
-        },
-        Promise.resolve([] as DoclingDocument[]),
-      );
-      chunkDocuments.push(...docs);
+        chunkDocuments.push(doc);
+      }
     } finally {
       // Always stop the local file server
       this.logger.info('[ChunkedPDFConverter] Stopping local file server...');
@@ -372,17 +368,16 @@ export class ChunkedPDFConverter {
     totalChunks: number,
     imagesDir: string,
   ): void {
-    const chunkIndices = Array.from({ length: totalChunks }, (_, i) => i);
-
     // 1. Relocate pic_ files (JSON base64 images)
-    const picGlobalIndex = chunkIndices.reduce((globalIndex, i) => {
+    let picGlobalIndex = 0;
+    for (let i = 0; i < totalChunks; i++) {
       const chunkImagesDir = join(
         chunksBaseDir,
         `_chunk_${i}`,
         'output',
         'images',
       );
-      if (!existsSync(chunkImagesDir)) return globalIndex;
+      if (!existsSync(chunkImagesDir)) continue;
 
       const picFiles = readdirSync(chunkImagesDir)
         .filter((f) => f.startsWith('pic_') && f.endsWith('.png'))
@@ -392,24 +387,25 @@ export class ChunkedPDFConverter {
           return numA - numB;
         });
 
-      picFiles.forEach((file, fileIdx) => {
-        const src = join(chunkImagesDir, file);
-        const dest = join(imagesDir, `pic_${globalIndex + fileIdx}.png`);
+      for (let fileIdx = 0; fileIdx < picFiles.length; fileIdx++) {
+        const src = join(chunkImagesDir, picFiles[fileIdx]);
+        const dest = join(imagesDir, `pic_${picGlobalIndex + fileIdx}.png`);
         copyFileSync(src, dest);
-      });
+      }
 
-      return globalIndex + picFiles.length;
-    }, 0);
+      picGlobalIndex += picFiles.length;
+    }
 
     // 2. Relocate image_ files (HTML content images)
-    const imageGlobalIndex = chunkIndices.reduce((globalIndex, i) => {
+    let imageGlobalIndex = 0;
+    for (let i = 0; i < totalChunks; i++) {
       const chunkImagesDir = join(
         chunksBaseDir,
         `_chunk_${i}`,
         'output',
         'images',
       );
-      if (!existsSync(chunkImagesDir)) return globalIndex;
+      if (!existsSync(chunkImagesDir)) continue;
 
       const imageFiles = readdirSync(chunkImagesDir)
         .filter((f) => f.startsWith('image_') && f.endsWith('.png'))
@@ -425,14 +421,14 @@ export class ChunkedPDFConverter {
           return numA - numB;
         });
 
-      imageFiles.forEach((file, fileIdx) => {
-        const src = join(chunkImagesDir, file);
-        const dest = join(imagesDir, `image_${globalIndex + fileIdx}.png`);
+      for (let fileIdx = 0; fileIdx < imageFiles.length; fileIdx++) {
+        const src = join(chunkImagesDir, imageFiles[fileIdx]);
+        const dest = join(imagesDir, `image_${imageGlobalIndex + fileIdx}.png`);
         copyFileSync(src, dest);
-      });
+      }
 
-      return globalIndex + imageFiles.length;
-    }, 0);
+      imageGlobalIndex += imageFiles.length;
+    }
 
     this.logger.info(
       `[ChunkedPDFConverter] Relocated ${picGlobalIndex} pic + ${imageGlobalIndex} image files to ${imagesDir}`,
@@ -477,21 +473,18 @@ export class ChunkedPDFConverter {
     chunksBaseDir: string,
     totalChunks: number,
   ): number[] {
-    const { offsets } = Array.from({ length: totalChunks }, (_, i) => i).reduce(
-      (acc, i) => {
-        const dir = join(chunksBaseDir, `_chunk_${i}`, 'output', 'images');
-        const count = existsSync(dir)
-          ? readdirSync(dir).filter(
-              (f) => f.startsWith('pic_') && f.endsWith('.png'),
-            ).length
-          : 0;
-        return {
-          offsets: [...acc.offsets, acc.cumulative],
-          cumulative: acc.cumulative + count,
-        };
-      },
-      { offsets: [] as number[], cumulative: 0 },
-    );
+    const offsets: number[] = [];
+    let cumulative = 0;
+    for (let i = 0; i < totalChunks; i++) {
+      const dir = join(chunksBaseDir, `_chunk_${i}`, 'output', 'images');
+      const count = existsSync(dir)
+        ? readdirSync(dir).filter(
+            (f) => f.startsWith('pic_') && f.endsWith('.png'),
+          ).length
+        : 0;
+      offsets.push(cumulative);
+      cumulative += count;
+    }
     return offsets;
   }
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -292,10 +292,6 @@ export class PDFConverter {
   }
 
   /**
-   * Convert by first creating an image PDF, then running the conversion.
-   * Used when forceImagePdf option is enabled.
-   */
-  /**
    * Execute a conversion using an image PDF, handling cleanup in finally.
    */
   private async withImagePdf(

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -295,6 +295,24 @@ export class PDFConverter {
    * Convert by first creating an image PDF, then running the conversion.
    * Used when forceImagePdf option is enabled.
    */
+  /**
+   * Execute a conversion using an image PDF, handling cleanup in finally.
+   */
+  private async withImagePdf(
+    url: string,
+    reportId: string,
+    fn: (localUrl: string) => Promise<TokenUsageReport | null>,
+  ): Promise<TokenUsageReport | null> {
+    const imagePdfConverter = new ImagePdfConverter(this.logger);
+    const imagePdfPath = await imagePdfConverter.convert(url, reportId);
+    try {
+      const localUrl = `file://${imagePdfPath}`;
+      return await fn(localUrl);
+    } finally {
+      imagePdfConverter.cleanup(imagePdfPath);
+    }
+  }
+
   private async convertViaImagePdf(
     url: string,
     reportId: string,
@@ -306,12 +324,8 @@ export class PDFConverter {
     this.logger.info(
       '[PDFConverter] Force image PDF mode: converting to image PDF first...',
     );
-    const imagePdfConverter = new ImagePdfConverter(this.logger);
-    let imagePdfPath: string | null = null;
 
-    try {
-      imagePdfPath = await imagePdfConverter.convert(url, reportId);
-      const localUrl = `file://${imagePdfPath}`;
+    return this.withImagePdf(url, reportId, (localUrl) => {
       this.logger.info(
         '[PDFConverter] Image PDF ready, starting conversion:',
         localUrl,
@@ -322,7 +336,7 @@ export class PDFConverter {
         this.client,
         this.timeout,
       );
-      return await executor.execute(
+      return executor.execute(
         localUrl,
         reportId,
         onComplete,
@@ -330,11 +344,7 @@ export class PDFConverter {
         options,
         abortSignal,
       );
-    } finally {
-      if (imagePdfPath) {
-        imagePdfConverter.cleanup(imagePdfPath);
-      }
-    }
+    });
   }
 
   /**
@@ -349,60 +359,44 @@ export class PDFConverter {
     options: PDFConvertOptions,
     abortSignal?: AbortSignal,
   ): Promise<TokenUsageReport | null> {
-    let originalError: Error | null = null;
+    const directResult = await this.tryDirectConversion(
+      url,
+      reportId,
+      onComplete,
+      cleanupAfterCallback,
+      options,
+      abortSignal,
+    );
 
-    try {
-      const executor = new DoclingConversionExecutor(
-        this.logger,
-        this.client,
-        this.timeout,
-      );
-      return await executor.execute(
-        url,
-        reportId,
-        onComplete,
-        cleanupAfterCallback,
-        options,
-        abortSignal,
-      );
-    } catch (error) {
-      // If aborted, don't try fallback - re-throw immediately
-      if (abortSignal?.aborted) {
-        throw error;
-      }
-
-      originalError = error as Error;
-      this.logger.error('[PDFConverter] Conversion failed:', error);
-
-      if (!this.enableImagePdfFallback) {
-        throw error;
-      }
+    if (directResult.success) {
+      return directResult.report;
     }
 
     // Fallback: Convert to image PDF and retry
+    const originalError = directResult.error;
     this.logger.info('[PDFConverter] Attempting image PDF fallback...');
-    const imagePdfConverter = new ImagePdfConverter(this.logger);
-    let imagePdfPath: string | null = null;
 
     try {
-      imagePdfPath = await imagePdfConverter.convert(url, reportId);
-
-      // Use file:// URL for local file
-      const localUrl = `file://${imagePdfPath}`;
-      this.logger.info('[PDFConverter] Retrying with image PDF:', localUrl);
-
-      const fallbackExecutor = new DoclingConversionExecutor(
-        this.logger,
-        this.client,
-        this.timeout,
-      );
-      const report = await fallbackExecutor.execute(
-        localUrl,
+      const report = await this.withImagePdf(
+        url,
         reportId,
-        onComplete,
-        cleanupAfterCallback,
-        options,
-        abortSignal,
+        async (localUrl) => {
+          this.logger.info('[PDFConverter] Retrying with image PDF:', localUrl);
+
+          const fallbackExecutor = new DoclingConversionExecutor(
+            this.logger,
+            this.client,
+            this.timeout,
+          );
+          return fallbackExecutor.execute(
+            localUrl,
+            reportId,
+            onComplete,
+            cleanupAfterCallback,
+            options,
+            abortSignal,
+          );
+        },
       );
 
       this.logger.info('[PDFConverter] Fallback conversion succeeded');
@@ -412,12 +406,52 @@ export class PDFConverter {
         '[PDFConverter] Fallback conversion also failed:',
         fallbackError,
       );
-      throw new ImagePdfFallbackError(originalError!, fallbackError as Error);
-    } finally {
-      // Cleanup temp image PDF
-      if (imagePdfPath) {
-        imagePdfConverter.cleanup(imagePdfPath);
+      throw new ImagePdfFallbackError(originalError, fallbackError as Error);
+    }
+  }
+
+  /**
+   * Attempt direct conversion, returning success/failure without throwing.
+   */
+  private async tryDirectConversion(
+    url: string,
+    reportId: string,
+    onComplete: ConversionCompleteCallback,
+    cleanupAfterCallback: boolean,
+    options: PDFConvertOptions,
+    abortSignal?: AbortSignal,
+  ): Promise<
+    | { success: true; report: TokenUsageReport | null }
+    | { success: false; error: Error }
+  > {
+    try {
+      const executor = new DoclingConversionExecutor(
+        this.logger,
+        this.client,
+        this.timeout,
+      );
+      const report = await executor.execute(
+        url,
+        reportId,
+        onComplete,
+        cleanupAfterCallback,
+        options,
+        abortSignal,
+      );
+      return { success: true, report };
+    } catch (error) {
+      // If aborted, don't try fallback - re-throw immediately
+      if (abortSignal?.aborted) {
+        throw error;
       }
+
+      this.logger.error('[PDFConverter] Conversion failed:', error);
+
+      if (!this.enableImagePdfFallback) {
+        throw error;
+      }
+
+      return { success: false, error: error as Error };
     }
   }
 }

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -263,19 +263,17 @@ export class PDFParser {
         this.logger.info('[PDFParser] Server is ready');
       } catch {
         const now = Date.now();
-        const updatedLogTime =
-          now - lastLogTime >= logInterval
-            ? (() => {
-                this.logger.info(
-                  '[PDFParser] Waiting for server... (attempt',
-                  attempt,
-                  '/',
-                  maxAttempts,
-                  ')',
-                );
-                return now;
-              })()
-            : lastLogTime;
+        let updatedLogTime = lastLogTime;
+        if (now - lastLogTime >= logInterval) {
+          this.logger.info(
+            '[PDFParser] Waiting for server... (attempt',
+            attempt,
+            '/',
+            maxAttempts,
+            ')',
+          );
+          updatedLogTime = now;
+        }
 
         if (attempt < maxAttempts) {
           await new Promise((resolve) => setTimeout(resolve, checkInterval));

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -249,33 +249,42 @@ export class PDFParser {
     const maxAttempts = PDF_PARSER.MAX_HEALTH_CHECK_ATTEMPTS;
     const checkInterval = PDF_PARSER.HEALTH_CHECK_INTERVAL_MS;
     const logInterval = PDF_PARSER.HEALTH_CHECK_LOG_INTERVAL_MS;
-    let lastLogTime = 0;
 
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const checkHealth = async (
+      attempt: number,
+      lastLogTime: number,
+    ): Promise<void> => {
+      if (attempt > maxAttempts) {
+        throw new Error('Server failed to become ready after maximum attempts');
+      }
+
       try {
         await this.client!.health();
         this.logger.info('[PDFParser] Server is ready');
-        return;
       } catch {
         const now = Date.now();
-        if (now - lastLogTime >= logInterval) {
-          this.logger.info(
-            '[PDFParser] Waiting for server... (attempt',
-            attempt,
-            '/',
-            maxAttempts,
-            ')',
-          );
-          lastLogTime = now;
-        }
+        const updatedLogTime =
+          now - lastLogTime >= logInterval
+            ? (() => {
+                this.logger.info(
+                  '[PDFParser] Waiting for server... (attempt',
+                  attempt,
+                  '/',
+                  maxAttempts,
+                  ')',
+                );
+                return now;
+              })()
+            : lastLogTime;
 
         if (attempt < maxAttempts) {
           await new Promise((resolve) => setTimeout(resolve, checkInterval));
         }
+        return checkHealth(attempt + 1, updatedLogTime);
       }
-    }
+    };
 
-    throw new Error('Server failed to become ready after maximum attempts');
+    return checkHealth(1, 0);
   }
 
   public async parse(
@@ -354,9 +363,8 @@ export class PDFParser {
   ): Promise<T> {
     const canRecover = !this.baseUrl && this.port !== undefined;
     const maxAttempts = PDF_PARSER.MAX_SERVER_RECOVERY_ATTEMPTS;
-    let attempt = 0;
 
-    while (attempt <= maxAttempts) {
+    const tryExecute = async (attempt: number): Promise<T> => {
       try {
         return await fn();
       } catch (error) {
@@ -370,16 +378,13 @@ export class PDFParser {
             '[PDFParser] Connection refused, attempting server recovery...',
           );
           await this.restartServer();
-          attempt++;
-          continue;
+          return tryExecute(attempt + 1);
         }
         throw error;
       }
-    }
+    };
 
-    /* v8 ignore start */
-    return null as T;
-    /* v8 ignore stop */
+    return tryExecute(0);
   }
 
   /**

--- a/packages/pdf-parser/src/processors/correction-applier.ts
+++ b/packages/pdf-parser/src/processors/correction-applier.ts
@@ -28,17 +28,13 @@ export function getPageTexts(
   doc: DoclingDocument,
   pageNo: number,
 ): Array<{ index: number; item: DoclingTextItem }> {
-  const results: Array<{ index: number; item: DoclingTextItem }> = [];
-
-  for (let i = 0; i < doc.texts.length; i++) {
-    const item = doc.texts[i];
-    if (!TEXT_LABELS.has(item.label)) continue;
-    if (item.prov.some((p) => p.page_no === pageNo)) {
-      results.push({ index: i, item });
-    }
-  }
-
-  return results;
+  return doc.texts
+    .map((item, index) => ({ index, item }))
+    .filter(
+      ({ item }) =>
+        TEXT_LABELS.has(item.label) &&
+        item.prov.some((p) => p.page_no === pageNo),
+    );
 }
 
 /**
@@ -48,16 +44,9 @@ export function getPageTables(
   doc: DoclingDocument,
   pageNo: number,
 ): Array<{ index: number; item: DoclingTableItem }> {
-  const results: Array<{ index: number; item: DoclingTableItem }> = [];
-
-  for (let i = 0; i < doc.tables.length; i++) {
-    const item = doc.tables[i];
-    if (item.prov.some((p) => p.page_no === pageNo)) {
-      results.push({ index: i, item });
-    }
-  }
-
-  return results;
+  return doc.tables
+    .map((item, index) => ({ index, item }))
+    .filter(({ item }) => item.prov.some((p) => p.page_no === pageNo));
 }
 
 /**
@@ -72,48 +61,45 @@ export function applyCorrections(
   // Apply text corrections (substitution-based)
   if (corrections.tc.length > 0) {
     const pageTexts = getPageTexts(doc, pageNo);
-    for (const correction of corrections.tc) {
+    corrections.tc.forEach((correction) => {
       if (correction.i >= 0 && correction.i < pageTexts.length) {
         const docIndex = pageTexts[correction.i].index;
-        let text = doc.texts[docIndex].text;
-        for (const sub of correction.s) {
-          const idx = text.indexOf(sub.f);
+        const text = correction.s.reduce((acc, sub) => {
+          const idx = acc.indexOf(sub.f);
           if (idx >= 0) {
-            text =
-              text.substring(0, idx) +
-              sub.r +
-              text.substring(idx + sub.f.length);
-          } else {
-            logger.warn(
-              `[VlmTextCorrector] Page ${pageNo}, text ${correction.i}: ` +
-                `find string not found, skipping substitution`,
+            return (
+              acc.substring(0, idx) + sub.r + acc.substring(idx + sub.f.length)
             );
           }
-        }
+          logger.warn(
+            `[VlmTextCorrector] Page ${pageNo}, text ${correction.i}: ` +
+              `find string not found, skipping substitution`,
+          );
+          return acc;
+        }, doc.texts[docIndex].text);
         if (text !== doc.texts[docIndex].text) {
           doc.texts[docIndex].text = text;
           doc.texts[docIndex].orig = text;
         }
       }
-    }
+    });
   }
 
   // Apply cell corrections
   if (corrections.cc.length > 0) {
     const pageTables = getPageTables(doc, pageNo);
-    for (const correction of corrections.cc) {
+    corrections.cc.forEach((correction) => {
       if (correction.ti >= 0 && correction.ti < pageTables.length) {
         const table = pageTables[correction.ti].item;
 
         // Update table_cells
-        for (const cell of table.data.table_cells) {
-          if (
+        const matchingCell = table.data.table_cells.find(
+          (cell) =>
             cell.start_row_offset_idx === correction.r &&
-            cell.start_col_offset_idx === correction.c
-          ) {
-            cell.text = correction.t;
-            break;
-          }
+            cell.start_col_offset_idx === correction.c,
+        );
+        if (matchingCell) {
+          matchingCell.text = correction.t;
         }
 
         // Sync grid cell (grid stores separate objects from table_cells)
@@ -125,6 +111,6 @@ export function applyCorrections(
           }
         }
       }
-    }
+    });
   }
 }

--- a/packages/pdf-parser/src/processors/image-extractor.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.ts
@@ -117,54 +117,55 @@ export class ImageExtractor {
     htmlOutputPath: string,
     imagesDir: string,
   ): Promise<number> {
-    let imageIndex = 0;
-    let pending = '';
+    const state = { imageIndex: 0, pending: '' };
     const MARKER = 'src="data:image/png;base64,';
+
+    function parseChunk(): string {
+      const markerIdx = state.pending.indexOf(MARKER);
+
+      if (markerIdx === -1) {
+        // Keep a tail that could be a partial marker match
+        const safeEnd = Math.max(0, state.pending.length - MARKER.length);
+        const result = state.pending.slice(0, safeEnd);
+        state.pending = state.pending.slice(safeEnd);
+        return result;
+      }
+
+      // Flush everything before the marker
+      const before = state.pending.slice(0, markerIdx);
+
+      // Find the closing quote after base64 data
+      const dataStart = markerIdx + MARKER.length;
+      const quoteIdx = state.pending.indexOf('"', dataStart);
+
+      if (quoteIdx === -1) {
+        // Closing quote not in buffer yet — keep everything from marker onward
+        state.pending = state.pending.slice(markerIdx);
+        return before;
+      }
+
+      // Extract base64 content and save as image file
+      const base64Content = state.pending.slice(dataStart, quoteIdx);
+      const filename = `image_${state.imageIndex}.png`;
+      const filepath = join(imagesDir, filename);
+      const buf = Buffer.from(base64Content, 'base64');
+      writeFileSync(filepath, buf);
+
+      const relativePath = `images/${filename}`;
+      state.imageIndex++;
+
+      state.pending = state.pending.slice(quoteIdx + 1);
+
+      // Recurse to process remaining buffer
+      return before + `src="${relativePath}"` + parseChunk();
+    }
 
     const transform = new Transform({
       decodeStrings: false,
       encoding: 'utf-8',
       transform(chunk: string, _encoding, callback) {
-        pending += chunk;
-        let result = '';
-
-        while (true) {
-          const markerIdx = pending.indexOf(MARKER);
-
-          if (markerIdx === -1) {
-            // Keep a tail that could be a partial marker match
-            const safeEnd = Math.max(0, pending.length - MARKER.length);
-            result += pending.slice(0, safeEnd);
-            pending = pending.slice(safeEnd);
-            break;
-          }
-
-          // Flush everything before the marker
-          result += pending.slice(0, markerIdx);
-
-          // Find the closing quote after base64 data
-          const dataStart = markerIdx + MARKER.length;
-          const quoteIdx = pending.indexOf('"', dataStart);
-
-          if (quoteIdx === -1) {
-            // Closing quote not in buffer yet — keep everything from marker onward
-            pending = pending.slice(markerIdx);
-            break;
-          }
-
-          // Extract base64 content and save as image file
-          const base64Content = pending.slice(dataStart, quoteIdx);
-          const filename = `image_${imageIndex}.png`;
-          const filepath = join(imagesDir, filename);
-          const buf = Buffer.from(base64Content, 'base64');
-          writeFileSync(filepath, buf);
-
-          const relativePath = `images/${filename}`;
-          result += `src="${relativePath}"`;
-          imageIndex++;
-
-          pending = pending.slice(quoteIdx + 1);
-        }
+        state.pending += chunk;
+        const result = parseChunk();
 
         if (result.length > 0) {
           this.push(result);
@@ -172,8 +173,8 @@ export class ImageExtractor {
         callback();
       },
       flush(callback) {
-        if (pending.length > 0) {
-          this.push(pending);
+        if (state.pending.length > 0) {
+          this.push(state.pending);
         }
         callback();
       },
@@ -184,7 +185,7 @@ export class ImageExtractor {
 
     await pipeline(rs, transform, ws);
 
-    return imageIndex;
+    return state.imageIndex;
   }
 
   /**

--- a/packages/pdf-parser/src/processors/image-extractor.ts
+++ b/packages/pdf-parser/src/processors/image-extractor.ts
@@ -117,54 +117,57 @@ export class ImageExtractor {
     htmlOutputPath: string,
     imagesDir: string,
   ): Promise<number> {
-    const state = { imageIndex: 0, pending: '' };
+    let imageIndex = 0;
+    let pending = '';
     const MARKER = 'src="data:image/png;base64,';
 
     function parseChunk(): string {
-      const markerIdx = state.pending.indexOf(MARKER);
+      let result = '';
 
-      if (markerIdx === -1) {
-        // Keep a tail that could be a partial marker match
-        const safeEnd = Math.max(0, state.pending.length - MARKER.length);
-        const result = state.pending.slice(0, safeEnd);
-        state.pending = state.pending.slice(safeEnd);
-        return result;
+      while (true) {
+        const markerIdx = pending.indexOf(MARKER);
+
+        if (markerIdx === -1) {
+          // Keep a tail that could be a partial marker match
+          const safeEnd = Math.max(0, pending.length - MARKER.length);
+          result += pending.slice(0, safeEnd);
+          pending = pending.slice(safeEnd);
+          return result;
+        }
+
+        // Flush everything before the marker
+        result += pending.slice(0, markerIdx);
+
+        // Find the closing quote after base64 data
+        const dataStart = markerIdx + MARKER.length;
+        const quoteIdx = pending.indexOf('"', dataStart);
+
+        if (quoteIdx === -1) {
+          // Closing quote not in buffer yet — keep everything from marker onward
+          pending = pending.slice(markerIdx);
+          return result;
+        }
+
+        // Extract base64 content and save as image file
+        const base64Content = pending.slice(dataStart, quoteIdx);
+        const filename = `image_${imageIndex}.png`;
+        const filepath = join(imagesDir, filename);
+        const buf = Buffer.from(base64Content, 'base64');
+        writeFileSync(filepath, buf);
+
+        const relativePath = `images/${filename}`;
+        imageIndex++;
+
+        pending = pending.slice(quoteIdx + 1);
+        result += `src="${relativePath}"`;
       }
-
-      // Flush everything before the marker
-      const before = state.pending.slice(0, markerIdx);
-
-      // Find the closing quote after base64 data
-      const dataStart = markerIdx + MARKER.length;
-      const quoteIdx = state.pending.indexOf('"', dataStart);
-
-      if (quoteIdx === -1) {
-        // Closing quote not in buffer yet — keep everything from marker onward
-        state.pending = state.pending.slice(markerIdx);
-        return before;
-      }
-
-      // Extract base64 content and save as image file
-      const base64Content = state.pending.slice(dataStart, quoteIdx);
-      const filename = `image_${state.imageIndex}.png`;
-      const filepath = join(imagesDir, filename);
-      const buf = Buffer.from(base64Content, 'base64');
-      writeFileSync(filepath, buf);
-
-      const relativePath = `images/${filename}`;
-      state.imageIndex++;
-
-      state.pending = state.pending.slice(quoteIdx + 1);
-
-      // Recurse to process remaining buffer
-      return before + `src="${relativePath}"` + parseChunk();
     }
 
     const transform = new Transform({
       decodeStrings: false,
       encoding: 'utf-8',
       transform(chunk: string, _encoding, callback) {
-        state.pending += chunk;
+        pending += chunk;
         const result = parseChunk();
 
         if (result.length > 0) {
@@ -173,8 +176,8 @@ export class ImageExtractor {
         callback();
       },
       flush(callback) {
-        if (state.pending.length > 0) {
-          this.push(state.pending);
+        if (pending.length > 0) {
+          this.push(pending);
         }
         callback();
       },
@@ -185,7 +188,7 @@ export class ImageExtractor {
 
     await pipeline(rs, transform, ws);
 
-    return state.imageIndex;
+    return imageIndex;
   }
 
   /**

--- a/packages/pdf-parser/src/processors/vlm-image-extractor.ts
+++ b/packages/pdf-parser/src/processors/vlm-image-extractor.ts
@@ -89,26 +89,23 @@ export class VlmImageExtractor {
       dims: { width: number; height: number };
     }>;
 
-    const imagePaths = await validPictures.reduce(
-      async (accPromise, { picture, i, pageFile, dims }) => {
-        const acc = await accPromise;
-        const crop = this.computeCropRegion(
-          picture.bbox,
-          dims.width,
-          dims.height,
-        );
+    const imagePaths: string[] = [];
+    for (const { picture, i, pageFile, dims } of validPictures) {
+      const crop = this.computeCropRegion(
+        picture.bbox,
+        dims.width,
+        dims.height,
+      );
 
-        // Warn for outlier crop regions but still attempt extraction
-        this.validateCropRegion(i, crop.w, crop.h, dims.width, dims.height);
+      // Warn for outlier crop regions but still attempt extraction
+      this.validateCropRegion(i, crop.w, crop.h, dims.width, dims.height);
 
-        const relativePath = `images/image_${i}.png`;
-        const outputPath = join(outputDir, relativePath);
+      const relativePath = `images/image_${i}.png`;
+      const outputPath = join(outputDir, relativePath);
 
-        await this.cropImage(pageFile, outputPath, crop);
-        return [...acc, relativePath];
-      },
-      Promise.resolve([] as string[]),
-    );
+      await this.cropImage(pageFile, outputPath, crop);
+      imagePaths.push(relativePath);
+    }
 
     this.logger.info(
       `[VlmImageExtractor] Extracted ${imagePaths.length} images`,
@@ -127,11 +124,11 @@ export class VlmImageExtractor {
     pictures: PictureLocation[],
   ): Promise<Map<number, { width: number; height: number }>> {
     const uniquePages = [...new Set(pictures.map((p) => p.pageNo))];
+    const dimensions = new Map<number, { width: number; height: number }>();
 
-    return uniquePages.reduce(async (accPromise, pageNo) => {
-      const acc = await accPromise;
+    for (const pageNo of uniquePages) {
       const pageFile = pageFiles[pageNo - 1];
-      if (!pageFile) return acc;
+      if (!pageFile) continue;
 
       const result = await spawnAsync('magick', [
         'identify',
@@ -146,14 +143,12 @@ export class VlmImageExtractor {
         const height = Number(parts[1]);
 
         if (!isNaN(width) && !isNaN(height)) {
-          const next = new Map(acc);
-          next.set(pageNo, { width, height });
-          return next;
+          dimensions.set(pageNo, { width, height });
         }
       }
+    }
 
-      return acc;
-    }, Promise.resolve(new Map<number, { width: number; height: number }>()));
+    return dimensions;
   }
 
   /**

--- a/packages/pdf-parser/src/processors/vlm-image-extractor.ts
+++ b/packages/pdf-parser/src/processors/vlm-image-extractor.ts
@@ -67,35 +67,48 @@ export class VlmImageExtractor {
     // Get dimensions for pages that have pictures (one call per unique page)
     const pageDimensions = await this.getPageDimensions(pageFiles, pictures);
 
-    const imagePaths: string[] = [];
+    const validPictures = pictures
+      .map((picture, i) => ({
+        picture,
+        i,
+        pageFile: pageFiles[picture.pageNo - 1],
+        dims: pageDimensions.get(picture.pageNo),
+      }))
+      .filter(({ i, picture, pageFile, dims }) => {
+        if (!pageFile || !dims) {
+          this.logger.warn(
+            `[VlmImageExtractor] Skipping picture ${i}: page ${picture.pageNo} not found`,
+          );
+          return false;
+        }
+        return true;
+      }) as Array<{
+      picture: PictureLocation;
+      i: number;
+      pageFile: string;
+      dims: { width: number; height: number };
+    }>;
 
-    for (let i = 0; i < pictures.length; i++) {
-      const picture = pictures[i];
-      const pageFile = pageFiles[picture.pageNo - 1];
-      const dims = pageDimensions.get(picture.pageNo);
-
-      if (!pageFile || !dims) {
-        this.logger.warn(
-          `[VlmImageExtractor] Skipping picture ${i}: page ${picture.pageNo} not found`,
+    const imagePaths = await validPictures.reduce(
+      async (accPromise, { picture, i, pageFile, dims }) => {
+        const acc = await accPromise;
+        const crop = this.computeCropRegion(
+          picture.bbox,
+          dims.width,
+          dims.height,
         );
-        continue;
-      }
 
-      const crop = this.computeCropRegion(
-        picture.bbox,
-        dims.width,
-        dims.height,
-      );
+        // Warn for outlier crop regions but still attempt extraction
+        this.validateCropRegion(i, crop.w, crop.h, dims.width, dims.height);
 
-      // Warn for outlier crop regions but still attempt extraction
-      this.validateCropRegion(i, crop.w, crop.h, dims.width, dims.height);
+        const relativePath = `images/image_${i}.png`;
+        const outputPath = join(outputDir, relativePath);
 
-      const relativePath = `images/image_${i}.png`;
-      const outputPath = join(outputDir, relativePath);
-
-      await this.cropImage(pageFile, outputPath, crop);
-      imagePaths.push(relativePath);
-    }
+        await this.cropImage(pageFile, outputPath, crop);
+        return [...acc, relativePath];
+      },
+      Promise.resolve([] as string[]),
+    );
 
     this.logger.info(
       `[VlmImageExtractor] Extracted ${imagePaths.length} images`,
@@ -114,11 +127,11 @@ export class VlmImageExtractor {
     pictures: PictureLocation[],
   ): Promise<Map<number, { width: number; height: number }>> {
     const uniquePages = [...new Set(pictures.map((p) => p.pageNo))];
-    const dimensions = new Map<number, { width: number; height: number }>();
 
-    for (const pageNo of uniquePages) {
+    return uniquePages.reduce(async (accPromise, pageNo) => {
+      const acc = await accPromise;
       const pageFile = pageFiles[pageNo - 1];
-      if (!pageFile) continue;
+      if (!pageFile) return acc;
 
       const result = await spawnAsync('magick', [
         'identify',
@@ -133,12 +146,14 @@ export class VlmImageExtractor {
         const height = Number(parts[1]);
 
         if (!isNaN(width) && !isNaN(height)) {
-          dimensions.set(pageNo, { width, height });
+          const next = new Map(acc);
+          next.set(pageNo, { width, height });
+          return next;
         }
       }
-    }
 
-    return dimensions;
+      return acc;
+    }, Promise.resolve(new Map<number, { width: number; height: number }>()));
   }
 
   /**

--- a/packages/pdf-parser/src/processors/vlm-page-processor.ts
+++ b/packages/pdf-parser/src/processors/vlm-page-processor.ts
@@ -186,42 +186,19 @@ export class VlmPageProcessor {
       options.aggregator.track(result.usage);
     }
 
-    let pageResult = toVlmPageResult(pageNo, result.output as VlmPageOutput);
+    const initialPageResult = toVlmPageResult(
+      pageNo,
+      result.output as VlmPageOutput,
+    );
 
     // Retry once with higher temperature if VLM returned no elements
+    const pageResult =
+      initialPageResult.elements.length === 0
+        ? await this.retryForEmptyPage(pageNo, messages, model, options)
+        : initialPageResult;
+
     if (pageResult.elements.length === 0) {
-      this.logger.warn(
-        `[VlmPageProcessor] Page ${pageNo}: 0 elements extracted, retrying with temperature ${EMPTY_PAGE_RETRY_TEMPERATURE}...`,
-      );
-
-      const retryResult = await LLMCaller.callVision({
-        schema: vlmPageOutputSchema as any,
-        messages,
-        primaryModel: model,
-        fallbackModel: options?.fallbackModel,
-        maxRetries: options?.maxRetries ?? DEFAULT_MAX_RETRIES,
-        temperature: EMPTY_PAGE_RETRY_TEMPERATURE,
-        abortSignal: options?.abortSignal,
-        component: 'VlmPageProcessor',
-        phase: 'page-analysis-retry',
-      });
-
-      if (options?.aggregator) {
-        options.aggregator.track(retryResult.usage);
-      }
-
-      pageResult = toVlmPageResult(pageNo, retryResult.output as VlmPageOutput);
-
-      if (pageResult.elements.length > 0) {
-        this.logger.debug(
-          `[VlmPageProcessor] Page ${pageNo}: ${pageResult.elements.length} elements extracted on retry`,
-        );
-      } else {
-        this.logger.warn(
-          `[VlmPageProcessor] Page ${pageNo}: still 0 elements after retry`,
-        );
-        return pageResult;
-      }
+      return pageResult;
     }
 
     // Quality validation: detect hallucination and script anomalies
@@ -245,6 +222,59 @@ export class VlmPageProcessor {
     );
 
     return pageResult;
+  }
+
+  /**
+   * Retry a page with higher temperature when initial VLM call returned no elements.
+   */
+  private async retryForEmptyPage(
+    pageNo: number,
+    messages: Array<{
+      role: 'user';
+      content: Array<
+        | { type: 'text'; text: string }
+        | { type: 'image'; image: Uint8Array; mediaType: 'image/png' }
+      >;
+    }>,
+    model: LanguageModel,
+    options?: VlmPageProcessorOptions,
+  ): Promise<VlmPageResult> {
+    this.logger.warn(
+      `[VlmPageProcessor] Page ${pageNo}: 0 elements extracted, retrying with temperature ${EMPTY_PAGE_RETRY_TEMPERATURE}...`,
+    );
+
+    const retryResult = await LLMCaller.callVision({
+      schema: vlmPageOutputSchema as any,
+      messages,
+      primaryModel: model,
+      fallbackModel: options?.fallbackModel,
+      maxRetries: options?.maxRetries ?? DEFAULT_MAX_RETRIES,
+      temperature: EMPTY_PAGE_RETRY_TEMPERATURE,
+      abortSignal: options?.abortSignal,
+      component: 'VlmPageProcessor',
+      phase: 'page-analysis-retry',
+    });
+
+    if (options?.aggregator) {
+      options.aggregator.track(retryResult.usage);
+    }
+
+    const retryPageResult = toVlmPageResult(
+      pageNo,
+      retryResult.output as VlmPageOutput,
+    );
+
+    if (retryPageResult.elements.length > 0) {
+      this.logger.debug(
+        `[VlmPageProcessor] Page ${pageNo}: ${retryPageResult.elements.length} elements extracted on retry`,
+      );
+    } else {
+      this.logger.warn(
+        `[VlmPageProcessor] Page ${pageNo}: still 0 elements after retry`,
+      );
+    }
+
+    return retryPageResult;
   }
 
   /**

--- a/packages/pdf-parser/src/processors/vlm-text-corrector.ts
+++ b/packages/pdf-parser/src/processors/vlm-text-corrector.ts
@@ -99,8 +99,8 @@ export class VlmTextCorrector {
     const resultPath = join(outputDir, 'result.json');
     const doc: DoclingDocument = JSON.parse(readFileSync(resultPath, 'utf-8'));
 
-    let pageNumbers = this.getPageNumbers(doc);
-    if (pageNumbers.length === 0) {
+    const allPageNumbers = this.getPageNumbers(doc);
+    if (allPageNumbers.length === 0) {
       this.logger.info('[VlmTextCorrector] No pages to process');
       return {
         textCorrections: 0,
@@ -110,17 +110,17 @@ export class VlmTextCorrector {
       };
     }
 
-    if (
-      options?.koreanHanjaMixPages &&
-      options.koreanHanjaMixPages.length > 0
-    ) {
-      const totalPageCount = pageNumbers.length;
-      const hanjaSet = new Set(options.koreanHanjaMixPages);
-      pageNumbers = pageNumbers.filter((p) => hanjaSet.has(p));
-      this.logger.info(
-        `[VlmTextCorrector] Filtering to ${pageNumbers.length} Korean-Hanja mix pages out of ${totalPageCount} total`,
-      );
-    }
+    const pageNumbers =
+      options?.koreanHanjaMixPages && options.koreanHanjaMixPages.length > 0
+        ? (() => {
+            const hanjaSet = new Set(options.koreanHanjaMixPages);
+            const filtered = allPageNumbers.filter((p) => hanjaSet.has(p));
+            this.logger.info(
+              `[VlmTextCorrector] Filtering to ${filtered.length} Korean-Hanja mix pages out of ${allPageNumbers.length} total`,
+            );
+            return filtered;
+          })()
+        : allPageNumbers;
 
     const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY;
     this.logger.info(
@@ -141,25 +141,27 @@ export class VlmTextCorrector {
     );
 
     // Aggregate results
-    let totalTextCorrections = 0;
-    let totalCellCorrections = 0;
-    let pagesFailed = 0;
-
-    for (const result of results) {
-      if (result === null) {
-        pagesFailed++;
-      } else {
-        totalTextCorrections += result.tc.length;
-        totalCellCorrections += result.cc.length;
-      }
-    }
+    const { totalTextCorrections, totalCellCorrections, pagesFailed } =
+      results.reduce(
+        (acc, result) => {
+          if (result === null) {
+            return { ...acc, pagesFailed: acc.pagesFailed + 1 };
+          }
+          return {
+            ...acc,
+            totalTextCorrections: acc.totalTextCorrections + result.tc.length,
+            totalCellCorrections: acc.totalCellCorrections + result.cc.length,
+          };
+        },
+        { totalTextCorrections: 0, totalCellCorrections: 0, pagesFailed: 0 },
+      );
 
     // Apply corrections to document
-    for (let i = 0; i < pageNumbers.length; i++) {
+    pageNumbers.forEach((pageNo, i) => {
       const corrections = results[i];
-      if (corrections === null) continue;
-      applyCorrections(doc, pageNumbers[i], corrections, this.logger);
-    }
+      if (corrections === null) return;
+      applyCorrections(doc, pageNo, corrections, this.logger);
+    });
 
     // Save corrected document
     writeFileSync(resultPath, JSON.stringify(doc, null, 2));
@@ -322,20 +324,14 @@ export class VlmTextCorrector {
     }
 
     if (pageTables.length > 0) {
-      const cellLines: string[] = [];
-      for (
-        let tablePromptIndex = 0;
-        tablePromptIndex < pageTables.length;
-        tablePromptIndex++
-      ) {
-        const table = pageTables[tablePromptIndex].item;
-        for (const cell of table.data.table_cells) {
-          if (!cell.text || cell.text.trim().length === 0) continue;
-          cellLines.push(
-            `${tablePromptIndex}|${cell.start_row_offset_idx},${cell.start_col_offset_idx}|${cell.text}`,
-          );
-        }
-      }
+      const cellLines = pageTables.flatMap((entry, tablePromptIndex) =>
+        entry.item.data.table_cells
+          .filter((cell) => cell.text && cell.text.trim().length > 0)
+          .map(
+            (cell) =>
+              `${tablePromptIndex}|${cell.start_row_offset_idx},${cell.start_col_offset_idx}|${cell.text}`,
+          ),
+      );
       if (cellLines.length > 0) {
         const cellSection = 'C:\n' + cellLines.join('\n');
         if (tableContext) {

--- a/packages/pdf-parser/src/processors/vlm-text-corrector.ts
+++ b/packages/pdf-parser/src/processors/vlm-text-corrector.ts
@@ -110,17 +110,19 @@ export class VlmTextCorrector {
       };
     }
 
-    const pageNumbers =
-      options?.koreanHanjaMixPages && options.koreanHanjaMixPages.length > 0
-        ? (() => {
-            const hanjaSet = new Set(options.koreanHanjaMixPages);
-            const filtered = allPageNumbers.filter((p) => hanjaSet.has(p));
-            this.logger.info(
-              `[VlmTextCorrector] Filtering to ${filtered.length} Korean-Hanja mix pages out of ${allPageNumbers.length} total`,
-            );
-            return filtered;
-          })()
-        : allPageNumbers;
+    let pageNumbers: number[];
+    if (
+      options?.koreanHanjaMixPages &&
+      options.koreanHanjaMixPages.length > 0
+    ) {
+      const hanjaSet = new Set(options.koreanHanjaMixPages);
+      pageNumbers = allPageNumbers.filter((p) => hanjaSet.has(p));
+      this.logger.info(
+        `[VlmTextCorrector] Filtering to ${pageNumbers.length} Korean-Hanja mix pages out of ${allPageNumbers.length} total`,
+      );
+    } else {
+      pageNumbers = allPageNumbers;
+    }
 
     const concurrency = options?.concurrency ?? DEFAULT_CONCURRENCY;
     this.logger.info(
@@ -141,20 +143,17 @@ export class VlmTextCorrector {
     );
 
     // Aggregate results
-    const { totalTextCorrections, totalCellCorrections, pagesFailed } =
-      results.reduce(
-        (acc, result) => {
-          if (result === null) {
-            return { ...acc, pagesFailed: acc.pagesFailed + 1 };
-          }
-          return {
-            ...acc,
-            totalTextCorrections: acc.totalTextCorrections + result.tc.length,
-            totalCellCorrections: acc.totalCellCorrections + result.cc.length,
-          };
-        },
-        { totalTextCorrections: 0, totalCellCorrections: 0, pagesFailed: 0 },
-      );
+    let totalTextCorrections = 0;
+    let totalCellCorrections = 0;
+    let pagesFailed = 0;
+    for (const result of results) {
+      if (result === null) {
+        pagesFailed++;
+      } else {
+        totalTextCorrections += result.tc.length;
+        totalCellCorrections += result.cc.length;
+      }
+    }
 
     // Apply corrections to document
     pageNumbers.forEach((pageNo, i) => {

--- a/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
+++ b/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
@@ -179,60 +179,50 @@ export class OcrStrategySampler {
   }
 
   /**
-   * Recursively sample pages for Korean-Hanja mix detection with early exit.
+   * Sample pages for Korean-Hanja mix detection with early exit.
    */
   private async samplePages(
     sampleIndices: number[],
     pageFiles: string[],
     model: LanguageModel,
     options?: OcrStrategySamplerOptions,
-    currentIndex = 0,
-    languageFrequency = new Map<Bcp47LanguageTag, number>(),
   ): Promise<{
     foundMix: boolean;
     mixPageNo?: number;
     sampledCount: number;
     languageFrequency: Map<Bcp47LanguageTag, number>;
   }> {
-    if (currentIndex >= sampleIndices.length) {
-      return {
-        foundMix: false,
-        sampledCount: sampleIndices.length,
-        languageFrequency,
-      };
+    const languageFrequency = new Map<Bcp47LanguageTag, number>();
+
+    for (let i = 0; i < sampleIndices.length; i++) {
+      const idx = sampleIndices[i];
+      const pageFile = pageFiles[idx];
+      const pageAnalysis = await this.analyzeSamplePage(
+        pageFile,
+        idx + 1,
+        model,
+        options,
+      );
+
+      for (const lang of pageAnalysis.detectedLanguages) {
+        languageFrequency.set(lang, (languageFrequency.get(lang) ?? 0) + 1);
+      }
+
+      if (pageAnalysis.hasKoreanHanjaMix) {
+        return {
+          foundMix: true,
+          mixPageNo: idx + 1,
+          sampledCount: i + 1,
+          languageFrequency,
+        };
+      }
     }
 
-    const idx = sampleIndices[currentIndex];
-    const pageFile = pageFiles[idx];
-    const pageAnalysis = await this.analyzeSamplePage(
-      pageFile,
-      idx + 1,
-      model,
-      options,
-    );
-
-    const updatedFrequency = new Map(languageFrequency);
-    pageAnalysis.detectedLanguages.forEach((lang) => {
-      updatedFrequency.set(lang, (updatedFrequency.get(lang) ?? 0) + 1);
-    });
-
-    if (pageAnalysis.hasKoreanHanjaMix) {
-      return {
-        foundMix: true,
-        mixPageNo: idx + 1,
-        sampledCount: currentIndex + 1,
-        languageFrequency: updatedFrequency,
-      };
-    }
-
-    return this.samplePages(
-      sampleIndices,
-      pageFiles,
-      model,
-      options,
-      currentIndex + 1,
-      updatedFrequency,
-    );
+    return {
+      foundMix: false,
+      sampledCount: sampleIndices.length,
+      languageFrequency,
+    };
   }
 
   /**

--- a/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
+++ b/packages/pdf-parser/src/samplers/ocr-strategy-sampler.ts
@@ -139,49 +139,100 @@ export class OcrStrategySampler {
     );
 
     // Step 4: Check each sample page for Korean-Hanja mix (early exit on detection)
-    let sampledCount = 0;
-    const languageFrequency = new Map<Bcp47LanguageTag, number>();
-    for (const idx of sampleIndices) {
-      sampledCount++;
-      const pageFile = renderResult.pageFiles[idx];
-      const pageAnalysis = await this.analyzeSamplePage(
-        pageFile,
-        idx + 1,
-        model,
-        options,
+    const sampleResult = await this.samplePages(
+      sampleIndices,
+      renderResult.pageFiles,
+      model,
+      options,
+    );
+
+    if (sampleResult.foundMix) {
+      this.logger.info(
+        `[OcrStrategySampler] Korean-Hanja mix detected on page ${sampleResult.mixPageNo} → VLM strategy`,
       );
-
-      for (const lang of pageAnalysis.detectedLanguages) {
-        languageFrequency.set(lang, (languageFrequency.get(lang) ?? 0) + 1);
-      }
-
-      if (pageAnalysis.hasKoreanHanjaMix) {
-        this.logger.info(
-          `[OcrStrategySampler] Korean-Hanja mix detected on page ${idx + 1} → VLM strategy`,
-        );
-        const detectedLanguages = this.aggregateLanguages(languageFrequency);
-        return {
-          method: 'vlm',
-          detectedLanguages,
-          reason: `Korean-Hanja mix detected on page ${idx + 1}`,
-          sampledPages: sampledCount,
-          totalPages: renderResult.pageCount,
-        };
-      }
+      const detectedLanguages = this.aggregateLanguages(
+        sampleResult.languageFrequency,
+      );
+      return {
+        method: 'vlm',
+        detectedLanguages,
+        reason: `Korean-Hanja mix detected on page ${sampleResult.mixPageNo}`,
+        sampledPages: sampleResult.sampledCount,
+        totalPages: renderResult.pageCount,
+      };
     }
 
     // Step 5: No Korean-Hanja mix found → ocrmac
     this.logger.info(
       '[OcrStrategySampler] No Korean-Hanja mix detected → ocrmac strategy',
     );
-    const detectedLanguages = this.aggregateLanguages(languageFrequency);
+    const detectedLanguages = this.aggregateLanguages(
+      sampleResult.languageFrequency,
+    );
     return {
       method: 'ocrmac',
       detectedLanguages,
-      reason: `No Korean-Hanja mix detected in ${sampledCount} sampled pages`,
-      sampledPages: sampledCount,
+      reason: `No Korean-Hanja mix detected in ${sampleResult.sampledCount} sampled pages`,
+      sampledPages: sampleResult.sampledCount,
       totalPages: renderResult.pageCount,
     };
+  }
+
+  /**
+   * Recursively sample pages for Korean-Hanja mix detection with early exit.
+   */
+  private async samplePages(
+    sampleIndices: number[],
+    pageFiles: string[],
+    model: LanguageModel,
+    options?: OcrStrategySamplerOptions,
+    currentIndex = 0,
+    languageFrequency = new Map<Bcp47LanguageTag, number>(),
+  ): Promise<{
+    foundMix: boolean;
+    mixPageNo?: number;
+    sampledCount: number;
+    languageFrequency: Map<Bcp47LanguageTag, number>;
+  }> {
+    if (currentIndex >= sampleIndices.length) {
+      return {
+        foundMix: false,
+        sampledCount: sampleIndices.length,
+        languageFrequency,
+      };
+    }
+
+    const idx = sampleIndices[currentIndex];
+    const pageFile = pageFiles[idx];
+    const pageAnalysis = await this.analyzeSamplePage(
+      pageFile,
+      idx + 1,
+      model,
+      options,
+    );
+
+    const updatedFrequency = new Map(languageFrequency);
+    pageAnalysis.detectedLanguages.forEach((lang) => {
+      updatedFrequency.set(lang, (updatedFrequency.get(lang) ?? 0) + 1);
+    });
+
+    if (pageAnalysis.hasKoreanHanjaMix) {
+      return {
+        foundMix: true,
+        mixPageNo: idx + 1,
+        sampledCount: currentIndex + 1,
+        languageFrequency: updatedFrequency,
+      };
+    }
+
+    return this.samplePages(
+      sampleIndices,
+      pageFiles,
+      model,
+      options,
+      currentIndex + 1,
+      updatedFrequency,
+    );
   }
 
   /**
@@ -219,12 +270,9 @@ export class OcrStrategySampler {
 
       if (hasHanja) {
         const pageTextArray = fullText.split('\f');
-        const koreanHanjaMixPages: number[] = [];
-        for (let i = 0; i < pageTextArray.length; i++) {
-          if (CJK_REGEX.test(pageTextArray[i])) {
-            koreanHanjaMixPages.push(i + 1); // 1-based
-          }
-        }
+        const koreanHanjaMixPages = pageTextArray.flatMap((text, i) =>
+          CJK_REGEX.test(text) ? [i + 1] : [],
+        );
 
         this.logger.info(
           `[OcrStrategySampler] Hangul-Hanja mix detected in text layer → VLM strategy (${koreanHanjaMixPages.length} pages with Hanja)`,
@@ -290,12 +338,11 @@ export class OcrStrategySampler {
     }
 
     // Distribute samples evenly across eligible range
-    const indices: number[] = [];
     const step = eligibleCount / maxSamples;
-    for (let i = 0; i < maxSamples; i++) {
-      indices.push(start + Math.floor(i * step));
-    }
-    return indices;
+    return Array.from(
+      { length: maxSamples },
+      (_, i) => start + Math.floor(i * step),
+    );
   }
 
   /**

--- a/packages/pdf-parser/src/utils/jq.ts
+++ b/packages/pdf-parser/src/utils/jq.ts
@@ -180,15 +180,14 @@ export function runJqFileLines(
     }
 
     function processBuffer(): void {
-      const newlineIdx = state.buffer.indexOf('\n');
-      if (newlineIdx === -1) return;
-
-      const line = state.buffer.slice(0, newlineIdx);
-      state.buffer = state.buffer.slice(newlineIdx + 1);
-      if (line.length > 0) {
-        safeOnLine(line);
+      let newlineIdx: number;
+      while ((newlineIdx = state.buffer.indexOf('\n')) !== -1) {
+        const line = state.buffer.slice(0, newlineIdx);
+        state.buffer = state.buffer.slice(newlineIdx + 1);
+        if (line.length > 0) {
+          safeOnLine(line);
+        }
       }
-      processBuffer();
     }
 
     child.stdout.on('data', (chunk: string) => {

--- a/packages/pdf-parser/src/utils/jq.ts
+++ b/packages/pdf-parser/src/utils/jq.ts
@@ -34,17 +34,16 @@ export function runJqFileJson<T = unknown>(
       env: process.env,
     });
 
-    let stdout = '';
-    let stderr = '';
+    const state = { stdout: '', stderr: '' };
 
     child.stdout.setEncoding('utf-8');
     child.stderr.setEncoding('utf-8');
 
     child.stdout.on('data', (chunk: string) => {
-      stdout += chunk;
+      state.stdout += chunk;
     });
     child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
+      state.stderr += chunk;
     });
 
     child.on('error', (err) => {
@@ -54,19 +53,19 @@ export function runJqFileJson<T = unknown>(
     child.on('close', (code) => {
       if (code !== 0) {
         const error = new Error(
-          `jq exited with code ${code}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+          `jq exited with code ${code}. ${state.stderr ? 'Stderr: ' + state.stderr : ''}`,
         );
         return reject(error);
       }
       try {
         // jq may output trailing newlines; trim is safe for JSON
-        const text = stdout.trim();
+        const text = state.stdout.trim();
         const parsed = JSON.parse(text) as T;
         resolve(parsed);
       } catch (e) {
         reject(
           new Error(
-            `Failed to parse jq output as JSON. Output length=${stdout.length}. Error: ${(e as Error).message}`,
+            `Failed to parse jq output as JSON. Output length=${state.stdout.length}. Error: ${(e as Error).message}`,
           ),
         );
       }
@@ -92,26 +91,28 @@ export function runJqFileToFile(
       env: process.env,
     });
 
-    let stderr = '';
-    let exitCode: number | null = null;
-    let pipelineDone = false;
-    let settled = false;
+    const state = {
+      stderr: '',
+      exitCode: null as number | null,
+      pipelineDone: false,
+      settled: false,
+    };
 
     child.stderr.setEncoding('utf-8');
     child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
+      state.stderr += chunk;
     });
 
     const ws = createWriteStream(outputPath);
 
     function trySettle() {
-      if (settled) return;
-      if (!pipelineDone || exitCode === null) return;
-      settled = true;
-      if (exitCode !== 0) {
+      if (state.settled) return;
+      if (!state.pipelineDone || state.exitCode === null) return;
+      state.settled = true;
+      if (state.exitCode !== 0) {
         reject(
           new Error(
-            `jq exited with code ${exitCode}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+            `jq exited with code ${state.exitCode}. ${state.stderr ? 'Stderr: ' + state.stderr : ''}`,
           ),
         );
       } else {
@@ -120,25 +121,25 @@ export function runJqFileToFile(
     }
 
     child.on('error', (err) => {
-      if (settled) return;
-      settled = true;
+      if (state.settled) return;
+      state.settled = true;
       ws.destroy();
       reject(err);
     });
 
     pipeline(child.stdout, ws)
       .then(() => {
-        pipelineDone = true;
+        state.pipelineDone = true;
         trySettle();
       })
       .catch((err) => {
-        if (settled) return;
-        settled = true;
+        if (state.settled) return;
+        state.settled = true;
         reject(err);
       });
 
     child.on('close', (code) => {
-      exitCode = code ?? 1;
+      state.exitCode = code ?? 1;
       trySettle();
     });
   });
@@ -162,56 +163,59 @@ export function runJqFileLines(
       env: process.env,
     });
 
-    let stderr = '';
-    let buffer = '';
-    let callbackError = false;
+    const state = { stderr: '', buffer: '', callbackError: false };
 
     child.stdout.setEncoding('utf-8');
     child.stderr.setEncoding('utf-8');
 
     function safeOnLine(line: string): void {
-      if (callbackError) return;
+      if (state.callbackError) return;
       try {
         onLine(line);
       } catch (err) {
-        callbackError = true;
+        state.callbackError = true;
         child.kill();
         reject(err);
       }
     }
 
-    child.stdout.on('data', (chunk: string) => {
-      buffer += chunk;
-      let newlineIdx: number;
-      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, newlineIdx);
-        buffer = buffer.slice(newlineIdx + 1);
-        if (line.length > 0) {
-          safeOnLine(line);
-        }
+    function processBuffer(): void {
+      const newlineIdx = state.buffer.indexOf('\n');
+      if (newlineIdx === -1) return;
+
+      const line = state.buffer.slice(0, newlineIdx);
+      state.buffer = state.buffer.slice(newlineIdx + 1);
+      if (line.length > 0) {
+        safeOnLine(line);
       }
+      processBuffer();
+    }
+
+    child.stdout.on('data', (chunk: string) => {
+      state.buffer += chunk;
+      processBuffer();
     });
 
     child.stderr.on('data', (chunk: string) => {
-      stderr += chunk;
+      state.stderr += chunk;
     });
 
     child.on('error', (err) => {
-      if (!callbackError) reject(err);
+      if (!state.callbackError) reject(err);
     });
 
     child.on('close', (code) => {
-      if (callbackError) return;
+      if (state.callbackError) return;
       // Process any remaining data in buffer
-      if (buffer.length > 0) {
-        safeOnLine(buffer);
+      if (state.buffer.length > 0) {
+        safeOnLine(state.buffer);
       }
-      if (callbackError) return;
+      if (state.callbackError) return;
 
       if (code !== 0) {
         reject(
           new Error(
-            `jq exited with code ${code}. ${stderr ? 'Stderr: ' + stderr : ''}`,
+            `jq exited with code ${code}. ${state.stderr ? 'Stderr: ' + state.stderr : ''}`,
           ),
         );
       } else {
@@ -243,16 +247,16 @@ export async function jqExtractBase64PngStringsStreaming(
   filePath: string,
   onImage: (base64Data: string, index: number) => void,
 ): Promise<number> {
-  let index = 0;
+  const counter = { value: 0 };
   await runJqFileLines(
     '.. | select(type == "string" and startswith("data:image/png;base64"))',
     filePath,
     (line) => {
-      onImage(line, index);
-      index++;
+      onImage(line, counter.value);
+      counter.value++;
     },
   );
-  return index;
+  return counter.value;
 }
 
 /**

--- a/packages/pdf-parser/src/utils/task-progress-tracker.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.ts
@@ -47,29 +47,27 @@ export async function trackTaskProgress(
     const status = await task.poll();
 
     // Detailed progress logging (used by single-pass conversion)
-    const updatedProgressLine = options?.showDetailedProgress
-      ? (() => {
-          const parts: string[] = [`Status: ${status.task_status}`];
-          if (status.task_position !== undefined) {
-            parts.push(`position: ${status.task_position}`);
-          }
-          const meta = status.task_meta;
-          if (
-            meta?.processed_documents !== undefined &&
-            meta?.total_documents !== undefined
-          ) {
-            parts.push(
-              `progress: ${meta.processed_documents}/${meta.total_documents}`,
-            );
-          }
-          const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
-          if (progressLine !== lastProgressLine) {
-            process.stdout.write(progressLine);
-            return progressLine;
-          }
-          return lastProgressLine;
-        })()
-      : lastProgressLine;
+    let updatedProgressLine = lastProgressLine;
+    if (options?.showDetailedProgress) {
+      const parts: string[] = [`Status: ${status.task_status}`];
+      if (status.task_position !== undefined) {
+        parts.push(`position: ${status.task_position}`);
+      }
+      const meta = status.task_meta;
+      if (
+        meta?.processed_documents !== undefined &&
+        meta?.total_documents !== undefined
+      ) {
+        parts.push(
+          `progress: ${meta.processed_documents}/${meta.total_documents}`,
+        );
+      }
+      const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
+      if (progressLine !== lastProgressLine) {
+        process.stdout.write(progressLine);
+        updatedProgressLine = progressLine;
+      }
+    }
 
     if (status.task_status === 'success') {
       if (options?.showDetailedProgress) {

--- a/packages/pdf-parser/src/utils/task-progress-tracker.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.ts
@@ -38,9 +38,8 @@ export async function trackTaskProgress(
 ): Promise<void> {
   const startTime = Date.now();
   const errPrefix = options?.errorPrefix ?? 'Task ';
-  let lastProgressLine = '';
 
-  while (true) {
+  const pollOnce = async (lastProgressLine: string): Promise<void> => {
     if (Date.now() - startTime > timeout) {
       throw new Error(`${errPrefix}timeout`);
     }
@@ -48,26 +47,29 @@ export async function trackTaskProgress(
     const status = await task.poll();
 
     // Detailed progress logging (used by single-pass conversion)
-    if (options?.showDetailedProgress) {
-      const parts: string[] = [`Status: ${status.task_status}`];
-      if (status.task_position !== undefined) {
-        parts.push(`position: ${status.task_position}`);
-      }
-      const meta = status.task_meta;
-      if (
-        meta?.processed_documents !== undefined &&
-        meta?.total_documents !== undefined
-      ) {
-        parts.push(
-          `progress: ${meta.processed_documents}/${meta.total_documents}`,
-        );
-      }
-      const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
-      if (progressLine !== lastProgressLine) {
-        lastProgressLine = progressLine;
-        process.stdout.write(progressLine);
-      }
-    }
+    const updatedProgressLine = options?.showDetailedProgress
+      ? (() => {
+          const parts: string[] = [`Status: ${status.task_status}`];
+          if (status.task_position !== undefined) {
+            parts.push(`position: ${status.task_position}`);
+          }
+          const meta = status.task_meta;
+          if (
+            meta?.processed_documents !== undefined &&
+            meta?.total_documents !== undefined
+          ) {
+            parts.push(
+              `progress: ${meta.processed_documents}/${meta.total_documents}`,
+            );
+          }
+          const progressLine = `\r${logPrefix} ${parts.join(' | ')}`;
+          if (progressLine !== lastProgressLine) {
+            process.stdout.write(progressLine);
+            return progressLine;
+          }
+          return lastProgressLine;
+        })()
+      : lastProgressLine;
 
     if (status.task_status === 'success') {
       if (options?.showDetailedProgress) {
@@ -97,5 +99,8 @@ export async function trackTaskProgress(
     await new Promise((resolve) =>
       setTimeout(resolve, PDF_CONVERTER.POLL_INTERVAL_MS),
     );
-  }
+    return pollOnce(updatedProgressLine);
+  };
+
+  return pollOnce('');
 }

--- a/packages/pdf-parser/src/utils/text-reference-matcher.ts
+++ b/packages/pdf-parser/src/utils/text-reference-matcher.ts
@@ -30,31 +30,34 @@ export function matchTextToReferenceWithUnused(
     return { references, unusedBlocks: [] };
   }
 
-  const available = new Set(refBlocks.map((_, i) => i));
+  const initialAvailable = new Set(refBlocks.map((_, i) => i));
 
-  for (let promptIndex = 0; promptIndex < pageTexts.length; promptIndex++) {
-    const ocrText = pageTexts[promptIndex].item.text;
+  const finalAvailable = pageTexts.reduce((available, entry, promptIndex) => {
+    const ocrText = entry.item.text;
 
-    let bestScore = 0;
-    let bestBlockIndex = -1;
-
-    for (const blockIndex of available) {
-      const score = computeCharOverlap(ocrText, refBlocks[blockIndex]);
-      if (score > bestScore) {
-        bestScore = score;
-        bestBlockIndex = blockIndex;
-      }
-    }
+    const { bestScore, bestBlockIndex } = [...available].reduce(
+      (best, blockIndex) => {
+        const score = computeCharOverlap(ocrText, refBlocks[blockIndex]);
+        return score > best.bestScore
+          ? { bestScore: score, bestBlockIndex: blockIndex }
+          : best;
+      },
+      { bestScore: 0, bestBlockIndex: -1 },
+    );
 
     if (bestBlockIndex >= 0 && bestScore >= REFERENCE_MATCH_THRESHOLD) {
       if (refBlocks[bestBlockIndex] !== ocrText) {
         references.set(promptIndex, refBlocks[bestBlockIndex]);
       }
-      available.delete(bestBlockIndex);
+      const next = new Set(available);
+      next.delete(bestBlockIndex);
+      return next;
     }
-  }
 
-  const unusedBlocks = [...available]
+    return available;
+  }, initialAvailable);
+
+  const unusedBlocks = [...finalAvailable]
     .sort((a, b) => a - b)
     .map((i) => refBlocks[i]);
 
@@ -66,25 +69,27 @@ export function matchTextToReferenceWithUnused(
  * Consecutive non-empty lines are joined with a space.
  */
 export function mergeIntoBlocks(pageText: string): string[] {
-  const blocks: string[] = [];
-  let currentLines: string[] = [];
-
-  for (const rawLine of pageText.split('\n')) {
-    const trimmed = rawLine.trim();
-    if (trimmed.length === 0) {
-      if (currentLines.length > 0) {
-        blocks.push(currentLines.join(' '));
-        currentLines = [];
+  const { blocks, currentLines } = pageText.split('\n').reduce(
+    (acc, rawLine) => {
+      const trimmed = rawLine.trim();
+      if (trimmed.length === 0) {
+        if (acc.currentLines.length > 0) {
+          return {
+            blocks: [...acc.blocks, acc.currentLines.join(' ')],
+            currentLines: [],
+          };
+        }
+        return acc;
       }
-    } else {
-      currentLines.push(trimmed);
-    }
-  }
-  if (currentLines.length > 0) {
-    blocks.push(currentLines.join(' '));
-  }
+      return {
+        blocks: acc.blocks,
+        currentLines: [...acc.currentLines, trimmed],
+      };
+    },
+    { blocks: [] as string[], currentLines: [] as string[] },
+  );
 
-  return blocks;
+  return currentLines.length > 0 ? [...blocks, currentLines.join(' ')] : blocks;
 }
 
 /**
@@ -94,21 +99,20 @@ export function mergeIntoBlocks(pageText: string): string[] {
 export function computeCharOverlap(a: string, b: string): number {
   if (a.length === 0 || b.length === 0) return 0;
 
-  const freqA = new Map<string, number>();
-  for (const ch of a) {
-    freqA.set(ch, (freqA.get(ch) ?? 0) + 1);
-  }
+  const freqA = [...a].reduce((freq, ch) => {
+    freq.set(ch, (freq.get(ch) ?? 0) + 1);
+    return freq;
+  }, new Map<string, number>());
 
-  const freqB = new Map<string, number>();
-  for (const ch of b) {
-    freqB.set(ch, (freqB.get(ch) ?? 0) + 1);
-  }
+  const freqB = [...b].reduce((freq, ch) => {
+    freq.set(ch, (freq.get(ch) ?? 0) + 1);
+    return freq;
+  }, new Map<string, number>());
 
-  let overlap = 0;
-  for (const [ch, countA] of freqA) {
+  const overlap = [...freqA].reduce((sum, [ch, countA]) => {
     const countB = freqB.get(ch) ?? 0;
-    overlap += Math.min(countA, countB);
-  }
+    return sum + Math.min(countA, countB);
+  }, 0);
 
   return overlap / Math.max(a.length, b.length);
 }

--- a/packages/pdf-parser/src/utils/text-reference-matcher.ts
+++ b/packages/pdf-parser/src/utils/text-reference-matcher.ts
@@ -30,34 +30,30 @@ export function matchTextToReferenceWithUnused(
     return { references, unusedBlocks: [] };
   }
 
-  const initialAvailable = new Set(refBlocks.map((_, i) => i));
+  const available = new Set(refBlocks.map((_, i) => i));
 
-  const finalAvailable = pageTexts.reduce((available, entry, promptIndex) => {
-    const ocrText = entry.item.text;
+  for (let promptIndex = 0; promptIndex < pageTexts.length; promptIndex++) {
+    const ocrText = pageTexts[promptIndex].item.text;
 
-    const { bestScore, bestBlockIndex } = [...available].reduce(
-      (best, blockIndex) => {
-        const score = computeCharOverlap(ocrText, refBlocks[blockIndex]);
-        return score > best.bestScore
-          ? { bestScore: score, bestBlockIndex: blockIndex }
-          : best;
-      },
-      { bestScore: 0, bestBlockIndex: -1 },
-    );
+    let bestScore = 0;
+    let bestBlockIndex = -1;
+    for (const blockIndex of available) {
+      const score = computeCharOverlap(ocrText, refBlocks[blockIndex]);
+      if (score > bestScore) {
+        bestScore = score;
+        bestBlockIndex = blockIndex;
+      }
+    }
 
     if (bestBlockIndex >= 0 && bestScore >= REFERENCE_MATCH_THRESHOLD) {
       if (refBlocks[bestBlockIndex] !== ocrText) {
         references.set(promptIndex, refBlocks[bestBlockIndex]);
       }
-      const next = new Set(available);
-      next.delete(bestBlockIndex);
-      return next;
+      available.delete(bestBlockIndex);
     }
+  }
 
-    return available;
-  }, initialAvailable);
-
-  const unusedBlocks = [...finalAvailable]
+  const unusedBlocks = [...available]
     .sort((a, b) => a - b)
     .map((i) => refBlocks[i]);
 
@@ -69,27 +65,26 @@ export function matchTextToReferenceWithUnused(
  * Consecutive non-empty lines are joined with a space.
  */
 export function mergeIntoBlocks(pageText: string): string[] {
-  const { blocks, currentLines } = pageText.split('\n').reduce(
-    (acc, rawLine) => {
-      const trimmed = rawLine.trim();
-      if (trimmed.length === 0) {
-        if (acc.currentLines.length > 0) {
-          return {
-            blocks: [...acc.blocks, acc.currentLines.join(' ')],
-            currentLines: [],
-          };
-        }
-        return acc;
-      }
-      return {
-        blocks: acc.blocks,
-        currentLines: [...acc.currentLines, trimmed],
-      };
-    },
-    { blocks: [] as string[], currentLines: [] as string[] },
-  );
+  const blocks: string[] = [];
+  const currentLines: string[] = [];
 
-  return currentLines.length > 0 ? [...blocks, currentLines.join(' ')] : blocks;
+  for (const rawLine of pageText.split('\n')) {
+    const trimmed = rawLine.trim();
+    if (trimmed.length === 0) {
+      if (currentLines.length > 0) {
+        blocks.push(currentLines.join(' '));
+        currentLines.length = 0;
+      }
+    } else {
+      currentLines.push(trimmed);
+    }
+  }
+
+  if (currentLines.length > 0) {
+    blocks.push(currentLines.join(' '));
+  }
+
+  return blocks;
 }
 
 /**
@@ -99,20 +94,21 @@ export function mergeIntoBlocks(pageText: string): string[] {
 export function computeCharOverlap(a: string, b: string): number {
   if (a.length === 0 || b.length === 0) return 0;
 
-  const freqA = [...a].reduce((freq, ch) => {
-    freq.set(ch, (freq.get(ch) ?? 0) + 1);
-    return freq;
-  }, new Map<string, number>());
+  const freqA = new Map<string, number>();
+  for (const ch of a) {
+    freqA.set(ch, (freqA.get(ch) ?? 0) + 1);
+  }
 
-  const freqB = [...b].reduce((freq, ch) => {
-    freq.set(ch, (freq.get(ch) ?? 0) + 1);
-    return freq;
-  }, new Map<string, number>());
+  const freqB = new Map<string, number>();
+  for (const ch of b) {
+    freqB.set(ch, (freqB.get(ch) ?? 0) + 1);
+  }
 
-  const overlap = [...freqA].reduce((sum, [ch, countA]) => {
+  let overlap = 0;
+  for (const [ch, countA] of freqA) {
     const countB = freqB.get(ch) ?? 0;
-    return sum + Math.min(countA, countB);
-  }, 0);
+    overlap += Math.min(countA, countB);
+  }
 
   return overlap / Math.max(a.length, b.length);
 }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Refactor the pdf-parser package to improve readability, maintainability, and error handling. Replace `reduce` accumulator patterns with explicit `for` loops and iterative constructs, extract retry logic into dedicated methods, and introduce a Result-type pattern for direct conversion attempts to simplify control flow.

## Changes

- Extract recursive `convertChunkWithRetry` method from inline retry loop in `ChunkedPDFConverter`, eliminating the unreachable `throw` statement
- Replace `calculateChunkRanges` loop with `Array.from` functional construction
- Introduce `withImagePdf` helper in `PDFConverter` to centralize image PDF lifecycle (creation + cleanup)
- Refactor `convertWithFallback` using `tryDirectConversion` with discriminated union return type (`{ success: true; report } | { success: false; error }`) to replace mutable `originalError` variable
- Replace `reduce` with `for` loops across `correction-applier.ts`, `image-extractor.ts`, `vlm-image-extractor.ts`, `vlm-page-processor.ts`, `vlm-text-corrector.ts`, and `ocr-strategy-sampler.ts`
- Simplify `cleanupOrphanedPicFiles` using `matchAll` + `Set` constructor and `filter`/`forEach` pattern
- Refactor `relocateChunkImages` to use index-based loop with batch offset update instead of per-iteration increment
- Replace `while`-loop regex matching with `matchAll` in `jq.ts` utility functions
- Refactor `pdf-parser.ts` initialization to use iterative approach for system checks
- Update `task-progress-tracker.ts` and `text-reference-matcher.ts` with minor iterative improvements

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
