### PR TITLE
test(pdf-parser): mock constants in task-progress-tracker tests to reduce poll interval

### DIFF
--- a/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
+++ b/packages/pdf-parser/src/utils/task-progress-tracker.test.ts
@@ -1,5 +1,7 @@
 import type { LoggerMethods } from '@heripo/logger';
 
+import type * as Constants from '../config/constants';
+
 import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PDF_CONVERTER } from '../config/constants';
@@ -9,6 +11,17 @@ import { trackTaskProgress } from './task-progress-tracker';
 vi.mock('./task-failure-details', () => ({
   getTaskFailureDetails: vi.fn(),
 }));
+
+vi.mock('../config/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof Constants>();
+  return {
+    ...actual,
+    PDF_CONVERTER: {
+      ...actual.PDF_CONVERTER,
+      POLL_INTERVAL_MS: 0,
+    },
+  };
+});
 
 function createMockTask(overrides?: {
   taskId?: string;


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Mock `PDF_CONVERTER.POLL_INTERVAL_MS` to `0` in `task-progress-tracker` tests to eliminate real `setTimeout` delays during polling. This reduces test execution time from ~10s to ~18ms (~560x speedup) without changing any test logic or assertions.

## Changes

- Add `vi.mock('../config/constants', ...)` in `task-progress-tracker.test.ts` to override `POLL_INTERVAL_MS` to `0`
- Import `type * as Constants` for type-safe `importOriginal` usage in the mock factory

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
