### PR TITLE
feat(document-processor): support injected page range maps in process()

### DIFF
--- a/packages/document-processor/README.ko.md
+++ b/packages/document-processor/README.ko.md
@@ -121,6 +121,29 @@ const { document, usage } = await processor.process(
 );
 ```
 
+### 수동 페이지 범위 매핑
+
+페이지 범위 매핑을 이미 검수했다면 `process()`의 네 번째 인자로 전달해
+PageRangeParser 자동 실행을 건너뛸 수 있습니다. 전달한 매핑은 추가 후처리 없이
+그대로 사용됩니다.
+
+```typescript
+import type { PageRange } from '@heripo/model';
+
+const pageRangeMap: Record<number, PageRange> = {
+  1: { startPageNo: 0, endPageNo: 0 },
+  2: { startPageNo: 1, endPageNo: 1 },
+  3: { startPageNo: 2, endPageNo: 3 },
+};
+
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { pageRangeMap },
+);
+```
+
 ## 처리 파이프라인
 
 DocumentProcessor는 다음 5단계 파이프라인으로 문서를 처리합니다:
@@ -216,15 +239,22 @@ interface DocumentProcessorOptions {
 
 #### 메서드
 
-##### `process(doclingDoc, reportId, artifactDir): Promise<DocumentProcessResult>`
+##### `process(doclingDoc, reportId, artifactDir, processOptions?): Promise<DocumentProcessResult>`
 
 DoclingDocument를 ProcessedDocument로 변환합니다.
+
+```typescript
+interface DocumentProcessorProcessOptions {
+  pageRangeMap?: Record<number, PageRange>;
+}
+```
 
 **파라미터:**
 
 - `doclingDoc` (DoclingDocument): PDF 파서의 출력
 - `reportId` (string): 리포트 ID
 - `artifactDir` (string): `images/`, `pages/`, `result.json` 같은 parser 산출물이 들어 있는 디렉토리
+- `processOptions` (DocumentProcessorProcessOptions, 선택): 문서별 처리 입력값. `pageRangeMap`이 제공되면 자동 페이지 범위 파싱을 건너뜁니다.
 
 **반환값:**
 

--- a/packages/document-processor/README.md
+++ b/packages/document-processor/README.md
@@ -121,6 +121,29 @@ const { document, usage } = await processor.process(
 );
 ```
 
+### Manual Page Range Map
+
+If page range mapping has already been reviewed, pass it as the fourth
+`process()` argument to skip automatic PageRangeParser execution. The provided
+map is used as-is without additional post-processing.
+
+```typescript
+import type { PageRange } from '@heripo/model';
+
+const pageRangeMap: Record<number, PageRange> = {
+  1: { startPageNo: 0, endPageNo: 0 },
+  2: { startPageNo: 1, endPageNo: 1 },
+  3: { startPageNo: 2, endPageNo: 3 },
+};
+
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { pageRangeMap },
+);
+```
+
 ## Processing Pipeline
 
 DocumentProcessor processes documents through a 5-stage pipeline:
@@ -216,15 +239,22 @@ interface DocumentProcessorOptions {
 
 #### Methods
 
-##### `process(doclingDoc, reportId, artifactDir): Promise<DocumentProcessResult>`
+##### `process(doclingDoc, reportId, artifactDir, processOptions?): Promise<DocumentProcessResult>`
 
 Transforms DoclingDocument into ProcessedDocument.
+
+```typescript
+interface DocumentProcessorProcessOptions {
+  pageRangeMap?: Record<number, PageRange>;
+}
+```
 
 **Parameters:**
 
 - `doclingDoc` (DoclingDocument): PDF parser output
 - `reportId` (string): Report ID
 - `artifactDir` (string): Artifact directory containing parser outputs such as `images/`, `pages/`, and `result.json`
+- `processOptions` (DocumentProcessorProcessOptions, optional): Per-document processing inputs. When `pageRangeMap` is provided, automatic page range parsing is skipped.
 
 **Returns:**
 

--- a/packages/document-processor/src/document-processor.test.ts
+++ b/packages/document-processor/src/document-processor.test.ts
@@ -1,5 +1,5 @@
 import type { LoggerMethods } from '@heripo/logger';
-import type { DoclingDocument } from '@heripo/model';
+import type { DoclingDocument, PageRange } from '@heripo/model';
 import type { LanguageModel } from 'ai';
 
 import { BatchProcessor } from '@heripo/shared';
@@ -160,6 +160,122 @@ describe('DocumentProcessor', () => {
   });
 
   describe('process', () => {
+    const createMockDoc = (): DoclingDocument =>
+      ({
+        schema_name: 'DoclingDocument',
+        version: '1.0.0',
+        name: 'test-doc',
+        origin: {
+          mimetype: 'application/pdf',
+          binary_hash: 123,
+          filename: 'test.pdf',
+        },
+        furniture: {
+          name: '_root_',
+          label: 'unspecified',
+          self_ref: '#/furniture',
+          children: [],
+          content_layer: 'furniture',
+        },
+        texts: [
+          {
+            text: 'test',
+            self_ref: '#/texts/0',
+            prov: [
+              {
+                page_no: 1,
+                bbox: { l: 0, t: 0, r: 100, b: 100, coord_origin: 'TOPLEFT' },
+                charspan: [0, 4],
+              },
+            ],
+            label: 'text',
+            orig: 'test',
+            children: [],
+            content_layer: 'body',
+          },
+        ],
+        pictures: [],
+        tables: [],
+        groups: [],
+        body: {
+          name: '_root_',
+          label: 'unspecified',
+          self_ref: '#/body',
+          children: [],
+          content_layer: 'body',
+        },
+        pages: { '1': {} as any },
+      }) as DoclingDocument;
+
+    const createProcessor = (): DocumentProcessor =>
+      new DocumentProcessor({
+        logger: mockLogger,
+        fallbackModel: mockModel,
+        textCleanerBatchSize: 10,
+        captionParserBatchSize: 5,
+        captionValidatorBatchSize: 5,
+      });
+
+    const stubSuccessfulProcessing = (
+      processor: DocumentProcessor,
+      pageRangeParseMock = vi.fn().mockResolvedValue({
+        pageRangeMap: { 1: { startPageNo: 1, endPageNo: 1 } },
+        usage: [],
+      }),
+    ) => {
+      const tocExtractMock = vi
+        .fn()
+        .mockResolvedValue([{ title: 'Chapter 1', level: 1, pageNo: 1 }]);
+      const convertAllMock = vi.fn().mockResolvedValue({
+        images: [],
+        tables: [],
+        footnotes: [],
+      });
+      const chapterConvertMock = vi.fn().mockReturnValue([
+        {
+          id: 'ch-001',
+          originTitle: 'Chapter 1',
+          title: 'Chapter 1',
+          pageNo: 1,
+          level: 1,
+          textBlocks: [],
+          imageIds: [],
+          tableIds: [],
+          footnoteIds: [],
+          children: [],
+        },
+      ]);
+      const originalInit = (processor as any).initializeProcessors.bind(
+        processor,
+      );
+
+      vi.spyOn(processor as any, 'initializeProcessors').mockImplementation(
+        (...args: any[]) => {
+          originalInit(...args);
+
+          (processor as any).pageRangeParser = {
+            parse: pageRangeParseMock,
+          };
+          (processor as any).tocExtractionPipeline = {
+            extract: tocExtractMock,
+          };
+          (processor as any).resourceConverter = {
+            convertAll: convertAllMock,
+          };
+          (processor as any).chapterConverter = {
+            convert: chapterConvertMock,
+          };
+        },
+      );
+
+      return {
+        pageRangeParseMock,
+        tocExtractMock,
+        convertAllMock,
+        chapterConvertMock,
+      };
+    };
+
     test('should throw TocNotFoundError when TOC extraction fails', async () => {
       const processor = new DocumentProcessor({
         logger: mockLogger,
@@ -372,6 +488,81 @@ describe('DocumentProcessor', () => {
       expect(result.document.footnotes).toEqual([]);
       expect(result.document.pageRangeMap).toBeDefined();
       expect(result.usage).toBeDefined();
+    });
+
+    test('should use injected pageRangeMap without parsing page ranges', async () => {
+      const processor = createProcessor();
+      const pageRangeMap: Record<number, PageRange> = {
+        1: { startPageNo: 10, endPageNo: 11 },
+      };
+      const mocks = stubSuccessfulProcessing(
+        processor,
+        vi.fn().mockRejectedValue(new Error('Should not parse page ranges')),
+      );
+      const mockDoc = createMockDoc();
+
+      const result = await processor.process(mockDoc, 'report-001', '/path', {
+        pageRangeMap,
+      });
+
+      expect(mocks.pageRangeParseMock).not.toHaveBeenCalled();
+      expect(result.document.pageRangeMap).toBe(pageRangeMap);
+      expect(mocks.tocExtractMock).toHaveBeenCalledWith(mockDoc, ['test']);
+      expect(mocks.chapterConvertMock).toHaveBeenCalledWith(
+        expect.any(Array),
+        mockDoc.texts,
+        pageRangeMap,
+        [],
+        [],
+        [],
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[DocumentProcessor] Using injected page range map with 1 entries',
+      );
+    });
+
+    test('should still extract TOC when only pageRangeMap is injected', async () => {
+      const processor = createProcessor();
+      const pageRangeMap: Record<number, PageRange> = {
+        1: { startPageNo: 1, endPageNo: 1 },
+      };
+      const mocks = stubSuccessfulProcessing(processor);
+      const mockDoc = createMockDoc();
+
+      await processor.process(mockDoc, 'report-001', '/path', {
+        pageRangeMap,
+      });
+
+      expect(mocks.pageRangeParseMock).not.toHaveBeenCalled();
+      expect(mocks.tocExtractMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('should treat an empty injected pageRangeMap as manual input', async () => {
+      const processor = createProcessor();
+      const pageRangeMap: Record<number, PageRange> = {};
+      const mocks = stubSuccessfulProcessing(
+        processor,
+        vi.fn().mockRejectedValue(new Error('Should not parse page ranges')),
+      );
+      const mockDoc = createMockDoc();
+
+      const result = await processor.process(mockDoc, 'report-001', '/path', {
+        pageRangeMap,
+      });
+
+      expect(mocks.pageRangeParseMock).not.toHaveBeenCalled();
+      expect(result.document.pageRangeMap).toBe(pageRangeMap);
+      expect(mocks.chapterConvertMock).toHaveBeenCalledWith(
+        expect.any(Array),
+        mockDoc.texts,
+        pageRangeMap,
+        [],
+        [],
+        [],
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[DocumentProcessor] Using injected page range map with 0 entries',
+      );
     });
   });
 

--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -115,6 +115,17 @@ export interface DocumentProcessorOptions {
 }
 
 /**
+ * Per-document processing inputs.
+ */
+export interface DocumentProcessorProcessOptions {
+  /**
+   * Precomputed PDF page number to actual document page range mapping.
+   * When provided, automatic PageRangeParser execution is skipped.
+   */
+  pageRangeMap?: Record<number, PageRange>;
+}
+
+/**
  * DocumentProcessor
  *
  * Main class that converts DoclingDocument to ProcessedDocument.
@@ -247,7 +258,7 @@ export class DocumentProcessor {
    * Conversion process:
    * 1. Initialize processors and resolvers
    * 2. Normalize and filter texts
-   * 3. Clean texts and parse page ranges (parallel)
+   * 3. Clean texts and resolve page ranges
    * 4. Extract table of contents
    * 5. Convert images and tables (parallel)
    * 6. Convert chapters and link resources
@@ -257,6 +268,7 @@ export class DocumentProcessor {
    * @param doclingDoc - Original document extracted from Docling SDK
    * @param reportId - Report unique identifier
    * @param artifactDir - Directory containing parser artifacts such as images/, pages/, and result.json
+   * @param processOptions - Per-document processing inputs such as manually verified page range mappings
    * @returns Document processing result with ProcessedDocument and token usage report
    *
    * @throws {TocExtractError} When TOC extraction fails
@@ -267,6 +279,7 @@ export class DocumentProcessor {
     doclingDoc: DoclingDocument,
     reportId: string,
     artifactDir: string,
+    processOptions: DocumentProcessorProcessOptions = {},
   ): Promise<DocumentProcessResult> {
     this.logger.info('[DocumentProcessor] Starting document processing...');
     this.logger.info('[DocumentProcessor] Report ID:', reportId);
@@ -290,10 +303,20 @@ export class DocumentProcessor {
     this.checkAborted();
 
     const startTimePageRange = Date.now();
-    const pageRangeMap = await this.parsePageRanges(doclingDoc);
+    const pageRangeMap =
+      processOptions.pageRangeMap !== undefined
+        ? processOptions.pageRangeMap
+        : await this.parsePageRanges(doclingDoc);
+
+    if (processOptions.pageRangeMap !== undefined) {
+      this.logger.info(
+        `[DocumentProcessor] Using injected page range map with ${Object.keys(pageRangeMap).length} entries`,
+      );
+    }
+
     const pageRangeTime = Date.now() - startTimePageRange;
     this.logger.info(
-      `[DocumentProcessor] Page range parsing took ${pageRangeTime}ms`,
+      `[DocumentProcessor] Page range resolution took ${pageRangeTime}ms`,
     );
     this.emitTokenUsage();
 

--- a/packages/document-processor/src/index.ts
+++ b/packages/document-processor/src/index.ts
@@ -22,7 +22,10 @@ export type {
   VisionLLMComponentOptions,
   ImageContent,
 } from './core';
-export type { DocumentProcessorOptions } from './document-processor';
+export type {
+  DocumentProcessorOptions,
+  DocumentProcessorProcessOptions,
+} from './document-processor';
 export type { TocEntry, TocAreaResult, PageSizeGroup } from './types';
 export {
   CaptionParser,


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Adds a `processOptions` parameter to `DocumentProcessor.process()` so callers can supply a precomputed PDF-page-to-document-page-range mapping. This enables bypassing the automatic `PageRangeParser` stage when a verified mapping is already available (e.g. human-corrected or externally derived), improving accuracy and skipping redundant LLM calls.

## Changes

- Add `DocumentProcessorProcessOptions` interface exposing an optional `pageRangeMap` field in [document-processor.ts](packages/document-processor/src/document-processor.ts)
- Extend `DocumentProcessor.process()` to accept `processOptions` and short-circuit `parsePageRanges()` when `pageRangeMap` is injected
- Log when an injected page range map is used, and rename the timing log to "Page range resolution"
- Re-export `DocumentProcessorProcessOptions` from the package entry point ([index.ts](packages/document-processor/src/index.ts))
- Document the new option in `README.md` and `README.ko.md`
- Add tests covering the injected-mapping path and verifying `PageRangeParser` is skipped

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #