### PR TITLE
fix(shared): split token usage by model within phases

### DIFF
--- a/packages/shared/src/utils/llm-token-usage-aggregator.test.ts
+++ b/packages/shared/src/utils/llm-token-usage-aggregator.test.ts
@@ -99,10 +99,8 @@ describe('LLMTokenUsageAggregator', () => {
       const byComponent = aggregator.getByComponent();
       const phase = byComponent[0].phases['extraction'];
 
-      expect(phase.primary?.inputTokens).toBe(100);
-      expect(phase.primary?.modelName).toBe('gpt-5');
-      expect(phase.fallback?.inputTokens).toBe(200);
-      expect(phase.fallback?.modelName).toBe('claude-opus-4-5');
+      expect(phase.primary.get('gpt-5')?.inputTokens).toBe(100);
+      expect(phase.fallback.get('claude-opus-4-5')?.inputTokens).toBe(200);
       expect(phase.total.inputTokens).toBe(300);
     });
 
@@ -184,10 +182,9 @@ describe('LLMTokenUsageAggregator', () => {
       const byComponent = aggregator.getByComponent();
       const phase = byComponent[0].phases['extraction'];
 
-      expect(phase.fallback?.inputTokens).toBe(300);
-      expect(phase.fallback?.outputTokens).toBe(125);
-      expect(phase.fallback?.totalTokens).toBe(425);
-      expect(phase.fallback?.modelName).toBe('claude-opus-4-5');
+      expect(phase.fallback.get('claude-opus-4-5')?.inputTokens).toBe(300);
+      expect(phase.fallback.get('claude-opus-4-5')?.outputTokens).toBe(125);
+      expect(phase.fallback.get('claude-opus-4-5')?.totalTokens).toBe(425);
     });
 
     test('should handle unknown model type gracefully (skip primary/fallback tracking)', () => {
@@ -206,9 +203,9 @@ describe('LLMTokenUsageAggregator', () => {
       const byComponent = aggregator.getByComponent();
       const phase = byComponent[0].phases['extraction'];
 
-      // Neither primary nor fallback should be set
-      expect(phase.primary).toBeUndefined();
-      expect(phase.fallback).toBeUndefined();
+      // Neither primary nor fallback should hold a model
+      expect(phase.primary.size).toBe(0);
+      expect(phase.fallback.size).toBe(0);
       // But total should still be updated
       expect(phase.total.inputTokens).toBe(100);
       expect(phase.total.outputTokens).toBe(50);
@@ -241,6 +238,54 @@ describe('LLMTokenUsageAggregator', () => {
           proposalCount: 1,
         },
       ]);
+    });
+
+    test('should keep distinct primary models separate within one phase', () => {
+      // Regression: review-assistance `work-item-review` mixes models — the
+      // `tables` task runs on a different model from the text tasks. They must
+      // not collapse onto the first model seen.
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'lmstudio/gemma',
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+      });
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'openai/gpt-5-mini',
+        inputTokens: 200,
+        outputTokens: 80,
+        totalTokens: 280,
+      });
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'lmstudio/gemma',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      });
+
+      const phase = aggregator.getByComponent()[0].phases['work-item-review'];
+
+      expect(phase.primary.size).toBe(2);
+      expect(phase.primary.get('lmstudio/gemma')).toEqual({
+        inputTokens: 110,
+        outputTokens: 45,
+        totalTokens: 155,
+      });
+      expect(phase.primary.get('openai/gpt-5-mini')).toEqual({
+        inputTokens: 200,
+        outputTokens: 80,
+        totalTokens: 280,
+      });
+      expect(phase.total.totalTokens).toBe(435);
     });
   });
 
@@ -445,11 +490,11 @@ describe('LLMTokenUsageAggregator', () => {
         totalTokens: 150,
       });
 
-      // Get the internal component and remove primary/fallback to create edge case
+      // Clear the per-model buckets to create the no-model phase edge case
       const components = aggregator.getByComponent();
       const phaseData = components[0].phases['testPhase'];
-      delete (phaseData as any).primary;
-      delete (phaseData as any).fallback;
+      phaseData.primary.clear();
+      phaseData.fallback.clear();
 
       aggregator.logSummary(mockLogger);
 
@@ -482,6 +527,46 @@ describe('LLMTokenUsageAggregator', () => {
       // Should contain Fallback total
       expect(calls).toContainEqual(
         'Fallback total: 200 input, 80 output, 280 total',
+      );
+    });
+
+    test('should log each model on its own line for a multi-model phase', () => {
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'lmstudio/gemma',
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+      });
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'openai/gpt-5-mini',
+        inputTokens: 200,
+        outputTokens: 80,
+        totalTokens: 280,
+      });
+
+      aggregator.logSummary(mockLogger);
+
+      const calls = vi.mocked(mockLogger.info).mock.calls.map((c) => c[0]);
+
+      // Each model is reported on its own primary line.
+      expect(calls).toContainEqual(
+        '      primary (lmstudio/gemma): 100 input, 40 output, 140 total',
+      );
+      expect(calls).toContainEqual(
+        '      primary (openai/gpt-5-mini): 200 input, 80 output, 280 total',
+      );
+      // Phase subtotal still reflects the combined total.
+      expect(calls).toContainEqual(
+        '      subtotal: 300 input, 120 output, 420 total',
+      );
+      expect(calls).toContainEqual(
+        'Primary total: 300 input, 120 output, 420 total',
       );
     });
   });
@@ -669,6 +754,118 @@ describe('LLMTokenUsageAggregator', () => {
       expect(report.components[0].phases[0].metadata).toEqual([
         { pageNo: 1, commandCount: 3 },
       ]);
+    });
+
+    test('should split a multi-model phase into one entry per model', () => {
+      // Invariant relied upon by heripo-web's token-usage emitter, which keys
+      // ledger rows by `${component}|${phase}|${tier}|${modelName}`: a phase
+      // that mixed models must emit multiple entries sharing the phase name,
+      // each carrying a single model, with every (tier, model) appearing
+      // exactly once (no collision, no double count).
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'lmstudio/gemma',
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+      });
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'primary',
+        modelName: 'openai/gpt-5-mini',
+        inputTokens: 200,
+        outputTokens: 80,
+        totalTokens: 280,
+      });
+      aggregator.track({
+        component: 'ReviewAssistance',
+        phase: 'work-item-review',
+        model: 'fallback',
+        modelName: 'openai/gpt-5',
+        inputTokens: 30,
+        outputTokens: 10,
+        totalTokens: 40,
+      });
+
+      const report = aggregator.getReport();
+      const entries = report.components[0].phases;
+
+      // All entries share the same phase name.
+      expect(entries.every((p) => p.phase === 'work-item-review')).toBe(true);
+
+      // Flatten to the 4-tuple keyset the consumer derives.
+      const leaves: Array<{ key: string; totalTokens: number }> = [];
+      for (const entry of entries) {
+        if (entry.primary) {
+          leaves.push({
+            key: `primary|${entry.primary.modelName}`,
+            totalTokens: entry.primary.totalTokens,
+          });
+        }
+        if (entry.fallback) {
+          leaves.push({
+            key: `fallback|${entry.fallback.modelName}`,
+            totalTokens: entry.fallback.totalTokens,
+          });
+        }
+      }
+
+      // No key collision — each (tier, model) appears exactly once.
+      const keys = leaves.map((l) => l.key);
+      expect(new Set(keys).size).toBe(keys.length);
+      expect(new Set(keys)).toEqual(
+        new Set([
+          'primary|lmstudio/gemma',
+          'primary|openai/gpt-5-mini',
+          'fallback|openai/gpt-5',
+        ]),
+      );
+
+      // Summed leaf tokens equal the phase total (no double count, no miss).
+      const summed = leaves.reduce((acc, l) => acc + l.totalTokens, 0);
+      expect(summed).toBe(140 + 280 + 40);
+      expect(report.total.totalTokens).toBe(460);
+    });
+
+    test('should emit a total-only entry for a phase with an unknown tier', () => {
+      // Unknown tier: tokens are tracked but land in neither primary nor
+      // fallback. The phase must still surface as a single total-only entry.
+      aggregator.track({
+        component: 'TestComponent',
+        phase: 'noModelPhase',
+        model: 'unknown' as 'primary' | 'fallback',
+        modelName: 'whatever',
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      });
+      // Same edge, but carrying metadata, to cover the metadata branch.
+      aggregator.track({
+        component: 'TestComponent',
+        phase: 'noModelPhaseWithMeta',
+        model: 'unknown' as 'primary' | 'fallback',
+        modelName: 'whatever',
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        metadata: { note: 'x' },
+      });
+
+      const report = aggregator.getReport();
+      const phases = report.components[0].phases;
+
+      const noModel = phases.find((p) => p.phase === 'noModelPhase');
+      expect(noModel?.primary).toBeUndefined();
+      expect(noModel?.fallback).toBeUndefined();
+      expect(noModel?.total.totalTokens).toBe(150);
+      expect(noModel?.metadata).toBeUndefined();
+
+      const withMeta = phases.find((p) => p.phase === 'noModelPhaseWithMeta');
+      expect(withMeta?.metadata).toEqual([{ note: 'x' }]);
+      expect(withMeta?.total.totalTokens).toBe(15);
     });
   });
 

--- a/packages/shared/src/utils/llm-token-usage-aggregator.ts
+++ b/packages/shared/src/utils/llm-token-usage-aggregator.ts
@@ -21,34 +21,97 @@ function formatTokens(usage: TokenUsage): string {
   return `${usage.inputTokens} input, ${usage.outputTokens} output, ${usage.totalTokens} total`;
 }
 
+interface MutableUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+function emptyUsage(): MutableUsage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+function addInto(target: MutableUsage, src: TokenUsage): void {
+  target.inputTokens += src.inputTokens;
+  target.outputTokens += src.outputTokens;
+  target.totalTokens += src.totalTokens;
+}
+
+function sumUsage(a?: MutableUsage, b?: MutableUsage): MutableUsage {
+  return {
+    inputTokens: (a?.inputTokens ?? 0) + (b?.inputTokens ?? 0),
+    outputTokens: (a?.outputTokens ?? 0) + (b?.outputTokens ?? 0),
+    totalTokens: (a?.totalTokens ?? 0) + (b?.totalTokens ?? 0),
+  };
+}
+
+/**
+ * Accumulate a single LLM call's usage into a per-model bucket.
+ *
+ * Buckets are keyed by `modelName` so that a single (phase, tier) that mixes
+ * several models (e.g. review-assistance `work-item-review` where the `tables`
+ * task uses a different model from the text tasks) keeps each model's tokens —
+ * and therefore each model's cost — distinct instead of collapsing onto the
+ * first model seen.
+ */
+function accumulateModel(
+  bucket: Map<string, MutableUsage>,
+  modelName: string,
+  usage: TokenUsage,
+): void {
+  let entry = bucket.get(modelName);
+  if (!entry) {
+    entry = emptyUsage();
+    bucket.set(modelName, entry);
+  }
+  addInto(entry, usage);
+}
+
+/**
+ * Aggregated token usage for a specific phase.
+ *
+ * `primary` / `fallback` map each model used in this (phase, tier) to its own
+ * accumulated usage. JS `Map` preserves insertion order, so the first model
+ * seen stays first — but every model keeps its own totals.
+ */
+interface PhaseAggregate {
+  primary: Map<string, MutableUsage>;
+  fallback: Map<string, MutableUsage>;
+  total: MutableUsage;
+  metadata: TokenUsageMetadata[];
+}
+
 /**
  * Aggregated token usage for a specific component
  */
 interface ComponentAggregate {
   component: string;
-  phases: Record<
-    string,
-    {
-      primary?: {
-        modelName: string;
-        inputTokens: number;
-        outputTokens: number;
-        totalTokens: number;
-      };
-      fallback?: {
-        modelName: string;
-        inputTokens: number;
-        outputTokens: number;
-        totalTokens: number;
-      };
-      total: {
-        inputTokens: number;
-        outputTokens: number;
-        totalTokens: number;
-      };
-      metadata: TokenUsageMetadata[];
-    }
-  >;
+  phases: Record<string, PhaseAggregate>;
+  total: MutableUsage;
+}
+
+interface ModelUsageReport {
+  modelName: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+interface PhaseReport {
+  phase: string;
+  primary?: ModelUsageReport;
+  fallback?: ModelUsageReport;
+  total: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+  metadata?: TokenUsageMetadata[];
+}
+
+interface ComponentReport {
+  component: string;
+  phases: PhaseReport[];
   total: {
     inputTokens: number;
     outputTokens: number;
@@ -66,7 +129,12 @@ interface ComponentAggregate {
  * Tracks usage by:
  * - Component (TocExtractor, PageRangeParser, etc.)
  * - Phase (extraction, validation, sampling, etc.)
- * - Model (primary vs fallback)
+ * - Model tier (primary vs fallback) AND model name
+ *
+ * A single (phase, tier) may legitimately span multiple model names — e.g.
+ * review-assistance `work-item-review`, where the `tables` work item runs on a
+ * different model from the text work items. Usage is therefore kept per model
+ * so that token totals and downstream cost attribution stay correct for each.
  *
  * @example
  * ```typescript
@@ -98,12 +166,11 @@ interface ComponentAggregate {
  * // Outputs:
  * // [DocumentProcessor] Token usage summary:
  * // TocExtractor:
- * //   - extraction (primary: gpt-5): 1500 input, 300 output, 1800 total
+ * //   - extraction:
+ * //       primary (gpt-5): 1500 input, 300 output, 1800 total
+ * //       subtotal: 1500 input, 300 output, 1800 total
  * //   TocExtractor total: 1500 input, 300 output, 1800 total
- * // PageRangeParser:
- * //   - sampling (fallback: claude-opus-4-5): 2000 input, 100 output, 2100 total
- * //   PageRangeParser total: 2000 input, 100 output, 2100 total
- * // Grand total: 3500 input, 400 output, 3900 total
+ * // ...
  * ```
  */
 export class LLMTokenUsageAggregator {
@@ -120,11 +187,7 @@ export class LLMTokenUsageAggregator {
       this.usage[usage.component] = {
         component: usage.component,
         phases: {},
-        total: {
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        },
+        total: emptyUsage(),
       };
     }
 
@@ -133,11 +196,9 @@ export class LLMTokenUsageAggregator {
     // Initialize phase if not seen before
     if (!component.phases[usage.phase]) {
       component.phases[usage.phase] = {
-        total: {
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        },
+        primary: new Map(),
+        fallback: new Map(),
+        total: emptyUsage(),
         metadata: [],
       };
     }
@@ -147,50 +208,24 @@ export class LLMTokenUsageAggregator {
       phase.metadata.push(usage.metadata);
     }
 
-    // Track by model type
+    // Track by model tier, keyed per model name (set-once misattribution fix)
     if (usage.model === 'primary') {
-      if (!phase.primary) {
-        phase.primary = {
-          modelName: usage.modelName,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        };
-      }
-
-      phase.primary.inputTokens += usage.inputTokens;
-      phase.primary.outputTokens += usage.outputTokens;
-      phase.primary.totalTokens += usage.totalTokens;
+      accumulateModel(phase.primary, usage.modelName, usage);
     } else if (usage.model === 'fallback') {
-      if (!phase.fallback) {
-        phase.fallback = {
-          modelName: usage.modelName,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        };
-      }
-
-      phase.fallback.inputTokens += usage.inputTokens;
-      phase.fallback.outputTokens += usage.outputTokens;
-      phase.fallback.totalTokens += usage.totalTokens;
+      accumulateModel(phase.fallback, usage.modelName, usage);
     }
 
     // Update phase total
-    phase.total.inputTokens += usage.inputTokens;
-    phase.total.outputTokens += usage.outputTokens;
-    phase.total.totalTokens += usage.totalTokens;
+    addInto(phase.total, usage);
 
     // Update component total
-    component.total.inputTokens += usage.inputTokens;
-    component.total.outputTokens += usage.outputTokens;
-    component.total.totalTokens += usage.totalTokens;
+    addInto(component.total, usage);
   }
 
   /**
    * Get aggregated usage grouped by component
    *
-   * @returns Array of component aggregates with phase breakdown
+   * @returns Array of component aggregates with per-model phase breakdown
    */
   getByComponent(): ComponentAggregate[] {
     return Object.values(this.usage);
@@ -200,148 +235,73 @@ export class LLMTokenUsageAggregator {
    * Get token usage report in structured JSON format
    *
    * Converts internal usage data to external TokenUsageReport format suitable
-   * for serialization and reporting. The report includes component breakdown,
-   * phase-level details, and both primary and fallback model usage.
+   * for serialization and reporting.
+   *
+   * Each (phase, model) pair becomes its own PhaseUsageReport entry. A phase
+   * that used a single primary (and/or a single fallback) model yields exactly
+   * one entry — identical to the legacy shape — while a phase that mixed models
+   * yields one entry per model, all sharing the same `phase` name. Every
+   * (phase, tier, modelName) combination appears in exactly one entry, so
+   * consumers that key by `${component}|${phase}|${tier}|${modelName}`
+   * (heripo-web's token-usage emitter / ledger recorder) attribute each model's
+   * tokens — and cost — correctly without double counting.
    *
    * @returns Structured token usage report with components and total
    */
   getReport(): {
-    components: Array<{
-      component: string;
-      phases: Array<{
-        phase: string;
-        primary?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        fallback?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        total: {
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        metadata?: TokenUsageMetadata[];
-      }>;
-      total: {
-        inputTokens: number;
-        outputTokens: number;
-        totalTokens: number;
-      };
-    }>;
+    components: ComponentReport[];
     total: TokenUsage;
   } {
-    const components: Array<{
-      component: string;
-      phases: Array<{
-        phase: string;
-        primary?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        fallback?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        total: {
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-      }>;
-      total: {
-        inputTokens: number;
-        outputTokens: number;
-        totalTokens: number;
-      };
-    }> = [];
+    const components: ComponentReport[] = [];
 
     for (const component of Object.values(this.usage)) {
-      const phases: Array<{
-        phase: string;
-        primary?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        fallback?: {
-          modelName: string;
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        total: {
-          inputTokens: number;
-          outputTokens: number;
-          totalTokens: number;
-        };
-        metadata?: TokenUsageMetadata[];
-      }> = [];
+      const phases: PhaseReport[] = [];
 
       for (const [phaseName, phaseData] of Object.entries(component.phases)) {
-        const phaseReport: {
-          phase: string;
-          primary?: {
-            modelName: string;
-            inputTokens: number;
-            outputTokens: number;
-            totalTokens: number;
-          };
-          fallback?: {
-            modelName: string;
-            inputTokens: number;
-            outputTokens: number;
-            totalTokens: number;
-          };
-          total: {
-            inputTokens: number;
-            outputTokens: number;
-            totalTokens: number;
-          };
-          metadata?: TokenUsageMetadata[];
-        } = {
-          phase: phaseName,
-          total: {
-            inputTokens: phaseData.total.inputTokens,
-            outputTokens: phaseData.total.outputTokens,
-            totalTokens: phaseData.total.totalTokens,
-          },
-        };
+        const primaryEntries = [...phaseData.primary.entries()];
+        const fallbackEntries = [...phaseData.fallback.entries()];
+        const entryCount = Math.max(
+          primaryEntries.length,
+          fallbackEntries.length,
+        );
 
-        if (phaseData.metadata.length > 0) {
-          phaseReport.metadata = [...phaseData.metadata];
+        // Phase tracked tokens but no primary/fallback model (e.g. an unknown
+        // tier). Preserve a single total-only entry so the phase still appears.
+        if (entryCount === 0) {
+          const phaseReport: PhaseReport = {
+            phase: phaseName,
+            total: { ...phaseData.total },
+          };
+          if (phaseData.metadata.length > 0) {
+            phaseReport.metadata = [...phaseData.metadata];
+          }
+          phases.push(phaseReport);
+          continue;
         }
 
-        if (phaseData.primary) {
-          phaseReport.primary = {
-            modelName: phaseData.primary.modelName,
-            inputTokens: phaseData.primary.inputTokens,
-            outputTokens: phaseData.primary.outputTokens,
-            totalTokens: phaseData.primary.totalTokens,
-          };
-        }
+        for (let i = 0; i < entryCount; i++) {
+          const primary = primaryEntries[i];
+          const fallback = fallbackEntries[i];
 
-        if (phaseData.fallback) {
-          phaseReport.fallback = {
-            modelName: phaseData.fallback.modelName,
-            inputTokens: phaseData.fallback.inputTokens,
-            outputTokens: phaseData.fallback.outputTokens,
-            totalTokens: phaseData.fallback.totalTokens,
+          const phaseReport: PhaseReport = {
+            phase: phaseName,
+            total: sumUsage(primary?.[1], fallback?.[1]),
           };
-        }
 
-        phases.push(phaseReport);
+          if (primary) {
+            phaseReport.primary = { modelName: primary[0], ...primary[1] };
+          }
+          if (fallback) {
+            phaseReport.fallback = { modelName: fallback[0], ...fallback[1] };
+          }
+          // Phase-level metadata is not model-specific; attach it once to the
+          // first entry to avoid duplicating it across split entries.
+          if (i === 0 && phaseData.metadata.length > 0) {
+            phaseReport.metadata = [...phaseData.metadata];
+          }
+
+          phases.push(phaseReport);
+        }
       }
 
       components.push({
@@ -393,8 +353,8 @@ export class LLMTokenUsageAggregator {
   /**
    * Log comprehensive token usage summary
    *
-   * Outputs usage grouped by component, with phase and model breakdown.
-   * Shows primary and fallback token usage separately for each phase.
+   * Outputs usage grouped by component, with phase and per-model breakdown.
+   * Shows each primary and fallback model on its own line for each phase.
    * Call this once at the end of document processing.
    *
    * @param logger - Logger instance for output
@@ -413,37 +373,29 @@ export class LLMTokenUsageAggregator {
     let grandInputTokens = 0;
     let grandOutputTokens = 0;
     let grandTotalTokens = 0;
-    let grandPrimaryInputTokens = 0;
-    let grandPrimaryOutputTokens = 0;
-    let grandPrimaryTotalTokens = 0;
-    let grandFallbackInputTokens = 0;
-    let grandFallbackOutputTokens = 0;
-    let grandFallbackTotalTokens = 0;
+    const grandPrimary = emptyUsage();
+    const grandFallback = emptyUsage();
 
     for (const component of components) {
       logger.info(`${component.component}:`);
 
-      for (const [phase, phaseData] of Object.entries(component.phases)) {
-        logger.info(`  - ${phase}:`);
+      for (const [phaseName, phaseData] of Object.entries(component.phases)) {
+        logger.info(`  - ${phaseName}:`);
 
-        // Show primary model usage
-        if (phaseData.primary) {
+        // Show primary model usage (one line per model)
+        for (const [modelName, modelUsage] of phaseData.primary) {
           logger.info(
-            `      primary (${phaseData.primary.modelName}): ${formatTokens(phaseData.primary)}`,
+            `      primary (${modelName}): ${formatTokens(modelUsage)}`,
           );
-          grandPrimaryInputTokens += phaseData.primary.inputTokens;
-          grandPrimaryOutputTokens += phaseData.primary.outputTokens;
-          grandPrimaryTotalTokens += phaseData.primary.totalTokens;
+          addInto(grandPrimary, modelUsage);
         }
 
-        // Show fallback model usage
-        if (phaseData.fallback) {
+        // Show fallback model usage (one line per model)
+        for (const [modelName, modelUsage] of phaseData.fallback) {
           logger.info(
-            `      fallback (${phaseData.fallback.modelName}): ${formatTokens(phaseData.fallback)}`,
+            `      fallback (${modelName}): ${formatTokens(modelUsage)}`,
           );
-          grandFallbackInputTokens += phaseData.fallback.inputTokens;
-          grandFallbackOutputTokens += phaseData.fallback.outputTokens;
-          grandFallbackTotalTokens += phaseData.fallback.totalTokens;
+          addInto(grandFallback, modelUsage);
         }
 
         // Show phase subtotal
@@ -462,23 +414,11 @@ export class LLMTokenUsageAggregator {
 
     // Show grand total with primary/fallback breakdown
     logger.info('--- Summary ---');
-    if (grandPrimaryTotalTokens > 0) {
-      logger.info(
-        `Primary total: ${formatTokens({
-          inputTokens: grandPrimaryInputTokens,
-          outputTokens: grandPrimaryOutputTokens,
-          totalTokens: grandPrimaryTotalTokens,
-        })}`,
-      );
+    if (grandPrimary.totalTokens > 0) {
+      logger.info(`Primary total: ${formatTokens(grandPrimary)}`);
     }
-    if (grandFallbackTotalTokens > 0) {
-      logger.info(
-        `Fallback total: ${formatTokens({
-          inputTokens: grandFallbackInputTokens,
-          outputTokens: grandFallbackOutputTokens,
-          totalTokens: grandFallbackTotalTokens,
-        })}`,
-      );
+    if (grandFallback.totalTokens > 0) {
+      logger.info(`Fallback total: ${formatTokens(grandFallback)}`);
     }
     logger.info(
       `Grand total: ${formatTokens({


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [x] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR fixes token usage attribution when a single phase uses multiple model names within the same primary or fallback tier. Previously, `LLMTokenUsageAggregator` collapsed all usage onto the first model seen for that phase, which kept token totals correct but produced incorrect model and cost attribution.

## Changes

- Updated `LLMTokenUsageAggregator.track()` to aggregate primary and fallback usage by `modelName` within each phase.
- Added per-model phase bucket helpers in `llm-token-usage-aggregator.ts`, including `emptyUsage()`, `addInto()`, `sumUsage()`, and `accumulateModel()`.
- Updated `getReport()` to emit one phase report entry per `(phase, tier, modelName)` combination while preserving total-only entries for unknown tiers.
- Updated `logSummary()` to print each model on its own primary or fallback line and calculate grand primary/fallback totals from per-model buckets.
- Expanded `llm-token-usage-aggregator.test.ts` with regression coverage for mixed-model phases, split report entries, total-only unknown-tier phases, and multi-model summary logging.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #