### PR TITLE
feat(demo-web): add GPT-5.4 Mini model with pricing

### DIFF
--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -26,6 +26,11 @@ export const LLM_MODELS: LLMModel[] = [
     provider: 'OpenAI',
   },
   {
+    id: 'openai/gpt-5.4-mini',
+    label: 'GPT-5.4 Mini',
+    provider: 'OpenAI',
+  },
+  {
     id: 'openai/gpt-5-mini',
     label: 'GPT-5 Mini',
     provider: 'OpenAI',

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -53,6 +53,7 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'gpt-5.1': { input: 1.25, output: 10 },
     'gpt-5.2': { input: 1.75, output: 14 },
     'gpt-5.4': { input: 2.5, output: 15 },
+    'gpt-5.4-mini': { input: 0.75, output: 4.5 },
     'gpt-5-mini': { input: 0.25, output: 2 },
     // Google
     'gemini-3-flash-preview': { input: 0.5, output: 3 },


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Add GPT-5.4 Mini as a selectable LLM model in the demo-web application. This expands the available OpenAI model options for users who want a cost-effective alternative to GPT-5.4 with lower per-token pricing.

## Changes

- Add `openai/gpt-5.4-mini` entry to `LLM_MODELS` array in `apps/demo-web/src/features/upload/constants/llm-models.ts`
- Add `gpt-5.4-mini` pricing (input: $0.75, output: $4.50 per 1M tokens) to `MODEL_PRICING` in `apps/demo-web/src/lib/cost/model-pricing.ts`

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
