### PR TITLE
feat(demo-web): add sponsor links to footer

### DIFF
--- a/apps/demo-web/src/components/layout/footer.tsx
+++ b/apps/demo-web/src/components/layout/footer.tsx
@@ -1,6 +1,22 @@
+import { ExternalLink, Heart } from 'lucide-react';
 import Link from 'next/link';
 
 import { publicModeConfig } from '~/lib/config/public-mode';
+
+import { Button } from '~/components/ui/button';
+
+const sponsorLinks = [
+  {
+    href: 'https://opencollective.com/heripo-project',
+    label: 'Open Collective',
+    ariaLabel: 'Sponsor heripo lab on Open Collective',
+  },
+  {
+    href: 'https://fairy.hada.io/@heripo',
+    label: 'fairy.hada.io/@heripo',
+    ariaLabel: 'Sponsor heripo lab through fairy.hada.io',
+  },
+] as const;
 
 const copyrightYear = (() => {
   const startYear = 2026; // The year the project started
@@ -15,54 +31,84 @@ const copyrightYear = (() => {
 
 export function Footer() {
   return (
-    <footer className="border-t py-6 md:py-0">
-      <div className="container mx-auto flex max-w-screen-xl flex-col items-center justify-between gap-4 px-4 md:h-16 md:flex-row xl:px-0">
-        <p className="text-muted-foreground text-sm">
-          © {copyrightYear} heripo lab. All rights reserved.
-        </p>
-        <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 text-sm">
-          <span>Apache-2.0</span>
-          <span>|</span>
-          <a
-            href="https://github.com/heripo-lab/heripo-engine"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-foreground underline underline-offset-4"
-          >
-            GitHub
-          </a>
-          {process.env.NEXT_PUBLIC_APP_VERSION && (
-            <>
-              <span>|</span>
-              <a
-                href="https://github.com/heripo-lab/heripo-engine/releases"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-foreground underline underline-offset-4"
-              >
-                v{process.env.NEXT_PUBLIC_APP_VERSION} Releases
-              </a>
-            </>
-          )}
-          {publicModeConfig.isOfficialDemo && (
-            <>
-              <span>|</span>
-              <Link
-                href="/legal/terms"
-                className="hover:text-foreground underline underline-offset-4"
-              >
-                Terms
-              </Link>
-              <span>|</span>
-              <Link
-                href="/legal/privacy"
-                className="hover:text-foreground underline underline-offset-4"
-              >
-                Privacy
-              </Link>
-            </>
-          )}
-        </p>
+    <footer className="border-t">
+      <div className="container mx-auto flex max-w-screen-xl flex-col gap-4 px-4 py-5 xl:px-0">
+        <section
+          aria-label="Sponsorship"
+          className="flex flex-col items-center justify-between gap-3 md:flex-row"
+        >
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Heart
+              className="h-4 w-4 fill-rose-500 text-rose-500"
+              aria-hidden="true"
+            />
+            <span>Sponsor heripo lab</span>
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            {sponsorLinks.map((sponsor) => (
+              <Button key={sponsor.href} variant="outline" size="sm" asChild>
+                <a
+                  href={sponsor.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={sponsor.ariaLabel}
+                >
+                  {sponsor.label}
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </a>
+              </Button>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-border/60 flex flex-col items-center justify-between gap-3 border-t pt-4 md:flex-row">
+          <p className="text-muted-foreground text-sm">
+            © {copyrightYear} heripo lab. All rights reserved.
+          </p>
+          <p className="text-muted-foreground flex flex-wrap items-center justify-center gap-x-1 text-sm md:justify-end">
+            <span>Apache-2.0</span>
+            <span>|</span>
+            <a
+              href="https://github.com/heripo-lab/heripo-engine"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-foreground underline underline-offset-4"
+            >
+              GitHub
+            </a>
+            {process.env.NEXT_PUBLIC_APP_VERSION && (
+              <>
+                <span>|</span>
+                <a
+                  href="https://github.com/heripo-lab/heripo-engine/releases"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-foreground underline underline-offset-4"
+                >
+                  v{process.env.NEXT_PUBLIC_APP_VERSION} Releases
+                </a>
+              </>
+            )}
+            {publicModeConfig.isOfficialDemo && (
+              <>
+                <span>|</span>
+                <Link
+                  href="/legal/terms"
+                  className="hover:text-foreground underline underline-offset-4"
+                >
+                  Terms
+                </Link>
+                <span>|</span>
+                <Link
+                  href="/legal/privacy"
+                  className="hover:text-foreground underline underline-offset-4"
+                >
+                  Privacy
+                </Link>
+              </>
+            )}
+          </p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Add visible sponsorship entry points to the demo web footer so users can support heripo lab from the public interface. The footer layout is updated to make room for sponsor actions while preserving the existing license, GitHub, release, and legal links.

## Changes

- Added `sponsorLinks` in `apps/demo-web/src/components/layout/footer.tsx` for Open Collective and fairy.hada.io sponsorship targets.
- Added a responsive `Sponsorship` section to `Footer` with `Heart`, `ExternalLink`, and shadcn `Button` UI.
- Reworked footer spacing and borders so sponsorship controls and existing metadata links remain readable across viewport sizes.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
