### PR TITLE
feat(demo-web): default VLM processor model to google/gemini-3.1-flash-lite-preview

### DIFF
--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -25,7 +25,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   forceImagePdf: false,
   // OCR Strategy
   strategySamplerModel: 'openai/gpt-5.4',
-  vlmProcessorModel: 'openai/gpt-5.1',
+  vlmProcessorModel: 'google/gemini-3.1-flash-lite-preview',
   forcedMethod: undefined,
   // LLM Models
   fallbackModel: 'openai/gpt-5.4',


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Switches the demo-web upload form's default VLM processor model from `openai/gpt-5.1` to `google/gemini-3.1-flash-lite-preview`. This aligns the default with the lighter, faster Gemini flash-lite variant for VLM-based mixed-script correction during PDF processing.

## Changes

- Update `DEFAULT_FORM_VALUES.vlmProcessorModel` in `apps/demo-web/src/features/upload/types/form-values.ts` to `google/gemini-3.1-flash-lite-preview`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #