### PR TITLE
feat(document-processor): add maxValidationRetries option for configurable TOC validation retries

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -279,6 +279,7 @@ const processor = new DocumentProcessor({
   captionParserBatchSize: 10,
   captionValidatorBatchSize: 10,
   maxRetries: 3,
+  maxValidationRetries: 3,
   enableFallbackRetry: true, // 실패 시 fallbackModel로 자동 재시도 (기본값: false)
   onTokenUsage: (report) => console.log('토큰 사용량:', report.total),
 });

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ const processor = new DocumentProcessor({
   captionParserBatchSize: 10,
   captionValidatorBatchSize: 10,
   maxRetries: 3,
+  maxValidationRetries: 3,
   enableFallbackRetry: true, // Automatically retry with fallbackModel on failure (default: false)
   onTokenUsage: (report) => console.log('Token usage:', report.total),
 });

--- a/packages/document-processor/README.ko.md
+++ b/packages/document-processor/README.ko.md
@@ -111,6 +111,7 @@ const processor = new DocumentProcessor({
 
   // 재시도 설정
   maxRetries: 3,
+  maxValidationRetries: 3,
   enableFallbackRetry: true, // fallback 모델로 자동 재시도 (기본값: false)
 });
 
@@ -273,6 +274,7 @@ interface DocumentProcessorOptions {
 
   // 재시도 설정
   maxRetries?: number; // LLM API 재시도 횟수 (기본값: 3)
+  maxValidationRetries?: number; // TOC 검증 보정 재시도 횟수 (기본값: 3)
   enableFallbackRetry?: boolean; // Fallback 재시도 활성화 (기본값: false)
 
   // 고급 옵션

--- a/packages/document-processor/README.md
+++ b/packages/document-processor/README.md
@@ -111,6 +111,7 @@ const processor = new DocumentProcessor({
 
   // Retry settings
   maxRetries: 3,
+  maxValidationRetries: 3,
   enableFallbackRetry: true, // Automatic retry with fallback model (default: false)
 });
 
@@ -273,6 +274,7 @@ interface DocumentProcessorOptions {
 
   // Retry settings
   maxRetries?: number; // LLM API retry count (default: 3)
+  maxValidationRetries?: number; // TOC validation correction retry count (default: 3)
   enableFallbackRetry?: boolean; // Enable fallback retry (default: false)
 
   // Advanced options

--- a/packages/document-processor/src/document-processor.test.ts
+++ b/packages/document-processor/src/document-processor.test.ts
@@ -94,6 +94,7 @@ describe('DocumentProcessor', () => {
         captionParserBatchSize: 15,
         captionValidatorBatchSize: 10,
         maxRetries: 5,
+        maxValidationRetries: 2,
       });
 
       expect(processor).toBeDefined();
@@ -217,6 +218,29 @@ describe('DocumentProcessor', () => {
         captionParserBatchSize: 5,
         captionValidatorBatchSize: 5,
       });
+
+    test('uses default maxValidationRetries when initializing TocExtractor', () => {
+      const processor = createProcessor();
+
+      (processor as any).initializeProcessors(createMockDoc(), '/tmp');
+
+      expect((processor as any).tocExtractor.maxValidationRetries).toBe(3);
+    });
+
+    test('passes custom maxValidationRetries to TocExtractor', () => {
+      const processor = new DocumentProcessor({
+        logger: mockLogger,
+        fallbackModel: mockModel,
+        textCleanerBatchSize: 10,
+        captionParserBatchSize: 5,
+        captionValidatorBatchSize: 5,
+        maxValidationRetries: 1,
+      });
+
+      (processor as any).initializeProcessors(createMockDoc(), '/tmp');
+
+      expect((processor as any).tocExtractor.maxValidationRetries).toBe(1);
+    });
 
     const stubSuccessfulProcessing = (
       processor: DocumentProcessor,

--- a/packages/document-processor/src/document-processor.ts
+++ b/packages/document-processor/src/document-processor.ts
@@ -95,6 +95,11 @@ export interface DocumentProcessorOptions {
   maxRetries?: number;
 
   /**
+   * Maximum retry count for TOC validation correction feedback (default: 3)
+   */
+  maxValidationRetries?: number;
+
+  /**
    * Enable fallback retry mechanism - automatically retries with fallback model on failure (default: false)
    * Set to true to enable automatic fallback retry with fallback model on component-specific model errors
    */
@@ -176,6 +181,7 @@ export interface DocumentProcessorProcessOptions {
  *   captionParserBatchSize: 10,    // LLM caption parsing
  *   captionValidatorBatchSize: 10, // LLM caption validation
  *   maxRetries: 3,
+ *   maxValidationRetries: 3,
  * });
  *
  * const result = await processor.process(
@@ -197,6 +203,7 @@ export class DocumentProcessor {
   private readonly captionParserBatchSize: number;
   private readonly captionValidatorBatchSize: number;
   private readonly maxRetries: number;
+  private readonly maxValidationRetries: number;
   private readonly enableFallbackRetry: boolean;
   private readonly abortSignal?: AbortSignal;
   private readonly onTokenUsage?: (report: TokenUsageReport) => void;
@@ -230,6 +237,7 @@ export class DocumentProcessor {
     this.captionParserBatchSize = options.captionParserBatchSize;
     this.captionValidatorBatchSize = options.captionValidatorBatchSize;
     this.maxRetries = options.maxRetries ?? 3;
+    this.maxValidationRetries = options.maxValidationRetries ?? 3;
     this.enableFallbackRetry = options.enableFallbackRetry ?? false;
     this.abortSignal = options.abortSignal;
     this.onTokenUsage = options.onTokenUsage;
@@ -430,6 +438,7 @@ export class DocumentProcessor {
       this.tocExtractorModel,
       {
         maxRetries: this.maxRetries,
+        maxValidationRetries: this.maxValidationRetries,
       },
       this.enableFallbackRetry ? this.fallbackModel : undefined,
       this.abortSignal,

--- a/packages/document-processor/src/extractors/toc-extractor.test.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.test.ts
@@ -713,6 +713,93 @@ describe('TocExtractor', () => {
       );
     });
 
+    test('uses custom maxValidationRetries for correction retry limit', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+        maxValidationRetries: 1,
+      });
+
+      const badEntries = [
+        { title: 'Chapter 1', level: 1, pageNo: 10 },
+        { title: 'Chapter 2', level: 1, pageNo: 5 },
+      ];
+
+      // Initial + 1 retry = 2 LLM calls
+      mockLLMCaller
+        .mockResolvedValueOnce(makeLLMResult(badEntries))
+        .mockResolvedValueOnce(makeLLMResult(badEntries, 'correction-1'));
+
+      const mockValidate = vi.fn().mockReturnValue({
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V001',
+            message: 'Page number decreased from 10 to 5',
+            path: '[1]',
+            entry: { title: 'Chapter 2', level: 1, pageNo: 5 },
+          },
+        ],
+      });
+
+      vi.mocked(TocValidator).mockImplementation(function () {
+        return { validate: mockValidate } as any;
+      });
+
+      await expect(
+        extractorWithValidation.extract('- some markdown'),
+      ).rejects.toThrow(TocValidationError);
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(2);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed (attempt 1/1)'),
+      );
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed after 1 retries'),
+      );
+    });
+
+    test('does not run correction retry when maxValidationRetries is 0', async () => {
+      const extractorWithValidation = new TocExtractor(mockLogger, mockModel, {
+        skipValidation: false,
+        maxValidationRetries: 0,
+      });
+
+      const badEntries = [
+        { title: 'Chapter 1', level: 1, pageNo: 10 },
+        { title: 'Chapter 2', level: 1, pageNo: 5 },
+      ];
+
+      mockLLMCaller.mockResolvedValueOnce(makeLLMResult(badEntries));
+
+      const mockValidate = vi.fn().mockReturnValue({
+        valid: false,
+        errorCount: 1,
+        issues: [
+          {
+            code: 'V001',
+            message: 'Page number decreased from 10 to 5',
+            path: '[1]',
+            entry: { title: 'Chapter 2', level: 1, pageNo: 5 },
+          },
+        ],
+      });
+
+      vi.mocked(TocValidator).mockImplementation(function () {
+        return { validate: mockValidate } as any;
+      });
+
+      await expect(
+        extractorWithValidation.extract('- some markdown'),
+      ).rejects.toThrow(TocValidationError);
+
+      expect(mockLLMCaller).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed after 0 retries'),
+      );
+    });
+
     test('does not retry when skipValidation is true', async () => {
       mockLLMCaller.mockResolvedValueOnce(
         makeLLMResult([{ title: 'Chapter 1', level: 1, pageNo: 1 }]),

--- a/packages/document-processor/src/extractors/toc-extractor.ts
+++ b/packages/document-processor/src/extractors/toc-extractor.ts
@@ -15,8 +15,7 @@ import {
 import { TocParseError, TocValidationError } from './toc-extract-error';
 import { TocValidator } from './toc-validator';
 
-// TODO: Make configurable via TocExtractorOptions when exposing to DocumentProcessorOptions
-const MAX_VALIDATION_RETRIES = 3;
+const DEFAULT_MAX_VALIDATION_RETRIES = 3;
 
 /**
  * Validation error code descriptions for correction prompts
@@ -87,6 +86,11 @@ export interface TocExtractorOptions extends BaseLLMComponentOptions {
    * Whether to skip validation entirely (default: false)
    */
   skipValidation?: boolean;
+
+  /**
+   * Maximum retry count for TOC validation correction feedback (default: 3)
+   */
+  maxValidationRetries?: number;
 }
 
 /**
@@ -96,11 +100,12 @@ export interface TocExtractorOptions extends BaseLLMComponentOptions {
  * Extends TextLLMComponent for standardized LLM call handling.
  *
  * When validation fails, automatically retries with correction feedback
- * up to MAX_VALIDATION_RETRIES times before throwing.
+ * up to maxValidationRetries times before throwing.
  */
 export class TocExtractor extends TextLLMComponent {
   private readonly validationOptions?: TocValidationOptions;
   private readonly skipValidation: boolean;
+  private readonly maxValidationRetries: number;
 
   constructor(
     logger: LoggerMethods,
@@ -118,12 +123,14 @@ export class TocExtractor extends TextLLMComponent {
     );
     this.validationOptions = options?.validation;
     this.skipValidation = options?.skipValidation ?? false;
+    this.maxValidationRetries =
+      options?.maxValidationRetries ?? DEFAULT_MAX_VALIDATION_RETRIES;
   }
 
   /**
    * Extract TOC structure from Markdown
    *
-   * When validation fails, retries with correction feedback up to MAX_VALIDATION_RETRIES times.
+   * When validation fails, retries with correction feedback up to maxValidationRetries times.
    *
    * @param markdown - Markdown representation of TOC area
    * @param validationOverrides - Optional overrides for validation options (merged with constructor options)
@@ -166,12 +173,12 @@ export class TocExtractor extends TextLLMComponent {
         // Retry loop with correction feedback
         for (
           let attempt = 1;
-          attempt <= MAX_VALIDATION_RETRIES && validationError !== null;
+          attempt <= this.maxValidationRetries && validationError !== null;
           attempt++
         ) {
           this.log(
             'warn',
-            `Validation failed (attempt ${attempt}/${MAX_VALIDATION_RETRIES}), retrying with correction feedback`,
+            `Validation failed (attempt ${attempt}/${this.maxValidationRetries}), retrying with correction feedback`,
           );
 
           const correctionPrompt = this.buildCorrectionPrompt(
@@ -199,7 +206,7 @@ export class TocExtractor extends TextLLMComponent {
         if (validationError !== null) {
           this.log(
             'error',
-            `Validation failed after ${MAX_VALIDATION_RETRIES} retries:\n${validationError.getSummary()}`,
+            `Validation failed after ${this.maxValidationRetries} retries:\n${validationError.getSummary()}`,
           );
           throw validationError;
         }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [x] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [x] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Exposes the TOC validation correction retry count as a configurable option on `DocumentProcessor`. Previously this was hard-coded as `MAX_VALIDATION_RETRIES = 3` inside `TocExtractor`, marked with a TODO to make it configurable. Consumers can now tune this value per use case (e.g., set to `0` to disable correction retries entirely).

## Changes

- Add `maxValidationRetries` field to `TocExtractorOptions` in `packages/document-processor/src/extractors/toc-extractor.ts`, defaulting to `DEFAULT_MAX_VALIDATION_RETRIES` (3).
- Replace the hard-coded `MAX_VALIDATION_RETRIES` constant and resolve the associated TODO; retry loop and log messages now reference `this.maxValidationRetries`.
- Add `maxValidationRetries` to `DocumentProcessorOptions` in `packages/document-processor/src/document-processor.ts` and forward it to `TocExtractor` in `initializeProcessors`.
- Add tests in `toc-extractor.test.ts` covering custom retry limits and the `maxValidationRetries: 0` (no retry) case.
- Add tests in `document-processor.test.ts` verifying default and custom propagation to `TocExtractor`.
- Update top-level `README.md` / `README.ko.md` and `packages/document-processor/README.md` / `README.ko.md` to document the new option.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #