### PR TITLE
feat(pdf-parser): add health check, server recovery, and stabilize docling runtime install

### DIFF
--- a/apps/demo-web/package.json
+++ b/apps/demo-web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start -H 0.0.0.0",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/apps/demo-web/src/app/api/system/status/route.ts
+++ b/apps/demo-web/src/app/api/system/status/route.ts
@@ -13,8 +13,9 @@ export async function GET() {
 
     // Check PDFParser status
     const pdfParserManager = PDFParserManager.getInstance();
-    const pdfParserReady = pdfParserManager.isReady();
-    const pdfParserInitializing = pdfParserManager.isInitializing();
+    const pdfParserStatus = await pdfParserManager.getStatus();
+    const pdfParserReady = pdfParserStatus === 'ready';
+    const pdfParserInitializing = pdfParserStatus === 'initializing';
 
     // Get queue status
     const queueManager = TaskQueueManager.getInstance();
@@ -30,11 +31,7 @@ export async function GET() {
           status: dbExists ? 'connected' : 'disconnected',
         },
         pdfParser: {
-          status: pdfParserReady
-            ? 'ready'
-            : pdfParserInitializing
-              ? 'initializing'
-              : 'not_initialized',
+          status: pdfParserStatus,
         },
         queue: {
           queueLength: queueStatus.queueLength,

--- a/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
+++ b/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
@@ -3,6 +3,8 @@ import type { LoggerMethods } from '@heripo/logger';
 import { Logger } from '@heripo/logger';
 import { PDFParser } from '@heripo/pdf-parser';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import { TaskQueueManager } from './task-queue-manager';
 
@@ -11,6 +13,9 @@ const PDF_PARSER_TIMEOUT = parseInt(
   process.env.PDF_PARSER_TIMEOUT || '10000000',
   10,
 );
+const PDF_PARSER_VENV_PATH =
+  process.env.PDF_PARSER_VENV_PATH ||
+  join(homedir(), '.heripo', 'pdf-parser-venv');
 
 class PDFParserManager {
   private static instance: PDFParserManager | null = null;
@@ -113,12 +118,17 @@ class PDFParserManager {
     });
 
     logger.info('[PDFParserManager] Initializing PDFParser...');
+    logger.info(
+      '[PDFParserManager] Using PDFParser venv:',
+      PDF_PARSER_VENV_PATH,
+    );
 
     try {
       this.parser = new PDFParser({
         logger,
         port: PDF_PARSER_PORT,
         timeout: PDF_PARSER_TIMEOUT,
+        venvPath: PDF_PARSER_VENV_PATH,
         killExistingProcess: false,
         enableImagePdfFallback: true,
       });

--- a/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
+++ b/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
@@ -17,10 +17,18 @@ const PDF_PARSER_VENV_PATH =
   process.env.PDF_PARSER_VENV_PATH ||
   join(homedir(), '.heripo', 'pdf-parser-venv');
 
+type PDFParserStatus =
+  | 'ready'
+  | 'initializing'
+  | 'not_initialized'
+  | 'unhealthy'
+  | 'shutting_down';
+
 class PDFParserManager {
   private static instance: PDFParserManager | null = null;
   private parser: PDFParser | null = null;
   private initPromise: Promise<void> | null = null;
+  private readinessPromise: Promise<void> | null = null;
   private initialized = false;
   private isShuttingDown = false;
 
@@ -67,6 +75,7 @@ class PDFParserManager {
     }
 
     if (this.parser && this.initialized) {
+      await this.ensureCachedParserReady();
       return this.parser;
     }
 
@@ -79,8 +88,47 @@ class PDFParserManager {
     }
 
     this.initPromise = this.initialize();
-    await this.initPromise;
+    try {
+      await this.initPromise;
+    } finally {
+      this.initPromise = null;
+    }
+
+    if (!this.parser || !this.initialized) {
+      throw new Error('PDFParser initialization failed');
+    }
+
     return this.parser!;
+  }
+
+  private async ensureCachedParserReady(): Promise<void> {
+    if (!this.parser || !this.initialized) {
+      return;
+    }
+
+    if (!this.readinessPromise) {
+      const parser = this.parser;
+      this.readinessPromise = parser
+        .ensureReady()
+        .catch(async (error: unknown) => {
+          this.initialized = false;
+          this.parser = null;
+          try {
+            await parser.dispose();
+          } catch (disposeError) {
+            console.error(
+              '[PDFParserManager] Failed to dispose unhealthy parser:',
+              disposeError,
+            );
+          }
+          throw error;
+        })
+        .finally(() => {
+          this.readinessPromise = null;
+        });
+    }
+
+    await this.readinessPromise;
   }
 
   private async initialize(): Promise<void> {
@@ -178,12 +226,20 @@ class PDFParserManager {
     process.on('SIGINT', shutdown);
   }
 
-  isReady(): boolean {
-    return this.initialized && this.parser !== null && !this.isShuttingDown;
-  }
+  async getStatus(): Promise<PDFParserStatus> {
+    if (this.isShuttingDown) {
+      return 'shutting_down';
+    }
 
-  isInitializing(): boolean {
-    return this.initPromise !== null && !this.initialized;
+    if (this.initPromise && !this.initialized) {
+      return 'initializing';
+    }
+
+    if (!this.parser || !this.initialized) {
+      return 'not_initialized';
+    }
+
+    return (await this.parser.isReady()) ? 'ready' : 'unhealthy';
   }
 }
 

--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -808,6 +808,180 @@ describe('PDFParser', () => {
       expect(result).toBe('OK');
     });
 
+    test('parse recovers from ECONNREFUSED via Error.code property', async () => {
+      doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+      const killSpy = vi.mocked((DoclingEnvironment as any).killProcessOnPort);
+      killSpy.mockResolvedValue(undefined);
+
+      // Error object whose message does NOT contain ECONNREFUSED but code does
+      const err = new Error('fetch failed') as Error & { code?: string };
+      err.code = 'ECONNREFUSED';
+      convertMock.mockRejectedValueOnce(err).mockResolvedValueOnce('OK');
+
+      mockDoclingEnvironment();
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const result = await parser.parse(
+        'http://file.pdf',
+        'report-1',
+        vi.fn(),
+        false,
+        { num_threads: 4 },
+      );
+
+      expect(result).toBe('OK');
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFParser] Connection refused, attempting server recovery...',
+      );
+    });
+
+    test('parse recovers from ECONNREFUSED on plain object error via code', async () => {
+      doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+      vi.mocked(
+        (DoclingEnvironment as any).killProcessOnPort,
+      ).mockResolvedValue(undefined);
+
+      convertMock
+        .mockRejectedValueOnce({ code: 'ECONNREFUSED' })
+        .mockResolvedValueOnce('OK');
+
+      mockDoclingEnvironment();
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const result = await parser.parse(
+        'http://file.pdf',
+        'report-1',
+        vi.fn(),
+        false,
+        { num_threads: 4 },
+      );
+
+      expect(result).toBe('OK');
+    });
+
+    test('parse recovers from ECONNREFUSED on plain object error via message', async () => {
+      doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+      vi.mocked(
+        (DoclingEnvironment as any).killProcessOnPort,
+      ).mockResolvedValue(undefined);
+
+      convertMock
+        .mockRejectedValueOnce({ message: 'connect ECONNREFUSED 127.0.0.1' })
+        .mockResolvedValueOnce('OK');
+
+      mockDoclingEnvironment();
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const result = await parser.parse(
+        'http://file.pdf',
+        'report-1',
+        vi.fn(),
+        false,
+        { num_threads: 4 },
+      );
+
+      expect(result).toBe('OK');
+    });
+
+    test('parse recovers from ECONNREFUSED on plain object error via cause chain', async () => {
+      doclingClient.health.mockResolvedValue(undefined);
+      vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+      vi.mocked(
+        (DoclingEnvironment as any).killProcessOnPort,
+      ).mockResolvedValue(undefined);
+
+      convertMock
+        .mockRejectedValueOnce({
+          cause: { code: 'ECONNREFUSED' },
+        })
+        .mockResolvedValueOnce('OK');
+
+      mockDoclingEnvironment();
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const result = await parser.parse(
+        'http://file.pdf',
+        'report-1',
+        vi.fn(),
+        false,
+        { num_threads: 4 },
+      );
+
+      expect(result).toBe('OK');
+    });
+
+    test('isReady returns true when health check succeeds', async () => {
+      doclingClient.health.mockResolvedValue(undefined);
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
+      await parser.init();
+
+      await expect(parser.isReady()).resolves.toBe(true);
+    });
+
+    test('ensureReady throws when parser is not initialized', async () => {
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+
+      await expect(parser.ensureReady()).rejects.toThrow(
+        'PDFParser is not initialized',
+      );
+    });
+
+    test('recoverServer reuses in-flight recovery promise for concurrent calls', async () => {
+      doclingClient.health
+        .mockResolvedValueOnce(undefined) // init
+        .mockRejectedValueOnce(new Error('down')) // ensureReady #1
+        .mockRejectedValueOnce(new Error('down')) // ensureReady #2
+        .mockResolvedValue(undefined); // waitForServerReady during restart
+      vi.mocked(envMocks.setupMock).mockResolvedValue(undefined);
+
+      // Delay startServer so both recoverServer calls overlap
+      let resolveStart: () => void;
+      const startGate = new Promise<void>((resolve) => {
+        resolveStart = resolve;
+      });
+      const startServerMock = vi
+        .fn<() => Promise<void>>()
+        .mockImplementation(() => startGate);
+      mockDoclingEnvironment(startServerMock);
+
+      const logger = makeLogger();
+      const parser = new PDFParser({ logger, port: 5001 });
+      await parser.init();
+
+      const p1 = parser.ensureReady();
+      const p2 = parser.ensureReady();
+
+      // Let the concurrent call hit the "already in progress" branch
+      await Promise.resolve();
+      await Promise.resolve();
+
+      resolveStart!();
+      await Promise.all([p1, p2]);
+
+      expect(startServerMock).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[PDFParser] Server recovery already in progress...',
+      );
+    });
+
     test('parse throws immediately when abortSignal is already aborted', async () => {
       doclingClient.health.mockResolvedValueOnce();
       vi.mocked(envMocks.setupMock).mockResolvedValueOnce();

--- a/packages/pdf-parser/src/core/pdf-parser.test.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.test.ts
@@ -70,6 +70,19 @@ const convertMock = (ConvMod as any).__convertMock as any;
 const convertWithStrategyMock = (ConvMod as any)
   .__convertWithStrategyMock as any;
 
+const mockDoclingEnvironment = (
+  startServerMock = vi.fn().mockResolvedValue(undefined),
+) => {
+  (DoclingEnvironment as any).mockImplementation(function () {
+    return {
+      setup: envMocks.setupMock,
+      startServer: startServerMock,
+    };
+  });
+
+  return startServerMock;
+};
+
 describe('PDFParser', () => {
   test('init with external server (baseUrl) succeeds and waits for health', async () => {
     doclingClient.health.mockResolvedValueOnce();
@@ -567,6 +580,70 @@ describe('PDFParser', () => {
     expect(doclingClient.destroy).toHaveBeenCalledTimes(1);
   });
 
+  test('isReady returns false before init', async () => {
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, port: 5001 });
+
+    await expect(parser.isReady()).resolves.toBe(false);
+  });
+
+  test('isReady checks the live Docling health endpoint', async () => {
+    doclingClient.health
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('down'));
+
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
+    await parser.init();
+
+    await expect(parser.isReady()).resolves.toBe(false);
+  });
+
+  test('ensureReady succeeds when health check passes', async () => {
+    doclingClient.health.mockResolvedValue(undefined);
+
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
+    await parser.init();
+
+    await expect(parser.ensureReady()).resolves.toBeUndefined();
+  });
+
+  test('ensureReady recovers local server when health check fails', async () => {
+    doclingClient.health
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValueOnce(undefined);
+    vi.mocked(envMocks.setupMock).mockResolvedValueOnce();
+    const startServerMock = mockDoclingEnvironment();
+
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, port: 5001 });
+    await parser.init();
+
+    await expect(parser.ensureReady()).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[PDFParser] Health check failed, attempting server recovery...',
+    );
+    expect(startServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ensureReady does not recover external server health failures', async () => {
+    doclingClient.health
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('down'));
+
+    const logger = makeLogger();
+    const parser = new PDFParser({ logger, baseUrl: 'http://example.com' });
+    await parser.init();
+
+    await expect(parser.ensureReady()).rejects.toThrow('down');
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      '[PDFParser] Health check failed, attempting server recovery...',
+    );
+  });
+
   describe('server recovery', () => {
     test('parse recovers from ECONNREFUSED error on local server', async () => {
       doclingClient.health.mockResolvedValue(undefined);
@@ -583,13 +660,7 @@ describe('PDFParser', () => {
         .mockResolvedValueOnce('OK');
 
       // Mock for startServer call during recovery
-      const startServerMock = vi.fn().mockResolvedValue(undefined);
-      (DoclingEnvironment as any).mockImplementation(function () {
-        return {
-          setup: envMocks.setupMock,
-          startServer: startServerMock,
-        };
-      });
+      mockDoclingEnvironment();
 
       const logger = makeLogger();
       const parser = new PDFParser({ logger, port: 5001 });
@@ -647,13 +718,7 @@ describe('PDFParser', () => {
         .mockRejectedValueOnce(econnRefusedError);
 
       // Mock for startServer call during recovery
-      const startServerMock = vi.fn().mockResolvedValue(undefined);
-      (DoclingEnvironment as any).mockImplementation(function () {
-        return {
-          setup: envMocks.setupMock,
-          startServer: startServerMock,
-        };
-      });
+      mockDoclingEnvironment();
 
       const logger = makeLogger();
       const parser = new PDFParser({ logger, port: 5001 });
@@ -723,13 +788,7 @@ describe('PDFParser', () => {
       const fetchError = new Error('fetch failed', { cause: causeError });
       convertMock.mockRejectedValueOnce(fetchError).mockResolvedValueOnce('OK');
 
-      const startServerMock = vi.fn().mockResolvedValue(undefined);
-      (DoclingEnvironment as any).mockImplementation(function () {
-        return {
-          setup: envMocks.setupMock,
-          startServer: startServerMock,
-        };
-      });
+      mockDoclingEnvironment();
 
       const logger = makeLogger();
       const parser = new PDFParser({ logger, port: 5001 });
@@ -905,13 +964,7 @@ describe('PDFParser', () => {
           tokenUsageReport: null,
         });
 
-      const startServerMock = vi.fn().mockResolvedValue(undefined);
-      (DoclingEnvironment as any).mockImplementation(function () {
-        return {
-          setup: envMocks.setupMock,
-          startServer: startServerMock,
-        };
-      });
+      mockDoclingEnvironment();
 
       const logger = makeLogger();
       const parser = new PDFParser({ logger, port: 5001 });
@@ -994,13 +1047,7 @@ describe('PDFParser', () => {
         .mockRejectedValueOnce(econnRefusedError)
         .mockRejectedValueOnce(econnRefusedError);
 
-      const startServerMock = vi.fn().mockResolvedValue(undefined);
-      (DoclingEnvironment as any).mockImplementation(function () {
-        return {
-          setup: envMocks.setupMock,
-          startServer: startServerMock,
-        };
-      });
+      mockDoclingEnvironment();
 
       const logger = makeLogger();
       const parser = new PDFParser({ logger, port: 5001 });

--- a/packages/pdf-parser/src/core/pdf-parser.ts
+++ b/packages/pdf-parser/src/core/pdf-parser.ts
@@ -93,6 +93,7 @@ export class PDFParser {
   private readonly enableImagePdfFallback: boolean;
   private client: DoclingAPIClient | null = null;
   private environment?: DoclingEnvironment;
+  private recoveryPromise: Promise<void> | null = null;
 
   constructor(options: Options) {
     const {
@@ -193,18 +194,46 @@ export class PDFParser {
    */
   private isConnectionRefusedError(error: unknown): boolean {
     if (error instanceof Error) {
-      // Check message and cause chain for ECONNREFUSED
+      const errorWithMetadata = error as Error & {
+        cause?: unknown;
+        code?: string;
+      };
+
       if (error.message.includes('ECONNREFUSED')) {
         return true;
       }
+      if (errorWithMetadata.code === 'ECONNREFUSED') {
+        return true;
+      }
+
+      return this.isConnectionRefusedError(errorWithMetadata.cause);
+    }
+
+    if (typeof error === 'object' && error !== null) {
+      const errorLike = error as {
+        cause?: unknown;
+        code?: unknown;
+        message?: unknown;
+      };
+
+      if (errorLike.code === 'ECONNREFUSED') {
+        return true;
+      }
       if (
-        error.cause instanceof Error &&
-        error.cause.message.includes('ECONNREFUSED')
+        typeof errorLike.message === 'string' &&
+        errorLike.message.includes('ECONNREFUSED')
       ) {
         return true;
       }
+
+      return this.isConnectionRefusedError(errorLike.cause);
     }
+
     return false;
+  }
+
+  private canRecoverLocalServer(): boolean {
+    return !this.baseUrl && this.port !== undefined;
   }
 
   /**
@@ -243,6 +272,54 @@ export class PDFParser {
 
     await this.waitForServerReady();
     this.logger.info('[PDFParser] Server restarted successfully');
+  }
+
+  private async recoverServer(message: string): Promise<void> {
+    this.logger.warn(message);
+
+    if (!this.recoveryPromise) {
+      this.recoveryPromise = this.restartServer().finally(() => {
+        this.recoveryPromise = null;
+      });
+    } else {
+      this.logger.warn('[PDFParser] Server recovery already in progress...');
+    }
+
+    await this.recoveryPromise;
+  }
+
+  public async isReady(): Promise<boolean> {
+    if (!this.client) {
+      return false;
+    }
+
+    try {
+      await this.client.health();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public async ensureReady(): Promise<void> {
+    if (!this.client) {
+      throw new Error(
+        'PDFParser is not initialized. Call init() before checking readiness',
+      );
+    }
+
+    try {
+      await this.client.health();
+    } catch (error) {
+      if (this.canRecoverLocalServer()) {
+        await this.recoverServer(
+          '[PDFParser] Health check failed, attempting server recovery...',
+        );
+        return;
+      }
+
+      throw error;
+    }
   }
 
   private async waitForServerReady(): Promise<void> {
@@ -359,7 +436,6 @@ export class PDFParser {
     fn: () => Promise<T>,
     abortSignal?: AbortSignal,
   ): Promise<T> {
-    const canRecover = !this.baseUrl && this.port !== undefined;
     const maxAttempts = PDF_PARSER.MAX_SERVER_RECOVERY_ATTEMPTS;
 
     const tryExecute = async (attempt: number): Promise<T> => {
@@ -368,14 +444,13 @@ export class PDFParser {
       } catch (error) {
         if (abortSignal?.aborted) throw error;
         if (
-          canRecover &&
+          this.canRecoverLocalServer() &&
           this.isConnectionRefusedError(error) &&
           attempt < maxAttempts
         ) {
-          this.logger.warn(
+          await this.recoverServer(
             '[PDFParser] Connection refused, attempting server recovery...',
           );
-          await this.restartServer();
           return tryExecute(attempt + 1);
         }
         throw error;

--- a/packages/pdf-parser/src/environment/python-environment.test.ts
+++ b/packages/pdf-parser/src/environment/python-environment.test.ts
@@ -50,12 +50,14 @@ describe('PythonEnvironment', () => {
         .mockResolvedValueOnce(createSpawnResult({})) // upgradePip
         .mockResolvedValueOnce(createSpawnResult({})) // installSetuptools
         .mockResolvedValueOnce(createSpawnResult({})) // installPyArrow
+        .mockResolvedValueOnce(createSpawnResult({})) // installDoclingRuntimePackages
+        .mockResolvedValueOnce(createSpawnResult({})) // installDoclingServeRuntimePackages
         .mockResolvedValueOnce(createSpawnResult({})); // installDoclingServe
 
       const env = new PythonEnvironment(logger, '/test/venv');
       await env.setup();
 
-      expect(mockSpawnAsync).toHaveBeenCalledTimes(7);
+      expect(mockSpawnAsync).toHaveBeenCalledTimes(9);
       expect(mockSpawnAsync).toHaveBeenNthCalledWith(1, 'python3', [
         '--version',
       ]);
@@ -89,12 +91,37 @@ describe('PythonEnvironment', () => {
       expect(mockSpawnAsync).toHaveBeenNthCalledWith(7, '/test/venv/bin/pip', [
         'install',
         '--upgrade',
-        'docling-serve==1.16.1',
         'docling-jobkit==1.17.0',
         'docling==2.90.0',
         'docling-core==2.74.0',
         'docling-ibm-models==3.13.0',
         'docling-parse==5.9.0',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(8, '/test/venv/bin/pip', [
+        'install',
+        '--upgrade',
+        'fastapi[standard]<0.130.0',
+        'httpx~=0.28',
+        'pydantic~=2.10',
+        'pydantic-settings~=2.4',
+        'python-multipart<0.1.0,>=0.0.14',
+        'typer~=0.12',
+        'uvicorn[standard]<1.0.0,>=0.29.0',
+        'websockets<17.0,>=14.0',
+        'scalar-fastapi>=1.0.3',
+        'docling-mcp>=1.0.0',
+        'opentelemetry-api==1.36.0',
+        'opentelemetry-sdk==1.36.0',
+        'opentelemetry-exporter-otlp==1.36.0',
+        'opentelemetry-instrumentation-fastapi==0.57b0',
+        'opentelemetry-exporter-prometheus==0.57b0',
+        'prometheus-client>=0.21.0',
+      ]);
+      expect(mockSpawnAsync).toHaveBeenNthCalledWith(9, '/test/venv/bin/pip', [
+        'install',
+        '--upgrade',
+        '--no-deps',
+        'docling-serve==1.16.1',
       ]);
     });
   });
@@ -105,6 +132,8 @@ describe('PythonEnvironment', () => {
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.9.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
@@ -124,6 +153,8 @@ describe('PythonEnvironment', () => {
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.12.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
@@ -213,6 +244,8 @@ describe('PythonEnvironment', () => {
         .mockResolvedValueOnce(createSpawnResult({ stderr: 'Python 3.11.0' }))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
@@ -324,12 +357,14 @@ describe('PythonEnvironment', () => {
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
         .mockResolvedValueOnce(createSpawnResult({}));
 
       const env = new PythonEnvironment(logger, '/test/venv');
       await env.setup();
 
-      expect(mockSpawnAsync).toHaveBeenCalledTimes(7);
+      expect(mockSpawnAsync).toHaveBeenCalledTimes(9);
     });
   });
 
@@ -441,8 +476,8 @@ describe('PythonEnvironment', () => {
     });
   });
 
-  describe('installDoclingServe', () => {
-    test('should handle docling-serve installation failure', async () => {
+  describe('installDoclingRuntimePackages', () => {
+    test('should handle docling runtime package installation failure', async () => {
       mockSpawnAsync
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
         .mockResolvedValueOnce(createSpawnResult({}))
@@ -457,15 +492,15 @@ describe('PythonEnvironment', () => {
       const env = new PythonEnvironment(logger, '/test/venv');
 
       await expect(env.setup()).rejects.toThrow(
-        'Failed to install docling-serve. Exit code: 1',
+        'Failed to install docling runtime packages. Exit code: 1',
       );
       expect(logger.error).toHaveBeenCalledWith(
-        '[DoclingEnvironment] Failed to install docling-serve:',
+        '[DoclingEnvironment] Failed to install docling runtime packages:',
         'Docling error',
       );
     });
 
-    test('should handle docling-serve installation process error', async () => {
+    test('should handle docling runtime package installation process error', async () => {
       mockSpawnAsync
         .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
         .mockResolvedValueOnce(createSpawnResult({}))
@@ -478,6 +513,92 @@ describe('PythonEnvironment', () => {
       const env = new PythonEnvironment(logger, '/test/venv');
 
       await expect(env.setup()).rejects.toThrow('Docling error');
+    });
+  });
+
+  describe('installDoclingServeRuntimePackages', () => {
+    test('should handle docling-serve runtime package installation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'Docling serve deps error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to install docling-serve runtime packages. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to install docling-serve runtime packages:',
+        'Docling serve deps error',
+      );
+    });
+
+    test('should handle docling-serve runtime package installation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('Docling serve deps error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Docling serve deps error');
+    });
+  });
+
+  describe('installDoclingServe', () => {
+    test('should handle docling-serve installation failure', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(
+          createSpawnResult({ stderr: 'Docling serve error', code: 1 }),
+        );
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow(
+        'Failed to install docling-serve. Exit code: 1',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        '[DoclingEnvironment] Failed to install docling-serve:',
+        'Docling serve error',
+      );
+    });
+
+    test('should handle docling-serve installation process error', async () => {
+      mockSpawnAsync
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({ stdout: 'Python 3.11.0' }))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockResolvedValueOnce(createSpawnResult({}))
+        .mockRejectedValueOnce(new Error('Docling serve error'));
+
+      const env = new PythonEnvironment(logger, '/test/venv');
+
+      await expect(env.setup()).rejects.toThrow('Docling serve error');
     });
   });
 });

--- a/packages/pdf-parser/src/environment/python-environment.test.ts
+++ b/packages/pdf-parser/src/environment/python-environment.test.ts
@@ -91,9 +91,9 @@ describe('PythonEnvironment', () => {
       expect(mockSpawnAsync).toHaveBeenNthCalledWith(7, '/test/venv/bin/pip', [
         'install',
         '--upgrade',
-        'docling-jobkit==1.17.0',
-        'docling==2.90.0',
-        'docling-core==2.74.0',
+        'docling-jobkit==1.16.0',
+        'docling==2.88.0',
+        'docling-core==2.73.0',
         'docling-ibm-models==3.13.0',
         'docling-parse==5.9.0',
       ]);

--- a/packages/pdf-parser/src/environment/python-environment.ts
+++ b/packages/pdf-parser/src/environment/python-environment.ts
@@ -10,13 +10,36 @@ import {
   validatePythonVersion,
 } from '../utils/python-version';
 
+const DOCLING_SERVE_PACKAGE = 'docling-serve==1.16.1';
+
+// docling-serve depends on docling-jobkit[kfp,ray,rq,vlm], which can push pip
+// into resolution-too-deep failures. Install the known runtime set explicitly,
+// then install docling-serve itself with --no-deps.
 const DOCLING_RUNTIME_PACKAGES = [
-  'docling-serve==1.16.1',
   'docling-jobkit==1.17.0',
   'docling==2.90.0',
   'docling-core==2.74.0',
   'docling-ibm-models==3.13.0',
   'docling-parse==5.9.0',
+];
+
+const DOCLING_SERVE_RUNTIME_PACKAGES = [
+  'fastapi[standard]<0.130.0',
+  'httpx~=0.28',
+  'pydantic~=2.10',
+  'pydantic-settings~=2.4',
+  'python-multipart<0.1.0,>=0.0.14',
+  'typer~=0.12',
+  'uvicorn[standard]<1.0.0,>=0.29.0',
+  'websockets<17.0,>=14.0',
+  'scalar-fastapi>=1.0.3',
+  'docling-mcp>=1.0.0',
+  'opentelemetry-api==1.36.0',
+  'opentelemetry-sdk==1.36.0',
+  'opentelemetry-exporter-otlp==1.36.0',
+  'opentelemetry-instrumentation-fastapi==0.57b0',
+  'opentelemetry-exporter-prometheus==0.57b0',
+  'prometheus-client>=0.21.0',
 ];
 
 export class PythonEnvironment {
@@ -31,6 +54,8 @@ export class PythonEnvironment {
     await this.upgradePip();
     await this.installSetuptools();
     await this.installPyArrow();
+    await this.installDoclingRuntimePackages();
+    await this.installDoclingServeRuntimePackages();
     await this.installDoclingServe();
   }
 
@@ -146,7 +171,7 @@ export class PythonEnvironment {
     }
   }
 
-  private async installDoclingServe(): Promise<void> {
+  private async installDoclingRuntimePackages(): Promise<void> {
     const pipPath = join(this.venvPath, 'bin', 'pip');
     const result = await spawnAsync(pipPath, [
       'install',
@@ -156,11 +181,50 @@ export class PythonEnvironment {
 
     if (result.code !== 0) {
       this.logger.error(
+        '[DoclingEnvironment] Failed to install docling runtime packages:',
+        result.stderr,
+      );
+      throw new Error(
+        `Failed to install docling runtime packages. Exit code: ${result.code}`,
+      );
+    }
+  }
+
+  private async installDoclingServe(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, [
+      'install',
+      '--upgrade',
+      '--no-deps',
+      DOCLING_SERVE_PACKAGE,
+    ]);
+
+    if (result.code !== 0) {
+      this.logger.error(
         '[DoclingEnvironment] Failed to install docling-serve:',
         result.stderr,
       );
       throw new Error(
         `Failed to install docling-serve. Exit code: ${result.code}`,
+      );
+    }
+  }
+
+  private async installDoclingServeRuntimePackages(): Promise<void> {
+    const pipPath = join(this.venvPath, 'bin', 'pip');
+    const result = await spawnAsync(pipPath, [
+      'install',
+      '--upgrade',
+      ...DOCLING_SERVE_RUNTIME_PACKAGES,
+    ]);
+
+    if (result.code !== 0) {
+      this.logger.error(
+        '[DoclingEnvironment] Failed to install docling-serve runtime packages:',
+        result.stderr,
+      );
+      throw new Error(
+        `Failed to install docling-serve runtime packages. Exit code: ${result.code}`,
       );
     }
   }

--- a/packages/pdf-parser/src/environment/python-environment.ts
+++ b/packages/pdf-parser/src/environment/python-environment.ts
@@ -16,9 +16,9 @@ const DOCLING_SERVE_PACKAGE = 'docling-serve==1.16.1';
 // into resolution-too-deep failures. Install the known runtime set explicitly,
 // then install docling-serve itself with --no-deps.
 const DOCLING_RUNTIME_PACKAGES = [
-  'docling-jobkit==1.17.0',
-  'docling==2.90.0',
-  'docling-core==2.74.0',
+  'docling-jobkit==1.16.0',
+  'docling==2.88.0',
+  'docling-core==2.73.0',
   'docling-ibm-models==3.13.0',
   'docling-parse==5.9.0',
 ];


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Improves reliability of the local Docling-based PDF parser by adding a health check and automatic server recovery path, so transient parser-server failures can self-heal instead of surfacing to callers. Also stabilizes the Python runtime installation by pinning and splitting `docling*` package installs, which were previously failing due to dependency resolution conflicts during setup.

## Changes

- `packages/pdf-parser/src/core/pdf-parser.ts`: Add `ensureReady` and `isReady` methods that probe parser health via API and, for local parsers, attempt server restart on failure. Refactor server restart flow with explicit error handling.
- `packages/pdf-parser/src/core/pdf-parser.test.ts`: Add coverage for readiness checks, recovery paths, and failure edge cases.
- `packages/pdf-parser/src/environment/python-environment.ts`: Pin `docling-jobkit`, `docling`, and `docling-core` to specific older versions for compatibility. Split `docling-runtime` and `docling-serve-runtime` installs into separate steps with per-step error handling to avoid pip dependency resolution conflicts.
- `packages/pdf-parser/src/environment/python-environment.test.ts`: Update assertions for the new version pins and split install steps.
- `apps/demo-web/src/lib/queue/pdf-parser-manager.ts`: Track readiness state, integrate `getStatus` for status reporting, and log the virtual environment path for easier debugging.
- `apps/demo-web/src/app/api/system/status/route.ts`: Surface parser readiness/status via the system status endpoint.
- `apps/demo-web/package.json`: Simplify build script by removing redundant `--webpack` flag.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #