### PR TITLE
refactor(pdf-parser): generalize document type validation messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "typescript-eslint": "^8.58.2",
     "vite": ">=7.3.2 <8.0.0"
   },
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=24"
   },
@@ -88,7 +88,8 @@
       "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
       "lodash-es@<=4.17.23": ">=4.18.0",
       "lodash@<=4.17.23": ">=4.18.0",
-      "vite": ">=7.3.2 <8.0.0"
+      "vite": ">=7.3.2 <8.0.0",
+      "postcss@<8.5.10": ">=8.5.10"
     },
     "ignoredBuiltDependencies": [
       "esbuild",

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -92,7 +92,7 @@ export class PDFConverter {
   ) {}
 
   /**
-   * Validate that the PDF is a Korean archaeological investigation report.
+   * Validate that the PDF is an archaeological investigation report.
    * Skipped when no documentValidationModel is configured or for non-local URLs.
    * Only runs once per converter instance (flag prevents duplicate checks on recursive calls).
    */

--- a/packages/pdf-parser/src/errors/invalid-document-type-error.test.ts
+++ b/packages/pdf-parser/src/errors/invalid-document-type-error.test.ts
@@ -16,7 +16,8 @@ describe('InvalidDocumentTypeError', () => {
   test('should include reason in message', () => {
     const error = new InvalidDocumentTypeError('not an archaeological report');
     expect(error.message).toBe(
-      'The uploaded PDF does not appear to be a Korean archaeological investigation report. Reason: not an archaeological report',
+      'The uploaded PDF does not appear to be an archaeological investigation report. Reason: not an' +
+        ' archaeological report',
     );
   });
 

--- a/packages/pdf-parser/src/errors/invalid-document-type-error.ts
+++ b/packages/pdf-parser/src/errors/invalid-document-type-error.ts
@@ -1,6 +1,6 @@
 /**
  * Error thrown when the uploaded PDF does not appear to be
- * a Korean archaeological investigation report.
+ * an archaeological investigation report.
  */
 export class InvalidDocumentTypeError extends Error {
   public readonly name = 'InvalidDocumentTypeError';
@@ -8,7 +8,7 @@ export class InvalidDocumentTypeError extends Error {
 
   constructor(public readonly reason: string) {
     super(
-      `The uploaded PDF does not appear to be a Korean archaeological investigation report. Reason: ${reason}`,
+      `The uploaded PDF does not appear to be an archaeological investigation report. Reason: ${reason}`,
     );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,7 @@ overrides:
   lodash-es@<=4.17.23: '>=4.18.0'
   lodash@<=4.17.23: '>=4.18.0'
   vite: '>=7.3.2 <8.0.0'
+  postcss@<8.5.10: '>=8.5.10'
 
 importers:
 
@@ -2397,7 +2398,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: '>=8.5.10'
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -3116,7 +3117,7 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -3132,16 +3133,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -3470,7 +3463,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -6037,7 +6030,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.19
       caniuse-lite: 1.0.30001788
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
@@ -6148,19 +6141,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.10:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -6624,7 +6605,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rollup: 4.59.0
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

Removes the "Korean" qualifier from `InvalidDocumentTypeError` and the related JSDoc in `PDFConverter`, so document-type validation messaging applies to archaeological investigation reports in general rather than being scoped to Korean documents. Also bumps the repo to pnpm 10.33.2 and adds a `postcss@<8.5.10` override (with corresponding lockfile cleanup) to consolidate transitive postcss versions.

## Changes

- `packages/pdf-parser/src/errors/invalid-document-type-error.ts`: rewords the error message and class JSDoc to drop "Korean", using "an archaeological investigation report" instead.
- `packages/pdf-parser/src/errors/invalid-document-type-error.test.ts`: updates the expected error message in the corresponding test case.
- `packages/pdf-parser/src/core/pdf-converter.ts`: updates the JSDoc on the document-type validation step to match the generalized wording.
- `package.json`: bumps `packageManager` from `pnpm@10.33.0` to `pnpm@10.33.2` and adds a `postcss@<8.5.10: '>=8.5.10'` entry to `pnpm.overrides`.
- `pnpm-lock.yaml`: collapses transitive `postcss` resolutions (`8.4.31`, `8.5.9`) onto `8.5.10` and updates affected peer-dependency ranges.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #