### PR TITLE
feat(document-processor): support manually injected TOC entries in process()

### DIFF
--- a/packages/document-processor/README.ko.md
+++ b/packages/document-processor/README.ko.md
@@ -144,6 +144,50 @@ const { document, usage } = await processor.process(
 );
 ```
 
+### 수동 TOC 항목
+
+목차를 이미 검수했다면 `process()`의 네 번째 인자로 `tocEntries`를 전달해
+자동 TOC 추출을 건너뛸 수 있습니다. 전달한 항목은 추가 추출이나 검증 없이
+그대로 사용됩니다.
+
+```typescript
+import type { TocEntry } from '@heripo/document-processor';
+
+const tocEntries: TocEntry[] = [
+  {
+    title: '제1장 조사 개요',
+    level: 1,
+    pageNo: 1,
+    children: [
+      {
+        title: '1. 조사 경위',
+        level: 2,
+        pageNo: 3,
+      },
+    ],
+  },
+];
+
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { tocEntries },
+);
+```
+
+수동 페이지 범위 매핑과 TOC 항목을 함께 전달하면 두 자동 단계를 모두
+건너뜁니다.
+
+```typescript
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { pageRangeMap, tocEntries },
+);
+```
+
 ## 처리 파이프라인
 
 DocumentProcessor는 다음 5단계 파이프라인으로 문서를 처리합니다:
@@ -246,6 +290,7 @@ DoclingDocument를 ProcessedDocument로 변환합니다.
 ```typescript
 interface DocumentProcessorProcessOptions {
   pageRangeMap?: Record<number, PageRange>;
+  tocEntries?: TocEntry[];
 }
 ```
 
@@ -254,7 +299,7 @@ interface DocumentProcessorProcessOptions {
 - `doclingDoc` (DoclingDocument): PDF 파서의 출력
 - `reportId` (string): 리포트 ID
 - `artifactDir` (string): `images/`, `pages/`, `result.json` 같은 parser 산출물이 들어 있는 디렉토리
-- `processOptions` (DocumentProcessorProcessOptions, 선택): 문서별 처리 입력값. `pageRangeMap`이 제공되면 자동 페이지 범위 파싱을 건너뜁니다.
+- `processOptions` (DocumentProcessorProcessOptions, 선택): 문서별 처리 입력값. `pageRangeMap`이 제공되면 자동 페이지 범위 파싱을 건너뜁니다. `tocEntries`가 제공되면 자동 TOC 추출을 건너뜁니다.
 
 **반환값:**
 

--- a/packages/document-processor/README.md
+++ b/packages/document-processor/README.md
@@ -144,6 +144,50 @@ const { document, usage } = await processor.process(
 );
 ```
 
+### Manual TOC Entries
+
+If the table of contents has already been reviewed, pass `tocEntries` as the
+fourth `process()` argument to skip automatic TOC extraction. The provided
+entries are used as-is without additional extraction or validation.
+
+```typescript
+import type { TocEntry } from '@heripo/document-processor';
+
+const tocEntries: TocEntry[] = [
+  {
+    title: 'Chapter 1. Overview',
+    level: 1,
+    pageNo: 1,
+    children: [
+      {
+        title: '1. Background',
+        level: 2,
+        pageNo: 3,
+      },
+    ],
+  },
+];
+
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { tocEntries },
+);
+```
+
+Manual page range maps and TOC entries can be provided together to skip both
+automatic stages.
+
+```typescript
+const { document, usage } = await processor.process(
+  doclingDocument,
+  'report-001',
+  artifactDir,
+  { pageRangeMap, tocEntries },
+);
+```
+
 ## Processing Pipeline
 
 DocumentProcessor processes documents through a 5-stage pipeline:
@@ -246,6 +290,7 @@ Transforms DoclingDocument into ProcessedDocument.
 ```typescript
 interface DocumentProcessorProcessOptions {
   pageRangeMap?: Record<number, PageRange>;
+  tocEntries?: TocEntry[];
 }
 ```
 
@@ -254,7 +299,7 @@ interface DocumentProcessorProcessOptions {
 - `doclingDoc` (DoclingDocument): PDF parser output
 - `reportId` (string): Report ID
 - `artifactDir` (string): Artifact directory containing parser outputs such as `images/`, `pages/`, and `result.json`
-- `processOptions` (DocumentProcessorProcessOptions, optional): Per-document processing inputs. When `pageRangeMap` is provided, automatic page range parsing is skipped.
+- `processOptions` (DocumentProcessorProcessOptions, optional): Per-document processing inputs. When `pageRangeMap` is provided, automatic page range parsing is skipped. When `tocEntries` is provided, automatic TOC extraction is skipped.
 
 **Returns:**
 

--- a/packages/document-processor/src/document-processor.test.ts
+++ b/packages/document-processor/src/document-processor.test.ts
@@ -2,6 +2,8 @@ import type { LoggerMethods } from '@heripo/logger';
 import type { DoclingDocument, PageRange } from '@heripo/model';
 import type { LanguageModel } from 'ai';
 
+import type { TocEntry } from './types';
+
 import { BatchProcessor } from '@heripo/shared';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -562,6 +564,130 @@ describe('DocumentProcessor', () => {
       );
       expect(mockLogger.info).toHaveBeenCalledWith(
         '[DocumentProcessor] Using injected page range map with 0 entries',
+      );
+    });
+
+    test('should use injected tocEntries without extracting TOC', async () => {
+      const processor = createProcessor();
+      const pageRangeMap: Record<number, PageRange> = {
+        1: { startPageNo: 1, endPageNo: 1 },
+      };
+      const tocEntries: TocEntry[] = [
+        { title: 'Injected Chapter', level: 1, pageNo: 1 },
+      ];
+      const mocks = stubSuccessfulProcessing(
+        processor,
+        vi.fn().mockResolvedValue({
+          pageRangeMap,
+          usage: [],
+        }),
+      );
+      const mockDoc = createMockDoc();
+
+      await processor.process(mockDoc, 'report-001', '/path', {
+        tocEntries,
+      });
+
+      expect(mocks.pageRangeParseMock).toHaveBeenCalledTimes(1);
+      expect(mocks.tocExtractMock).not.toHaveBeenCalled();
+      expect(mocks.chapterConvertMock).toHaveBeenCalledWith(
+        tocEntries,
+        mockDoc.texts,
+        pageRangeMap,
+        [],
+        [],
+        [],
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[DocumentProcessor] Using injected TOC entries with 1 top-level entries',
+      );
+    });
+
+    test('should still parse page ranges when only tocEntries is injected', async () => {
+      const processor = createProcessor();
+      const tocEntries: TocEntry[] = [
+        { title: 'Injected Chapter', level: 1, pageNo: 1 },
+      ];
+      const mocks = stubSuccessfulProcessing(processor);
+      const mockDoc = createMockDoc();
+
+      await processor.process(mockDoc, 'report-001', '/path', {
+        tocEntries,
+      });
+
+      expect(mocks.pageRangeParseMock).toHaveBeenCalledTimes(1);
+      expect(mocks.tocExtractMock).not.toHaveBeenCalled();
+    });
+
+    test('should extract TOC when tocEntries is explicitly undefined', async () => {
+      const processor = createProcessor();
+      const mocks = stubSuccessfulProcessing(processor);
+      const mockDoc = createMockDoc();
+
+      await processor.process(mockDoc, 'report-001', '/path', {
+        tocEntries: undefined,
+      });
+
+      expect(mocks.tocExtractMock).toHaveBeenCalledWith(mockDoc, ['test']);
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('Using injected TOC entries'),
+      );
+    });
+
+    test('should skip both automatic steps when pageRangeMap and tocEntries are injected', async () => {
+      const processor = createProcessor();
+      const pageRangeMap: Record<number, PageRange> = {
+        1: { startPageNo: 10, endPageNo: 11 },
+      };
+      const tocEntries: TocEntry[] = [
+        { title: 'Injected Chapter', level: 1, pageNo: 10 },
+      ];
+      const mocks = stubSuccessfulProcessing(
+        processor,
+        vi.fn().mockRejectedValue(new Error('Should not parse page ranges')),
+      );
+      const mockDoc = createMockDoc();
+
+      const result = await processor.process(mockDoc, 'report-001', '/path', {
+        pageRangeMap,
+        tocEntries,
+      });
+
+      expect(mocks.pageRangeParseMock).not.toHaveBeenCalled();
+      expect(mocks.tocExtractMock).not.toHaveBeenCalled();
+      expect(result.document.pageRangeMap).toBe(pageRangeMap);
+      expect(mocks.chapterConvertMock).toHaveBeenCalledWith(
+        tocEntries,
+        mockDoc.texts,
+        pageRangeMap,
+        [],
+        [],
+        [],
+      );
+    });
+
+    test('should treat empty injected tocEntries as manual input and throw TocNotFoundError', async () => {
+      const processor = createProcessor();
+      const tocEntries: TocEntry[] = [];
+      const mocks = stubSuccessfulProcessing(
+        processor,
+        vi.fn().mockResolvedValue({
+          pageRangeMap: { 1: { startPageNo: 1, endPageNo: 1 } },
+          usage: [],
+        }),
+      );
+      const mockDoc = createMockDoc();
+
+      await expect(
+        processor.process(mockDoc, 'report-001', '/path', {
+          tocEntries,
+        }),
+      ).rejects.toThrow(TocNotFoundError);
+
+      expect(mocks.pageRangeParseMock).toHaveBeenCalledTimes(1);
+      expect(mocks.tocExtractMock).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        '[DocumentProcessor] Using injected TOC entries with 0 top-level entries',
       );
     });
   });

--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -123,6 +123,12 @@ export interface DocumentProcessorProcessOptions {
    * When provided, automatic PageRangeParser execution is skipped.
    */
   pageRangeMap?: Record<number, PageRange>;
+
+  /**
+   * Precomputed table of contents entries.
+   * When provided, automatic TOC extraction pipeline execution is skipped.
+   */
+  tocEntries?: TocEntry[];
 }
 
 /**
@@ -268,7 +274,7 @@ export class DocumentProcessor {
    * @param doclingDoc - Original document extracted from Docling SDK
    * @param reportId - Report unique identifier
    * @param artifactDir - Directory containing parser artifacts such as images/, pages/, and result.json
-   * @param processOptions - Per-document processing inputs such as manually verified page range mappings
+   * @param processOptions - Per-document processing inputs such as manually verified page range mappings and TOC entries
    * @returns Document processing result with ProcessedDocument and token usage report
    *
    * @throws {TocExtractError} When TOC extraction fails
@@ -324,10 +330,17 @@ export class DocumentProcessor {
     this.checkAborted();
 
     const startTimeToc = Date.now();
-    const tocEntries = await this.tocExtractionPipeline!.extract(
-      doclingDoc,
-      filtered,
-    );
+    const tocEntries =
+      processOptions.tocEntries !== undefined
+        ? processOptions.tocEntries
+        : await this.tocExtractionPipeline!.extract(doclingDoc, filtered);
+
+    if (processOptions.tocEntries !== undefined) {
+      this.logger.info(
+        `[DocumentProcessor] Using injected TOC entries with ${tocEntries.length} top-level entries`,
+      );
+    }
+
     const tocTime = Date.now() - startTimeToc;
     this.logger.info(`[DocumentProcessor] TOC extraction took ${tocTime}ms`);
     this.emitTokenUsage();


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Adds a `tocEntries` option to `DocumentProcessor.process()` so callers can supply precomputed, manually verified table-of-contents entries. When provided, the automatic TOC extraction pipeline is skipped, enabling workflows where users correct or override TOC data before downstream processing.

## Changes

- Add optional `tocEntries?: TocEntry[]` field to `DocumentProcessorProcessOptions` in `document-processor.ts`
- Skip `tocExtractionPipeline.extract()` when `processOptions.tocEntries` is provided, and log that injected entries are being used
- Update JSDoc on `process()` to document the new injection behavior
- Add test coverage in `document-processor.test.ts` for the injected-TOC path
- Document the new option in `README.md` and `README.ko.md`

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #