### PR TITLE
fix(pdf-parser): restore OCR language detection

### DIFF
--- a/apps/demo-web/src/features/upload/components/processing-options-card.tsx
+++ b/apps/demo-web/src/features/upload/components/processing-options-card.tsx
@@ -234,10 +234,23 @@ export function ProcessingOptionsCard({
           )}
         </CardTitle>
         <CardDescription>
-          Configure mandatory correction, OCR, and processing settings
+          Configure language detection, correction, OCR, and processing settings
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <form.Field name="languageDetectionModel">
+          {(field: OptionalStringFieldApi) => (
+            <VisionModelSelect
+              label="Language Detection Model"
+              description="Detects document languages for Docling OCR hints when the PDF text layer is insufficient"
+              value={field.state.value}
+              onChange={field.handleChange}
+              disabled={disabled}
+              optional
+            />
+          )}
+        </form.Field>
+
         <form.Field name="correction.models.textCorrection">
           {(field: StringFieldApi) => (
             <VisionModelSelect

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -21,6 +21,8 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   threadCount: 4,
   // Document type validation
   documentValidationModel: 'openai/gpt-5.4',
+  // PDF language detection for OCR language hints
+  languageDetectionModel: 'openai/gpt-5.4',
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // Mandatory post-Docling correction.

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -408,6 +408,11 @@ export async function runTaskWorker(
       chunkedConversion: true,
       num_threads: options.threadCount,
       forceImagePdf: options.forceImagePdf,
+      ...(options.languageDetectionModel
+        ? {
+            languageDetectionModel: createModel(options.languageDetectionModel),
+          }
+        : {}),
       ...(isPublicMode && !task.isOtpBypass && options.documentValidationModel
         ? {
             documentValidationModel: createModel(

--- a/apps/demo-web/src/lib/validations/schemas/task.ts
+++ b/apps/demo-web/src/lib/validations/schemas/task.ts
@@ -76,6 +76,9 @@ export const processingOptionsSchema = z.object({
   // Document type validation
   documentValidationModel: llmModelSchema.optional(),
 
+  // PDF language detection for OCR language hints
+  languageDetectionModel: llmModelSchema.optional(),
+
   // Force image PDF pre-conversion
   forceImagePdf: z.boolean().default(false),
 

--- a/packages/pdf-parser/src/config/constants.ts
+++ b/packages/pdf-parser/src/config/constants.ts
@@ -59,7 +59,7 @@ export const DOCLING_ENVIRONMENT = {
 export const PAGE_RENDERING = {
   /** Default rendering DPI for VLM text recognition quality */
   DEFAULT_DPI: 200,
-  /** Low-resolution DPI for OCR strategy sampling */
+  /** Low-resolution DPI for language detection sampling */
   SAMPLE_DPI: 150,
 } as const;
 

--- a/packages/pdf-parser/src/core/conversion-options-builder.test.ts
+++ b/packages/pdf-parser/src/core/conversion-options-builder.test.ts
@@ -17,6 +17,7 @@ describe('buildConversionOptions', () => {
     expect(result).toEqual({
       to_formats: ['json', 'html'],
       image_export_mode: 'embedded',
+      ocr_lang: ['ko-KR', 'en-US'],
       ocr_engine: 'ocrmac',
       ocr_options: {
         kind: 'ocrmac',
@@ -43,6 +44,7 @@ describe('buildConversionOptions', () => {
       ocr_lang: ['ja-JP', 'en-US'],
     });
 
+    expect(result.ocr_lang).toEqual(['ja-JP', 'en-US']);
     expect(result.ocr_options).toEqual({
       kind: 'ocrmac',
       lang: ['ja-JP', 'en-US'],
@@ -101,6 +103,7 @@ describe('buildConversionOptions', () => {
       chunkSize: 20,
       chunkMaxRetries: 5,
       documentValidationModel: {} as any,
+      languageDetectionModel: {} as any,
     } as any);
 
     expect(result).not.toHaveProperty('forceImagePdf');
@@ -112,6 +115,7 @@ describe('buildConversionOptions', () => {
     expect(result).not.toHaveProperty('chunkSize');
     expect(result).not.toHaveProperty('chunkMaxRetries');
     expect(result).not.toHaveProperty('documentValidationModel');
+    expect(result).not.toHaveProperty('languageDetectionModel');
   });
 
   test('should pass through unknown options via spread', () => {

--- a/packages/pdf-parser/src/core/conversion-options-builder.ts
+++ b/packages/pdf-parser/src/core/conversion-options-builder.ts
@@ -4,6 +4,8 @@ import type { PDFConvertOptions } from './pdf-converter';
 
 import { omit } from 'es-toolkit';
 
+import { DEFAULT_OCR_LANGUAGES } from '../detectors/pdf-language-detector';
+
 /**
  * Build Docling ConversionOptions from PDFConvertOptions.
  * Strips pdf-parser-specific fields and configures OCR settings.
@@ -11,6 +13,8 @@ import { omit } from 'es-toolkit';
 export function buildConversionOptions(
   options: PDFConvertOptions,
 ): ConversionOptions {
+  const ocrLanguages = options.ocr_lang ?? DEFAULT_OCR_LANGUAGES;
+
   return {
     ...omit(options, [
       'num_threads',
@@ -24,13 +28,17 @@ export function buildConversionOptions(
       'chunkSize',
       'chunkMaxRetries',
       'documentValidationModel',
+      'languageDetectionModel',
     ]),
     to_formats: ['json', 'html'],
     image_export_mode: 'embedded',
+    // Docling currently reads this top-level field in addition to ocr_options.
+    // Keep it populated even when language detection is skipped.
+    ocr_lang: ocrLanguages,
     ocr_engine: 'ocrmac',
     ocr_options: {
       kind: 'ocrmac',
-      lang: options.ocr_lang ?? ['ko-KR', 'en-US'],
+      lang: ocrLanguages,
       recognition: 'accurate',
       framework: 'livetext',
     },

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -7,6 +7,7 @@ import { LLMTokenUsageAggregator } from '@heripo/shared';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { PdfLanguageDetector } from '../detectors/pdf-language-detector';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
@@ -25,6 +26,17 @@ vi.mock('./image-pdf-converter', () => ({
 
 vi.mock('./docling-conversion-executor', () => ({
   DoclingConversionExecutor: vi.fn(),
+}));
+
+const pdfLanguageDetectorMocks = vi.hoisted(() => ({
+  detect: vi.fn(),
+}));
+
+vi.mock('../detectors/pdf-language-detector', () => ({
+  DEFAULT_OCR_LANGUAGES: ['ko-KR', 'en-US'],
+  PdfLanguageDetector: vi.fn(function () {
+    return { detect: pdfLanguageDetectorMocks.detect };
+  }),
 }));
 
 vi.mock('node:fs', () => ({
@@ -100,6 +112,14 @@ describe('PDFConverter', () => {
     } as unknown as DoclingAPIClient;
 
     converter = new PDFConverter(logger, client);
+    pdfLanguageDetectorMocks.detect.mockReset();
+    pdfLanguageDetectorMocks.detect.mockResolvedValue({
+      detectedLanguages: ['ko-KR'],
+      reason: 'test language detection',
+      sampledPages: 1,
+      totalPages: 1,
+      source: 'text-layer',
+    });
 
     vi.mocked(join).mockImplementation((...args) => args.join('/'));
 
@@ -359,7 +379,7 @@ describe('PDFConverter', () => {
         'report123',
         onComplete,
         false,
-        withCorrection(),
+        withCorrection({ ocr_lang: ['ko-KR'] }),
       );
 
       expect(PdfTextExtractor).not.toHaveBeenCalled();
@@ -452,6 +472,55 @@ describe('PDFConverter', () => {
       );
 
       expect(result).toEqual(aggregator.getReport());
+    });
+
+    test('detects OCR languages for local PDFs and passes them to conversion', async () => {
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        withCorrection(),
+      );
+
+      expect(PdfLanguageDetector).toHaveBeenCalled();
+      expect(pdfLanguageDetectorMocks.detect).toHaveBeenCalledWith(
+        '/test/doc.pdf',
+        expect.stringContaining('output/report123/_language_detection'),
+        expect.objectContaining({
+          model: undefined,
+          abortSignal: undefined,
+          aggregator: expect.any(LLMTokenUsageAggregator),
+        }),
+      );
+      expect(mockExecute).toHaveBeenCalledWith(
+        'file:///test/doc.pdf',
+        'report123',
+        expect.any(Function),
+        false,
+        expect.objectContaining({ ocr_lang: ['ko-KR'] }),
+        undefined,
+      );
+    });
+
+    test('skips language detection when OCR languages are already provided', async () => {
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        withCorrection({ ocr_lang: ['ja-JP', 'en-US'] }),
+      );
+
+      expect(pdfLanguageDetectorMocks.detect).not.toHaveBeenCalled();
+      expect(mockExecute).toHaveBeenCalledWith(
+        'file:///test/doc.pdf',
+        'report123',
+        expect.any(Function),
+        false,
+        expect.objectContaining({ ocr_lang: ['ja-JP', 'en-US'] }),
+        undefined,
+      );
     });
   });
 

--- a/packages/pdf-parser/src/core/pdf-converter.test.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.test.ts
@@ -4,6 +4,7 @@ import type { DoclingAPIClient } from 'docling-sdk';
 import type { PDFConvertOptions } from './pdf-converter';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
+import { existsSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -122,6 +123,8 @@ describe('PDFConverter', () => {
     });
 
     vi.mocked(join).mockImplementation((...args) => args.join('/'));
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(rmSync).mockImplementation(() => undefined);
 
     // Mock DoclingConversionExecutor
     mockExecute = vi.fn().mockResolvedValue(null);
@@ -500,6 +503,73 @@ describe('PDFConverter', () => {
         false,
         expect.objectContaining({ ocr_lang: ['ko-KR'] }),
         undefined,
+      );
+    });
+
+    test('emits token usage after language detection when usage was tracked', async () => {
+      const aggregator = new LLMTokenUsageAggregator();
+      const onTokenUsage = vi.fn();
+      pdfLanguageDetectorMocks.detect.mockImplementationOnce(async () => {
+        aggregator.track({
+          component: 'PdfLanguageDetector',
+          phase: 'language-detection',
+          model: 'primary',
+          modelName: 'language-model',
+          inputTokens: 3,
+          outputTokens: 2,
+          totalTokens: 5,
+        });
+        return {
+          detectedLanguages: ['ko-KR'],
+          reason: 'test language detection',
+          sampledPages: 1,
+          totalPages: 1,
+          source: 'text-layer',
+        };
+      });
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        withCorrection({ aggregator, onTokenUsage }),
+      );
+
+      expect(onTokenUsage).toHaveBeenCalledWith(aggregator.getReport());
+    });
+
+    test('does not emit token usage after language detection when report is empty', async () => {
+      const onTokenUsage = vi.fn();
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        withCorrection({ onTokenUsage }),
+      );
+
+      expect(onTokenUsage).not.toHaveBeenCalled();
+    });
+
+    test('cleans up language detection temporary directory when it exists', async () => {
+      vi.mocked(existsSync).mockReturnValueOnce(true);
+
+      await converter.convert(
+        'file:///test/doc.pdf',
+        'report123',
+        vi.fn(),
+        false,
+        withCorrection(),
+      );
+
+      expect(rmSync).toHaveBeenCalledWith(
+        expect.stringContaining('output/report123/_language_detection'),
+        {
+          recursive: true,
+          force: true,
+        },
       );
     });
 

--- a/packages/pdf-parser/src/core/pdf-converter.ts
+++ b/packages/pdf-parser/src/core/pdf-converter.ts
@@ -9,9 +9,16 @@ import type { ConversionOptions, DoclingAPIClient } from 'docling-sdk';
 import type { PDFCorrectionOptions } from './correction-options';
 
 import { LLMTokenUsageAggregator } from '@heripo/shared';
+import { existsSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { CHUNKED_CONVERSION, PDF_CONVERTER } from '../config/constants';
+import {
+  DEFAULT_OCR_LANGUAGES,
+  PdfLanguageDetector,
+} from '../detectors/pdf-language-detector';
 import { ImagePdfFallbackError } from '../errors/image-pdf-fallback-error';
+import { PageRenderer } from '../processors/page-renderer';
 import { PdfTextExtractor } from '../processors/pdf-text-extractor';
 import { DocumentTypeValidator } from '../validators/document-type-validator';
 import { ChunkedPDFConverter } from './chunked-pdf-converter';
@@ -66,6 +73,8 @@ export type PDFConvertOptions = Omit<
   chunkSize?: number;
   /** Max retry attempts per failed chunk (default: CHUNKED_CONVERSION.DEFAULT_MAX_RETRIES) */
   chunkMaxRetries?: number;
+  /** Vision model for document language detection when the PDF text layer is insufficient */
+  languageDetectionModel?: LanguageModel;
   /** LLM model for document type validation (opt-in: skipped when not set) */
   documentValidationModel?: LanguageModel;
 };
@@ -116,8 +125,13 @@ export class PDFConverter {
     this.logger.info('[PDFConverter] Converting:', url);
 
     const aggregator = options.aggregator ?? new LLMTokenUsageAggregator();
-    const trackedOptions: PDFConvertOptions = { ...options, aggregator };
     const pdfPath = url.startsWith('file://') ? url.slice(7) : undefined;
+    const trackedOptions = await this.withDetectedLanguages(
+      pdfPath,
+      reportId,
+      { ...options, aggregator },
+      abortSignal,
+    );
     const correctedOnComplete = new PostDoclingCorrectionPipeline(
       this.logger,
     ).wrapCallback(pdfPath, reportId, trackedOptions, onComplete, abortSignal);
@@ -186,6 +200,69 @@ export class PDFConverter {
     }
 
     return this.buildTokenReport(aggregator) ?? conversionReport;
+  }
+
+  private async withDetectedLanguages(
+    pdfPath: string | undefined,
+    reportId: string,
+    options: PDFConvertOptions,
+    abortSignal?: AbortSignal,
+  ): Promise<PDFConvertOptions> {
+    if (options.ocr_lang && options.ocr_lang.length > 0) {
+      this.logger.info(
+        `[PDFConverter] OCR languages provided: ${JSON.stringify(options.ocr_lang)}`,
+      );
+      return options;
+    }
+
+    if (!pdfPath) {
+      this.logger.info(
+        '[PDFConverter] Local PDF not available; OCR languages will use defaults',
+      );
+      return {
+        ...options,
+        ocr_lang: [...DEFAULT_OCR_LANGUAGES],
+      };
+    }
+
+    const languageDetectionDir = join(
+      process.cwd(),
+      'output',
+      reportId,
+      '_language_detection',
+    );
+    const detector = new PdfLanguageDetector(
+      this.logger,
+      new PageRenderer(this.logger),
+      new PdfTextExtractor(this.logger),
+    );
+
+    try {
+      const result = await detector.detect(pdfPath, languageDetectionDir, {
+        model: options.languageDetectionModel,
+        aggregator: options.aggregator,
+        abortSignal,
+      });
+      this.logger.info(
+        `[PDFConverter] OCR languages detected: ${JSON.stringify(result.detectedLanguages)} (${result.reason})`,
+      );
+
+      if (options.onTokenUsage && options.aggregator) {
+        const tokenReport = this.buildTokenReport(options.aggregator);
+        if (tokenReport) {
+          options.onTokenUsage(tokenReport);
+        }
+      }
+
+      return {
+        ...options,
+        ocr_lang: result.detectedLanguages,
+      };
+    } finally {
+      if (existsSync(languageDetectionDir)) {
+        rmSync(languageDetectionDir, { recursive: true, force: true });
+      }
+    }
   }
 
   /**

--- a/packages/pdf-parser/src/detectors/pdf-language-detector.test.ts
+++ b/packages/pdf-parser/src/detectors/pdf-language-detector.test.ts
@@ -1,0 +1,132 @@
+import type { LoggerMethods } from '@heripo/logger';
+
+import { LLMCaller } from '@heripo/shared';
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { PdfLanguageDetector } from './pdf-language-detector';
+
+vi.mock('@heripo/shared', () => ({
+  LLMCaller: {
+    callVision: vi.fn(),
+  },
+}));
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+describe('PdfLanguageDetector', () => {
+  let logger: LoggerMethods;
+  let pageRenderer: { renderPages: ReturnType<typeof vi.fn> };
+  let textExtractor: {
+    getPageCount: ReturnType<typeof vi.fn>;
+    extractFullText: ReturnType<typeof vi.fn>;
+  };
+  let detector: PdfLanguageDetector;
+
+  beforeEach(() => {
+    logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    pageRenderer = {
+      renderPages: vi.fn(),
+    };
+    textExtractor = {
+      getPageCount: vi.fn(),
+      extractFullText: vi.fn(),
+    };
+    detector = new PdfLanguageDetector(
+      logger,
+      pageRenderer as any,
+      textExtractor as any,
+    );
+    vi.mocked(readFileSync).mockReturnValue(Buffer.from([1, 2, 3]));
+    vi.mocked(LLMCaller.callVision).mockReset();
+  });
+
+  test('detects Korean and English from the PDF text layer without rendering pages', async () => {
+    textExtractor.getPageCount.mockResolvedValue(12);
+    textExtractor.extractFullText.mockResolvedValue(
+      '조사지역은 연동 한가운데 있다. S=1/25,000',
+    );
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling');
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'text-layer',
+      sampledPages: 12,
+      totalPages: 12,
+    });
+    expect(pageRenderer.renderPages).not.toHaveBeenCalled();
+  });
+
+  test('uses default OCR languages when text layer is empty and no model is configured', async () => {
+    textExtractor.getPageCount.mockResolvedValue(3);
+    textExtractor.extractFullText.mockResolvedValue('');
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling');
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'default',
+      sampledPages: 0,
+    });
+    expect(pageRenderer.renderPages).not.toHaveBeenCalled();
+  });
+
+  test('samples rendered pages with a model when the text layer has no language signal', async () => {
+    const model = { modelId: 'language-model' } as any;
+    textExtractor.getPageCount.mockResolvedValue(3);
+    textExtractor.extractFullText.mockResolvedValue('12345');
+    pageRenderer.renderPages.mockResolvedValue({
+      pageCount: 3,
+      pagesDir: '/tmp/sampling/pages',
+      pageFiles: ['/tmp/page-1.png', '/tmp/page-2.png', '/tmp/page-3.png'],
+    });
+    vi.mocked(LLMCaller.callVision)
+      .mockResolvedValueOnce({
+        output: { detectedLanguages: ['ko'] },
+        usage: { component: 'PdfLanguageDetector' },
+      } as any)
+      .mockResolvedValueOnce({
+        output: { detectedLanguages: ['en-US'] },
+        usage: { component: 'PdfLanguageDetector' },
+      } as any)
+      .mockResolvedValueOnce({
+        output: { detectedLanguages: ['ko-KR'] },
+        usage: { component: 'PdfLanguageDetector' },
+      } as any);
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling', {
+      model,
+    });
+
+    expect(pageRenderer.renderPages).toHaveBeenCalledWith(
+      '/tmp/report.pdf',
+      '/tmp/sampling',
+      {
+        dpi: 150,
+      },
+    );
+    expect(LLMCaller.callVision).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'vlm',
+      sampledPages: 3,
+      totalPages: 3,
+    });
+  });
+
+  test('selects all pages when the document fits within the sample limit', () => {
+    expect(detector.selectSamplePages(3, 15)).toEqual([0, 1, 2]);
+  });
+
+  test('trims edges and distributes samples for large documents', () => {
+    expect(detector.selectSamplePages(100, 5)).toEqual([10, 26, 42, 58, 74]);
+  });
+});

--- a/packages/pdf-parser/src/detectors/pdf-language-detector.test.ts
+++ b/packages/pdf-parser/src/detectors/pdf-language-detector.test.ts
@@ -1,6 +1,6 @@
 import type { LoggerMethods } from '@heripo/logger';
 
-import { LLMCaller } from '@heripo/shared';
+import { LLMCaller, type LLMTokenUsageAggregator } from '@heripo/shared';
 import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -48,6 +48,15 @@ describe('PdfLanguageDetector', () => {
     vi.mocked(LLMCaller.callVision).mockReset();
   });
 
+  test('creates a default text extractor when none is provided', () => {
+    const detectorWithDefaultExtractor = new PdfLanguageDetector(
+      logger,
+      pageRenderer as any,
+    );
+
+    expect(detectorWithDefaultExtractor).toBeInstanceOf(PdfLanguageDetector);
+  });
+
   test('detects Korean and English from the PDF text layer without rendering pages', async () => {
     textExtractor.getPageCount.mockResolvedValue(12);
     textExtractor.extractFullText.mockResolvedValue(
@@ -65,6 +74,23 @@ describe('PdfLanguageDetector', () => {
     expect(pageRenderer.renderPages).not.toHaveBeenCalled();
   });
 
+  test('detects Japanese and English from the PDF text layer by prevalence', async () => {
+    textExtractor.getPageCount.mockResolvedValue(2);
+    textExtractor.extractFullText.mockResolvedValue(
+      '調査地域 ABC かなカナ かなカナ',
+    );
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling');
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ja-JP', 'en-US'],
+      source: 'text-layer',
+      sampledPages: 2,
+      totalPages: 2,
+    });
+    expect(pageRenderer.renderPages).not.toHaveBeenCalled();
+  });
+
   test('uses default OCR languages when text layer is empty and no model is configured', async () => {
     textExtractor.getPageCount.mockResolvedValue(3);
     textExtractor.extractFullText.mockResolvedValue('');
@@ -76,6 +102,36 @@ describe('PdfLanguageDetector', () => {
       source: 'default',
       sampledPages: 0,
     });
+    expect(pageRenderer.renderPages).not.toHaveBeenCalled();
+  });
+
+  test('uses default OCR languages when the text layer has zero pages', async () => {
+    textExtractor.getPageCount.mockResolvedValue(0);
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling');
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'default',
+      sampledPages: 0,
+      totalPages: 0,
+    });
+    expect(textExtractor.extractFullText).not.toHaveBeenCalled();
+    expect(pageRenderer.renderPages).not.toHaveBeenCalled();
+  });
+
+  test('uses default OCR languages when text layer detection throws and no model is configured', async () => {
+    textExtractor.getPageCount.mockRejectedValue(new Error('pdfinfo failed'));
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling');
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'default',
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      '[PdfLanguageDetector] Text layer language detection failed; falling back to sampled language detection',
+    );
     expect(pageRenderer.renderPages).not.toHaveBeenCalled();
   });
 
@@ -122,8 +178,126 @@ describe('PdfLanguageDetector', () => {
     });
   });
 
+  test('uses default OCR languages when sampled rendering returns no pages', async () => {
+    const model = { modelId: 'language-model' } as any;
+    textExtractor.getPageCount.mockResolvedValue(3);
+    textExtractor.extractFullText.mockResolvedValue('12345');
+    pageRenderer.renderPages.mockResolvedValue({
+      pageCount: 0,
+      pagesDir: '/tmp/sampling/pages',
+      pageFiles: [],
+    });
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling', {
+      model,
+    });
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      reason: 'No pages found in PDF',
+      source: 'default',
+      sampledPages: 0,
+      totalPages: 0,
+    });
+    expect(LLMCaller.callVision).not.toHaveBeenCalled();
+  });
+
+  test('uses default OCR languages when sampled pages are missing', async () => {
+    const model = { modelId: 'language-model' } as any;
+    textExtractor.getPageCount.mockResolvedValue(3);
+    textExtractor.extractFullText.mockResolvedValue('12345');
+    pageRenderer.renderPages.mockResolvedValue({
+      pageCount: 2,
+      pagesDir: '/tmp/sampling/pages',
+      pageFiles: [],
+    });
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling', {
+      model,
+    });
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'default',
+      sampledPages: 0,
+      totalPages: 2,
+    });
+    expect(LLMCaller.callVision).not.toHaveBeenCalled();
+  });
+
+  test('uses default OCR languages when sampled pages return no valid languages', async () => {
+    const model = { modelId: 'language-model' } as any;
+    const abortController = new AbortController();
+    const track = vi.fn();
+    const aggregator = { track } as unknown as LLMTokenUsageAggregator;
+    textExtractor.getPageCount.mockResolvedValue(3);
+    textExtractor.extractFullText.mockResolvedValue('12345');
+    pageRenderer.renderPages.mockResolvedValue({
+      pageCount: 1,
+      pagesDir: '/tmp/sampling/pages',
+      pageFiles: ['/tmp/page-1.png'],
+    });
+    vi.mocked(LLMCaller.callVision).mockResolvedValueOnce({
+      output: { detectedLanguages: ['xx', 'und'] },
+      usage: {
+        component: 'PdfLanguageDetector',
+        phase: 'language-detection',
+        model: 'primary',
+        modelName: 'language-model',
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+      },
+    } as any);
+
+    const result = await detector.detect('/tmp/report.pdf', '/tmp/sampling', {
+      model,
+      maxRetries: 5,
+      temperature: 0.2,
+      abortSignal: abortController.signal,
+      aggregator,
+    });
+
+    expect(result).toMatchObject({
+      detectedLanguages: ['ko-KR', 'en-US'],
+      source: 'default',
+      sampledPages: 1,
+      totalPages: 1,
+    });
+    expect(LLMCaller.callVision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        primaryModel: model,
+        maxRetries: 5,
+        temperature: 0.2,
+        abortSignal: abortController.signal,
+        component: 'PdfLanguageDetector',
+        phase: 'language-detection',
+      }),
+    );
+    expect(track).toHaveBeenCalledWith(
+      expect.objectContaining({
+        component: 'PdfLanguageDetector',
+        totalTokens: 3,
+      }),
+    );
+  });
+
+  test('selects no pages for an empty document', () => {
+    expect(detector.selectSamplePages(0, 15)).toEqual([]);
+  });
+
   test('selects all pages when the document fits within the sample limit', () => {
     expect(detector.selectSamplePages(3, 15)).toEqual([0, 1, 2]);
+  });
+
+  test('selects the middle page when edge trimming leaves no eligible pages', () => {
+    expect(detector.selectSamplePages(2, 0)).toEqual([1]);
+  });
+
+  test('selects all eligible middle pages when trimmed range fits within the sample limit', () => {
+    expect(detector.selectSamplePages(20, 18)).toEqual([
+      2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+    ]);
   });
 
   test('trims edges and distributes samples for large documents', () => {

--- a/packages/pdf-parser/src/detectors/pdf-language-detector.ts
+++ b/packages/pdf-parser/src/detectors/pdf-language-detector.ts
@@ -1,0 +1,318 @@
+import type { LoggerMethods } from '@heripo/logger';
+import type { Bcp47LanguageTag } from '@heripo/model';
+import type { LLMTokenUsageAggregator } from '@heripo/shared';
+import type { LanguageModel } from 'ai';
+
+import type { PageRenderer } from '../processors/page-renderer';
+
+import { normalizeToBcp47 } from '@heripo/model';
+import { LLMCaller } from '@heripo/shared';
+import { readFileSync } from 'node:fs';
+import { z } from 'zod/v4';
+
+import { PAGE_RENDERING } from '../config/constants';
+import { PdfTextExtractor } from '../processors/pdf-text-extractor';
+import { KOREAN_DOCUMENT_DETECTION_PROMPT } from '../prompts/korean-document-detection-prompt';
+
+const DEFAULT_MAX_SAMPLE_PAGES = 15;
+const DEFAULT_MAX_RETRIES = 3;
+const EDGE_TRIM_RATIO = 0.1;
+
+const HANGUL_REGEX = /[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]/g;
+const JAPANESE_KANA_REGEX = /[\u3040-\u30ff]/g;
+const LATIN_REGEX = /[A-Za-z]/g;
+
+export const DEFAULT_OCR_LANGUAGES: Bcp47LanguageTag[] = ['ko-KR', 'en-US'];
+
+const languageDetectionSchema = z.object({
+  detectedLanguages: z
+    .array(z.string())
+    .describe(
+      'BCP 47 language tags found on this page, ordered by prevalence.',
+    ),
+});
+
+export interface PdfLanguageDetectionOptions {
+  model?: LanguageModel;
+  maxSamplePages?: number;
+  maxRetries?: number;
+  temperature?: number;
+  abortSignal?: AbortSignal;
+  aggregator?: LLMTokenUsageAggregator;
+}
+
+export interface PdfLanguageDetectionResult {
+  detectedLanguages: Bcp47LanguageTag[];
+  reason: string;
+  sampledPages: number;
+  totalPages: number;
+  source: 'text-layer' | 'vlm' | 'default';
+}
+
+export class PdfLanguageDetector {
+  private readonly textExtractor: PdfTextExtractor;
+
+  constructor(
+    private readonly logger: LoggerMethods,
+    private readonly pageRenderer: PageRenderer,
+    textExtractor?: PdfTextExtractor,
+  ) {
+    this.textExtractor = textExtractor ?? new PdfTextExtractor(logger);
+  }
+
+  async detect(
+    pdfPath: string,
+    outputDir: string,
+    options?: PdfLanguageDetectionOptions,
+  ): Promise<PdfLanguageDetectionResult> {
+    this.logger.info(
+      '[PdfLanguageDetector] Starting PDF language detection...',
+    );
+
+    const textLayerResult = await this.detectFromTextLayer(pdfPath);
+    if (textLayerResult) {
+      return textLayerResult;
+    }
+
+    if (!options?.model) {
+      this.logger.info(
+        `[PdfLanguageDetector] Language detection model not configured; using default OCR languages: ${JSON.stringify(DEFAULT_OCR_LANGUAGES)}`,
+      );
+      return {
+        detectedLanguages: [...DEFAULT_OCR_LANGUAGES],
+        reason: 'Language detection model not configured',
+        sampledPages: 0,
+        totalPages: 0,
+        source: 'default',
+      };
+    }
+
+    return this.detectFromSampledPages(pdfPath, outputDir, {
+      ...options,
+      model: options.model,
+    });
+  }
+
+  private async detectFromTextLayer(
+    pdfPath: string,
+  ): Promise<PdfLanguageDetectionResult | null> {
+    try {
+      const totalPages = await this.textExtractor.getPageCount(pdfPath);
+      if (totalPages === 0) return null;
+
+      const fullText = await this.textExtractor.extractFullText(pdfPath);
+      if (fullText.trim().length === 0) {
+        this.logger.debug(
+          '[PdfLanguageDetector] No text in text layer; falling back to sampled language detection',
+        );
+        return null;
+      }
+
+      const detectedLanguages = this.detectLanguagesFromText(fullText);
+      if (detectedLanguages.length === 0) {
+        this.logger.debug(
+          '[PdfLanguageDetector] No known language signal in text layer; falling back to sampled language detection',
+        );
+        return null;
+      }
+
+      this.logger.info(
+        `[PdfLanguageDetector] Languages detected in text layer: ${detectedLanguages.join(', ')}`,
+      );
+      return {
+        detectedLanguages,
+        reason: `Languages found in PDF text layer (${totalPages} pages checked)`,
+        sampledPages: totalPages,
+        totalPages,
+        source: 'text-layer',
+      };
+    } catch {
+      this.logger.debug(
+        '[PdfLanguageDetector] Text layer language detection failed; falling back to sampled language detection',
+      );
+      return null;
+    }
+  }
+
+  private detectLanguagesFromText(text: string): Bcp47LanguageTag[] {
+    const scores: Array<{ tag: Bcp47LanguageTag; count: number }> = [
+      { tag: 'ko-KR', count: this.countMatches(text, HANGUL_REGEX) },
+      { tag: 'ja-JP', count: this.countMatches(text, JAPANESE_KANA_REGEX) },
+      { tag: 'en-US', count: this.countMatches(text, LATIN_REGEX) },
+    ];
+
+    return scores
+      .filter(({ count }) => count > 0)
+      .sort((a, b) => b.count - a.count)
+      .map(({ tag }) => tag);
+  }
+
+  private countMatches(text: string, regex: RegExp): number {
+    regex.lastIndex = 0;
+    return text.match(regex)?.length ?? 0;
+  }
+
+  private async detectFromSampledPages(
+    pdfPath: string,
+    outputDir: string,
+    options: Required<Pick<PdfLanguageDetectionOptions, 'model'>> &
+      PdfLanguageDetectionOptions,
+  ): Promise<PdfLanguageDetectionResult> {
+    const renderResult = await this.pageRenderer.renderPages(
+      pdfPath,
+      outputDir,
+      {
+        dpi: PAGE_RENDERING.SAMPLE_DPI,
+      },
+    );
+
+    if (renderResult.pageCount === 0) {
+      this.logger.info(
+        `[PdfLanguageDetector] No pages found; using default OCR languages: ${JSON.stringify(DEFAULT_OCR_LANGUAGES)}`,
+      );
+      return {
+        detectedLanguages: [...DEFAULT_OCR_LANGUAGES],
+        reason: 'No pages found in PDF',
+        sampledPages: 0,
+        totalPages: 0,
+        source: 'default',
+      };
+    }
+
+    const sampleIndices = this.selectSamplePages(
+      renderResult.pageCount,
+      options.maxSamplePages ?? DEFAULT_MAX_SAMPLE_PAGES,
+    );
+    this.logger.info(
+      `[PdfLanguageDetector] Sampling ${sampleIndices.length} of ${renderResult.pageCount} pages for language detection: [${sampleIndices.map((i) => i + 1).join(', ')}]`,
+    );
+
+    const languageFrequency = new Map<Bcp47LanguageTag, number>();
+    let sampledPages = 0;
+    for (const index of sampleIndices) {
+      const pageFile = renderResult.pageFiles[index];
+      if (!pageFile) continue;
+
+      sampledPages += 1;
+      const detectedLanguages = await this.analyzeSamplePage(
+        pageFile,
+        index + 1,
+        options,
+      );
+      for (const language of detectedLanguages) {
+        languageFrequency.set(
+          language,
+          (languageFrequency.get(language) ?? 0) + 1,
+        );
+      }
+    }
+
+    const detectedLanguages = this.aggregateLanguages(languageFrequency);
+    if (detectedLanguages.length === 0) {
+      this.logger.info(
+        `[PdfLanguageDetector] No languages detected from sampled pages; using default OCR languages: ${JSON.stringify(DEFAULT_OCR_LANGUAGES)}`,
+      );
+      return {
+        detectedLanguages: [...DEFAULT_OCR_LANGUAGES],
+        reason: `No language detected in ${sampledPages} sampled pages`,
+        sampledPages,
+        totalPages: renderResult.pageCount,
+        source: 'default',
+      };
+    }
+
+    this.logger.info(
+      `[PdfLanguageDetector] Languages detected from sampled pages: ${detectedLanguages.join(', ')}`,
+    );
+    return {
+      detectedLanguages,
+      reason: `Languages detected in ${sampledPages} sampled pages`,
+      sampledPages,
+      totalPages: renderResult.pageCount,
+      source: 'vlm',
+    };
+  }
+
+  selectSamplePages(totalPages: number, maxSamples: number): number[] {
+    if (totalPages === 0) return [];
+    if (totalPages <= maxSamples) {
+      return Array.from({ length: totalPages }, (_, i) => i);
+    }
+
+    const trimCount = Math.max(1, Math.ceil(totalPages * EDGE_TRIM_RATIO));
+    const start = trimCount;
+    const end = totalPages - trimCount;
+    const eligibleCount = end - start;
+
+    if (eligibleCount <= 0) {
+      return [Math.floor(totalPages / 2)];
+    }
+    if (eligibleCount <= maxSamples) {
+      return Array.from({ length: eligibleCount }, (_, i) => start + i);
+    }
+
+    const step = eligibleCount / maxSamples;
+    return Array.from(
+      { length: maxSamples },
+      (_, i) => start + Math.floor(i * step),
+    );
+  }
+
+  private async analyzeSamplePage(
+    pageFile: string,
+    pageNo: number,
+    options: Required<Pick<PdfLanguageDetectionOptions, 'model'>> &
+      PdfLanguageDetectionOptions,
+  ): Promise<Bcp47LanguageTag[]> {
+    this.logger.debug(
+      `[PdfLanguageDetector] Analyzing page ${pageNo} for language...`,
+    );
+
+    const imageData = new Uint8Array(readFileSync(pageFile));
+    const result = await LLMCaller.callVision({
+      schema: languageDetectionSchema as any,
+      messages: [
+        {
+          role: 'user' as const,
+          content: [
+            {
+              type: 'text' as const,
+              text: KOREAN_DOCUMENT_DETECTION_PROMPT,
+            },
+            {
+              type: 'image' as const,
+              image: imageData,
+              mediaType: 'image/png' as const,
+            },
+          ],
+        },
+      ],
+      primaryModel: options.model,
+      maxRetries: options.maxRetries ?? DEFAULT_MAX_RETRIES,
+      temperature: options.temperature ?? 0,
+      abortSignal: options.abortSignal,
+      component: 'PdfLanguageDetector',
+      phase: 'language-detection',
+    });
+
+    options.aggregator?.track(result.usage);
+
+    const output = result.output as { detectedLanguages: string[] };
+    const detectedLanguages = output.detectedLanguages
+      .map(normalizeToBcp47)
+      .filter((tag): tag is Bcp47LanguageTag => tag !== null);
+
+    this.logger.debug(
+      `[PdfLanguageDetector] Page ${pageNo}: detectedLanguages=${detectedLanguages.join(',')}`,
+    );
+    return detectedLanguages;
+  }
+
+  private aggregateLanguages(
+    languageFrequency: Map<Bcp47LanguageTag, number>,
+  ): Bcp47LanguageTag[] {
+    return [...languageFrequency.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([language]) => language);
+  }
+}


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Restore the missing OCR language detection path that was accidentally omitted from the previous PDF parsing implementation. This ensures Docling receives appropriate OCR language hints instead of relying only on static defaults, improving recognition for PDFs with missing or unreliable text layers.

## Changes

- Added `PdfLanguageDetector` to infer OCR languages from the PDF text layer before conversion.
- Added sampled-page vision model fallback when the text layer does not provide a reliable language signal.
- Wired detected languages into `PDFConverter` and `buildConversionOptions` through `ocr_lang`.
- Added default Korean/English OCR languages when detection is skipped or cannot produce a result.
- Added temporary `_language_detection` directory cleanup after detection.
- Added `languageDetectionModel` to demo-web processing options, form defaults, validation schema, and task worker conversion setup.
- Expanded tests for language detection, fallback behavior, OCR language propagation, cleanup, token usage, and option filtering.

## Breaking Changes

- [x] None
- If any, describe migration steps: N/A

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #