### PR TITLE
feat(pdf-parser): pin docling runtime packages to specific versions

### DIFF
--- a/packages/pdf-parser/src/environment/python-environment.test.ts
+++ b/packages/pdf-parser/src/environment/python-environment.test.ts
@@ -89,7 +89,12 @@ describe('PythonEnvironment', () => {
       expect(mockSpawnAsync).toHaveBeenNthCalledWith(7, '/test/venv/bin/pip', [
         'install',
         '--upgrade',
-        'docling-serve',
+        'docling-serve==1.16.1',
+        'docling-jobkit==1.17.0',
+        'docling==2.90.0',
+        'docling-core==2.74.0',
+        'docling-ibm-models==3.13.0',
+        'docling-parse==5.9.0',
       ]);
     });
   });

--- a/packages/pdf-parser/src/environment/python-environment.ts
+++ b/packages/pdf-parser/src/environment/python-environment.ts
@@ -10,6 +10,15 @@ import {
   validatePythonVersion,
 } from '../utils/python-version';
 
+const DOCLING_RUNTIME_PACKAGES = [
+  'docling-serve==1.16.1',
+  'docling-jobkit==1.17.0',
+  'docling==2.90.0',
+  'docling-core==2.74.0',
+  'docling-ibm-models==3.13.0',
+  'docling-parse==5.9.0',
+];
+
 export class PythonEnvironment {
   constructor(
     private readonly logger: LoggerMethods,
@@ -142,7 +151,7 @@ export class PythonEnvironment {
     const result = await spawnAsync(pipPath, [
       'install',
       '--upgrade',
-      'docling-serve',
+      ...DOCLING_RUNTIME_PACKAGES,
     ]);
 
     if (result.code !== 0) {


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Pins the Docling Python runtime stack installed by `PythonEnvironment` to specific versions instead of always upgrading `docling-serve` to latest. This ensures reproducible PDF parsing behavior across environments and prevents breakage from upstream Docling releases.

## Changes

- Added `DOCLING_RUNTIME_PACKAGES` constant in `packages/pdf-parser/src/environment/python-environment.ts` listing pinned versions:
  - `docling-serve==1.16.1`
  - `docling-jobkit==1.17.0`
  - `docling==2.90.0`
  - `docling-core==2.74.0`
  - `docling-ibm-models==3.13.0`
  - `docling-parse==5.9.0`
- Replaced the single `docling-serve` argument in the `pip install --upgrade` invocation with the spread of `DOCLING_RUNTIME_PACKAGES`.
- Updated `python-environment.test.ts` to assert the new pinned package list is passed to `pip install`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #