### PR TITLE
chore(scripts): use build:packages:force in publish-all

### DIFF
--- a/scripts/publish-all.mjs
+++ b/scripts/publish-all.mjs
@@ -253,7 +253,7 @@ const commitAndTag = (version) => {
 const main = async () => {
   ensureCleanGit();
   bumpVersions();
-  run('pnpm', ['build']);
+  run('pnpm', ['build:packages:force']);
   await packAndPublish();
 
   if (!noGit) {


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/shared` (internal)
- [ ] `@heripo/logger` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Switches the release script (`scripts/publish-all.mjs`) from `pnpm build` to `pnpm build:packages:force` so that publish runs build only the publishable packages and bypass Turbo's cache. This avoids unnecessarily building `demo-web` during release and guarantees fresh artifacts are produced before `npm publish`.

## Changes

- `scripts/publish-all.mjs`: replace `run('pnpm', ['build'])` with `run('pnpm', ['build:packages:force'])` in the `main` flow so publish builds only library packages with `--force`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
