### PR TITLE
feat(engine-demo): use Gemini Flash Lite stable model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Lint, Typecheck, Build, Test
+    name: Format, Lint, Typecheck, Build, Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -31,6 +31,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
+      - name: Format check
+        run: pnpm format:check
 
       - name: Lint
         run: pnpm lint

--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -65,8 +65,8 @@ export const LLM_MODELS: LLMModel[] = [
     provider: 'Google',
   },
   {
-    id: 'google/gemini-3.1-flash-lite-preview',
-    label: 'Gemini 3.1 Flash Lite Preview',
+    id: 'google/gemini-3.1-flash-lite',
+    label: 'Gemini 3.1 Flash Lite',
     provider: 'Google',
   },
 

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -25,7 +25,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   forceImagePdf: false,
   // Korean report detection
   strategySamplerModel: 'openai/gpt-5.4',
-  vlmProcessorModel: 'google/gemini-3.1-flash-lite-preview',
+  vlmProcessorModel: 'google/gemini-3.1-flash-lite',
   forcedMethod: undefined,
   // LLM Models
   fallbackModel: 'openai/gpt-5.4',

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -58,6 +58,7 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     // Google
     'gemini-3-flash-preview': { input: 0.5, output: 3 },
     'gemini-3.1-pro-preview': { input: 2, output: 12 },
+    'gemini-3.1-flash-lite': { input: 0.25, output: 1.5 },
     'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
     // Claude
     'anthropic/claude-opus-4-6': { input: 5, output: 25 },
@@ -70,6 +71,7 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'openai/gpt-5-mini': { input: 0.25, output: 2 },
     'google/gemini-3.1-pro-preview': { input: 2, output: 12 },
     'google/gemini-3-flash-preview': { input: 0.5, output: 3 },
+    'google/gemini-3.1-flash-lite': { input: 0.25, output: 1.5 },
     'google/gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
   };
 


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

This PR migrates the demo upload workflow from the deprecated Gemini 3.1 Flash Lite Preview model to the stable Gemini 3.1 Flash Lite release. The preview model is removed only from the selectable model list because it is still referenced by existing cost calculation data. It also adds a CI format check so formatting is validated alongside lint, typecheck, build, and test.

## Changes

- Updated `DEFAULT_FORM_VALUES.vlmProcessorModel` to use `google/gemini-3.1-flash-lite`.
- Replaced the deprecated `Gemini 3.1 Flash Lite Preview` dropdown option with `Gemini 3.1 Flash Lite` in `LLM_MODELS`.
- Added pricing entries for `gemini-3.1-flash-lite` and `google/gemini-3.1-flash-lite` in `MODEL_PRICING`.
- Kept `gemini-3.1-flash-lite-preview` pricing entries for historical cost calculation references.
- Added `pnpm format:check` to the GitHub Actions CI workflow.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #
