### PR TITLE
fix(pdf-parser): add image PDF fallback for chunked conversion failure

### DIFF
--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -162,6 +162,79 @@ describe('PDFConverter', () => {
 
         expect(ChunkedPDFConverter).not.toHaveBeenCalled();
       });
+
+      test('falls back to image PDF when chunked conversion fails', async () => {
+        mockConvertChunked.mockRejectedValue(
+          new Error('Chunk task failed: unable to retrieve error details'),
+        );
+
+        const mockImagePdfConverter = {
+          convert: vi.fn().mockResolvedValue('/tmp/image.pdf'),
+          cleanup: vi.fn(),
+        };
+        vi.mocked(ImagePdfConverter).mockImplementation(function () {
+          return mockImagePdfConverter as any;
+        });
+
+        await converter.convert(
+          'file:///test/input.pdf',
+          'report-fallback',
+          vi.fn(),
+          false,
+          { chunkedConversion: true },
+        );
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          '[PDFConverter] Chunked conversion failed, retrying with image-based PDF...',
+          'Chunk task failed: unable to retrieve error details',
+        );
+        expect(ImagePdfConverter).toHaveBeenCalled();
+        expect(mockImagePdfConverter.convert).toHaveBeenCalled();
+      });
+
+      test('re-throws AbortError without falling back to image PDF', async () => {
+        const abortError = new Error('Chunked PDF conversion was aborted');
+        abortError.name = 'AbortError';
+        mockConvertChunked.mockRejectedValue(abortError);
+
+        await expect(
+          converter.convert(
+            'file:///test/input.pdf',
+            'report-abort',
+            vi.fn(),
+            false,
+            { chunkedConversion: true },
+          ),
+        ).rejects.toThrow('Chunked PDF conversion was aborted');
+
+        expect(ImagePdfConverter).not.toHaveBeenCalled();
+      });
+
+      test('falls back with non-Error thrown value', async () => {
+        mockConvertChunked.mockRejectedValue('string error');
+
+        const mockImagePdfConverter = {
+          convert: vi.fn().mockResolvedValue('/tmp/image.pdf'),
+          cleanup: vi.fn(),
+        };
+        vi.mocked(ImagePdfConverter).mockImplementation(function () {
+          return mockImagePdfConverter as any;
+        });
+
+        await converter.convert(
+          'file:///test/input.pdf',
+          'report-non-error',
+          vi.fn(),
+          false,
+          { chunkedConversion: true },
+        );
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          '[PDFConverter] Chunked conversion failed, retrying with image-based PDF...',
+          'string error',
+        );
+        expect(ImagePdfConverter).toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -129,7 +129,7 @@ export class PDFConverter {
     // Validate document type before processing
     await this.validateDocumentType(url, options, abortSignal);
 
-    // Chunked conversion for large local PDFs
+    // Chunked conversion for large local PDFs (with image PDF fallback)
     if (options.chunkedConversion && url.startsWith('file://')) {
       const chunked = new ChunkedPDFConverter(
         this.logger,
@@ -141,14 +141,32 @@ export class PDFConverter {
         },
         this.timeout,
       );
-      return chunked.convertChunked(
-        url,
-        reportId,
-        onComplete,
-        cleanupAfterCallback,
-        options,
-        abortSignal,
-      );
+      try {
+        return await chunked.convertChunked(
+          url,
+          reportId,
+          onComplete,
+          cleanupAfterCallback,
+          options,
+          abortSignal,
+        );
+      } catch (error) {
+        if (error instanceof Error && error.name === 'AbortError') {
+          throw error;
+        }
+        this.logger.warn(
+          '[PDFConverter] Chunked conversion failed, retrying with image-based PDF...',
+          error instanceof Error ? error.message : error,
+        );
+        return this.convertViaImagePdf(
+          url,
+          reportId,
+          onComplete,
+          cleanupAfterCallback,
+          options,
+          abortSignal,
+        );
+      }
     }
 
     // Force image PDF pre-conversion when explicitly requested


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Some archaeological report PDFs contain non-UTF-8 encoded text layers (e.g., EUC-KR/CP949), which cause Docling's preprocess stage to fail with a `'utf-8' codec can't decode byte` error before OCR even runs. The chunked conversion path had no fallback for this scenario, resulting in an opaque `NETWORK_ERROR` and total processing failure.

This PR wraps the chunked conversion in a try/catch so that when it fails, the system automatically retries using image-based PDF conversion (which strips the problematic text layer entirely).

## Changes

- Wrap `ChunkedPDFConverter.convertChunked()` call in `PDFConverter.convert()` with try/catch to catch conversion failures
- On failure, fall back to `convertViaImagePdf()` which pre-renders pages as images, removing the non-UTF-8 text layer
- Propagate `AbortError` without fallback to respect user cancellation

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
