### PR TITLE
feat(demo-web): run text correction with local fallback

### DIFF
--- a/apps/demo-web/src/features/upload/components/advanced-options-card.tsx
+++ b/apps/demo-web/src/features/upload/components/advanced-options-card.tsx
@@ -85,6 +85,12 @@ interface AdvancedOptionsCardProps {
 
 const NONE_VALUE = '__none__';
 
+// Review-assistance correction is disabled in the demo — only the text-correction
+// stage runs (see `reviewAssistanceEnabled: false` in task-worker.ts). Its UI
+// controls (review-task models, table correction, review/table concurrency,
+// per-stage retry overrides) are hidden behind this flag; flip to re-expose them.
+const REVIEW_ASSISTANCE_UI: boolean = false;
+
 const MODELS_BY_PROVIDER = LLM_MODELS.reduce(
   (acc, model) => {
     if (!acc[model.provider]) {
@@ -316,124 +322,136 @@ export function AdvancedOptionsCard({
         <CardDescription>Batch processing and retry settings</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-3">
-          <label className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-            Correction Models
-          </label>
-          <form.Field name="correction.models.tableCorrection">
-            {(field: OptionalStringFieldApi) => (
-              <VisionModelSelect
-                label="Table Correction"
-                description="Overrides the tables task model for table-specific correction"
-                value={field.state.value}
-                onChange={field.handleChange}
-                disabled={disabled}
-              />
-            )}
-          </form.Field>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {REVIEW_TASK_MODEL_FIELDS.map((config) => (
-              <form.Field key={config.name} name={config.name}>
+        {REVIEW_ASSISTANCE_UI && (
+          <>
+            <div className="space-y-3">
+              <label className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Correction Models
+              </label>
+              <form.Field name="correction.models.tableCorrection">
                 {(field: OptionalStringFieldApi) => (
                   <VisionModelSelect
-                    label={config.label}
-                    description="Optional model override for this review task"
+                    label="Table Correction"
+                    description="Overrides the tables task model for table-specific correction"
                     value={field.state.value}
                     onChange={field.handleChange}
                     disabled={disabled}
                   />
                 )}
               </form.Field>
-            ))}
-          </div>
-        </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {REVIEW_TASK_MODEL_FIELDS.map((config) => (
+                  <form.Field key={config.name} name={config.name}>
+                    {(field: OptionalStringFieldApi) => (
+                      <VisionModelSelect
+                        label={config.label}
+                        description="Optional model override for this review task"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        disabled={disabled}
+                      />
+                    )}
+                  </form.Field>
+                ))}
+              </div>
+            </div>
 
-        <div className="bg-border h-px" />
+            <div className="bg-border h-px" />
 
-        <div className="space-y-3">
-          <label className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-            Correction Concurrency
-          </label>
-          <div className="grid gap-3">
-            <form.Field name="correction.concurrency.reviewTasks">
-              {(field: NumberFieldApi) => (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">Review Tasks</span>
-                  <SelectWithTooltip
-                    value={String(field.state.value)}
-                    onValueChange={(v) => field.handleChange(parseInt(v, 10))}
-                    disabled={disabled}
-                    className="w-20"
-                    options={[
-                      { value: '1', label: '1' },
-                      { value: '2', label: '2' },
-                      { value: '3', label: '3' },
-                      { value: '6', label: '6' },
-                    ]}
-                  />
-                </div>
-              )}
-            </form.Field>
-            <form.Field name="correction.concurrency.tables">
-              {(field: NumberFieldApi) => (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">Tables</span>
-                  <SelectWithTooltip
-                    value={String(field.state.value)}
-                    onValueChange={(v) => field.handleChange(parseInt(v, 10))}
-                    disabled={disabled}
-                    className="w-20"
-                    options={[
-                      { value: '1', label: '1' },
-                      { value: '2', label: '2' },
-                      { value: '4', label: '4' },
-                      { value: '8', label: '8' },
-                    ]}
-                  />
-                </div>
-              )}
-            </form.Field>
-            <form.Field name="correction.modelConcurrency">
-              {(field: OptionalNumberFieldApi) => (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">Local Work Items</span>
-                  <SelectWithTooltip
-                    value={String(field.state.value ?? 1)}
-                    onValueChange={(v) => field.handleChange(parseInt(v, 10))}
-                    disabled={disabled}
-                    className="w-20"
-                    options={[
-                      { value: '1', label: '1' },
-                      { value: '2', label: '2' },
-                      { value: '3', label: '3' },
-                      { value: '4', label: '4' },
-                    ]}
-                  />
-                </div>
-              )}
-            </form.Field>
-            <form.Field name="correction.workItemTimeoutMs">
-              {(field: OptionalNumberFieldApi) => (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm">Work Item Timeout</span>
-                  <SelectWithTooltip
-                    value={String(field.state.value ?? 1_800_000)}
-                    onValueChange={(v) => field.handleChange(parseInt(v, 10))}
-                    disabled={disabled}
-                    className="w-28"
-                    options={[
-                      { value: '600000', label: '10 min' },
-                      { value: '1800000', label: '30 min' },
-                      { value: '3600000', label: '60 min' },
-                    ]}
-                  />
-                </div>
-              )}
-            </form.Field>
-          </div>
-        </div>
+            <div className="space-y-3">
+              <label className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                Correction Concurrency
+              </label>
+              <div className="grid gap-3">
+                <form.Field name="correction.concurrency.reviewTasks">
+                  {(field: NumberFieldApi) => (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">Review Tasks</span>
+                      <SelectWithTooltip
+                        value={String(field.state.value)}
+                        onValueChange={(v) =>
+                          field.handleChange(parseInt(v, 10))
+                        }
+                        disabled={disabled}
+                        className="w-20"
+                        options={[
+                          { value: '1', label: '1' },
+                          { value: '2', label: '2' },
+                          { value: '3', label: '3' },
+                          { value: '6', label: '6' },
+                        ]}
+                      />
+                    </div>
+                  )}
+                </form.Field>
+                <form.Field name="correction.concurrency.tables">
+                  {(field: NumberFieldApi) => (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">Tables</span>
+                      <SelectWithTooltip
+                        value={String(field.state.value)}
+                        onValueChange={(v) =>
+                          field.handleChange(parseInt(v, 10))
+                        }
+                        disabled={disabled}
+                        className="w-20"
+                        options={[
+                          { value: '1', label: '1' },
+                          { value: '2', label: '2' },
+                          { value: '4', label: '4' },
+                          { value: '8', label: '8' },
+                        ]}
+                      />
+                    </div>
+                  )}
+                </form.Field>
+                <form.Field name="correction.modelConcurrency">
+                  {(field: OptionalNumberFieldApi) => (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">Local Work Items</span>
+                      <SelectWithTooltip
+                        value={String(field.state.value ?? 1)}
+                        onValueChange={(v) =>
+                          field.handleChange(parseInt(v, 10))
+                        }
+                        disabled={disabled}
+                        className="w-20"
+                        options={[
+                          { value: '1', label: '1' },
+                          { value: '2', label: '2' },
+                          { value: '3', label: '3' },
+                          { value: '4', label: '4' },
+                        ]}
+                      />
+                    </div>
+                  )}
+                </form.Field>
+                <form.Field name="correction.workItemTimeoutMs">
+                  {(field: OptionalNumberFieldApi) => (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm">Work Item Timeout</span>
+                      <SelectWithTooltip
+                        value={String(field.state.value ?? 1_800_000)}
+                        onValueChange={(v) =>
+                          field.handleChange(parseInt(v, 10))
+                        }
+                        disabled={disabled}
+                        className="w-28"
+                        options={[
+                          { value: '600000', label: '10 min' },
+                          { value: '1800000', label: '30 min' },
+                          { value: '3600000', label: '60 min' },
+                        ]}
+                      />
+                    </div>
+                  )}
+                </form.Field>
+              </div>
+            </div>
 
-        <div className="bg-border h-px" />
+            <div className="bg-border h-px" />
+          </>
+        )}
 
         {/* Batch Sizes */}
         <div className="space-y-3">
@@ -555,7 +573,11 @@ export function AdvancedOptionsCard({
             inherit to use the global value above.
           </p>
           <div className="grid gap-3">
-            {CORRECTION_RETRY_FIELDS.map((config) => (
+            {CORRECTION_RETRY_FIELDS.filter(
+              (config) =>
+                REVIEW_ASSISTANCE_UI ||
+                config.name === 'correction.maxRetries.textCorrection',
+            ).map((config) => (
               <form.Field key={config.name} name={config.name}>
                 {(field: OptionalNumberFieldApi) => (
                   <div className="flex items-center justify-between">

--- a/apps/demo-web/src/features/upload/components/processing-options-card.tsx
+++ b/apps/demo-web/src/features/upload/components/processing-options-card.tsx
@@ -52,6 +52,11 @@ interface OptionalStringFieldApi {
 
 const NONE_VALUE = '__none__';
 
+// Review-assistance correction is disabled in the demo — only the text-correction
+// stage runs (see `reviewAssistanceEnabled: false` in task-worker.ts). Its UI
+// controls are hidden behind this flag; flip to true to re-expose them.
+const REVIEW_ASSISTANCE_UI: boolean = false;
+
 /**
  * Group models by provider for select dropdown
  */
@@ -263,29 +268,33 @@ export function ProcessingOptionsCard({
           )}
         </form.Field>
 
-        <form.Field name="correction.models.pageGate">
-          {(field: StringFieldApi) => (
-            <VisionModelSelect
-              label="Page Gate Model"
-              description="Classifies pages for structural review noise control"
-              value={field.state.value}
-              onChange={(value) => value && field.handleChange(value)}
-              disabled={disabled}
-            />
-          )}
-        </form.Field>
+        {REVIEW_ASSISTANCE_UI && (
+          <>
+            <form.Field name="correction.models.pageGate">
+              {(field: StringFieldApi) => (
+                <VisionModelSelect
+                  label="Page Gate Model"
+                  description="Classifies pages for structural review noise control"
+                  value={field.state.value}
+                  onChange={(value) => value && field.handleChange(value)}
+                  disabled={disabled}
+                />
+              )}
+            </form.Field>
 
-        <form.Field name="correction.models.reviewAssistance">
-          {(field: StringFieldApi) => (
-            <VisionModelSelect
-              label="Review Assistance Model"
-              description="Runs structural review tasks for eligible pages"
-              value={field.state.value}
-              onChange={(value) => value && field.handleChange(value)}
-              disabled={disabled}
-            />
-          )}
-        </form.Field>
+            <form.Field name="correction.models.reviewAssistance">
+              {(field: StringFieldApi) => (
+                <VisionModelSelect
+                  label="Review Assistance Model"
+                  description="Runs structural review tasks for eligible pages"
+                  value={field.state.value}
+                  onChange={(value) => value && field.handleChange(value)}
+                  disabled={disabled}
+                />
+              )}
+            </form.Field>
+          </>
+        )}
 
         {/* Document Validation Model */}
         <form.Field name="documentValidationModel">
@@ -349,6 +358,7 @@ export function ProcessingOptionsCard({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="1">1 (sequential)</SelectItem>
+                    <SelectItem value="2">2 concurrent</SelectItem>
                     <SelectItem value="3">3 concurrent</SelectItem>
                     <SelectItem value="5">5 concurrent</SelectItem>
                     <SelectItem value="10">10 concurrent</SelectItem>
@@ -361,34 +371,36 @@ export function ProcessingOptionsCard({
           )}
         </form.Field>
 
-        <form.Field name="correction.outputLanguage">
-          {(field: StringFieldApi) => (
-            <div className="space-y-2">
-              <label className="text-sm font-medium">
-                Correction Output Language
-              </label>
-              <p className="text-muted-foreground text-xs">
-                Language of AI-written reasons, descriptions, and issues in the
-                correction report (BCP 47 tag)
-              </p>
-              <DisabledWrapper disabled={disabled}>
-                <Select
-                  value={field.state.value}
-                  onValueChange={(v) => field.handleChange(v)}
-                  disabled={disabled}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select language" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ko-KR">한국어 (ko-KR)</SelectItem>
-                    <SelectItem value="en-US">English (en-US)</SelectItem>
-                  </SelectContent>
-                </Select>
-              </DisabledWrapper>
-            </div>
-          )}
-        </form.Field>
+        {REVIEW_ASSISTANCE_UI && (
+          <form.Field name="correction.outputLanguage">
+            {(field: StringFieldApi) => (
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Correction Output Language
+                </label>
+                <p className="text-muted-foreground text-xs">
+                  Language of AI-written reasons, descriptions, and issues in
+                  the correction report (BCP 47 tag)
+                </p>
+                <DisabledWrapper disabled={disabled}>
+                  <Select
+                    value={field.state.value}
+                    onValueChange={(v) => field.handleChange(v)}
+                    disabled={disabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select language" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ko-KR">한국어 (ko-KR)</SelectItem>
+                      <SelectItem value="en-US">English (en-US)</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </DisabledWrapper>
+              </div>
+            )}
+          </form.Field>
+        )}
 
         {/* Force Image PDF */}
         <form.Field name="forceImagePdf">

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -26,13 +26,16 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // Mandatory post-Docling correction.
-  // NOTE: demo-web defaults assume cloud VLMs (Gemini, OpenAI) where higher
-  // page concurrency is safe. For local models prefer a smaller value
-  // (the pdf-parser library default is 1) to keep GPU/memory usage bounded —
-  // see Phase D in docs/plans/pdf-parser-correction-gating.md.
+  // NOTE: review assistance (the structural correction logic) is disabled for
+  // the demo — only the text-correction stage runs (see `reviewAssistanceEnabled:
+  // false` in task-worker.ts). Accordingly, only `textCorrection` uses a local
+  // model (LM Studio gemma 26b) with a cloud fallback so it still completes if
+  // the local model fails; every other slot stays on the original cloud models
+  // and is inert while review assistance is off.
   correction: {
     models: {
-      textCorrection: 'google/gemini-3.1-flash-lite',
+      textCorrection: 'lmstudio/gemma-4-26b-a4b-it-mlx',
+      textCorrectionFallback: 'openai/gpt-5.4',
       pageGate: 'google/gemini-3.1-flash-lite',
       reviewAssistance: 'google/gemini-3.1-flash-lite',
       tableCorrection: 'openai/gpt-5-mini',
@@ -46,13 +49,13 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
       },
     },
     concurrency: {
-      pages: 10,
+      pages: 2,
       reviewTasks: 6,
       tables: 1,
     },
     outputLanguage: 'ko-KR',
     maxRetries: undefined,
-    modelConcurrency: 5,
+    modelConcurrency: 3,
     workItemTimeoutMs: 1_800_000,
   },
   // LLM Models

--- a/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
+++ b/apps/demo-web/src/lib/queue/pdf-parser-manager.ts
@@ -3,12 +3,27 @@ import type { LoggerMethods } from '@heripo/logger';
 import { Logger } from '@heripo/logger';
 import { PDFParser } from '@heripo/pdf-parser';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import { execFile } from 'node:child_process';
+import net from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 
 import { TaskQueueManager } from './task-queue-manager';
 
+const execFileAsync = promisify(execFile);
+
+// Lower bound of the Docling port scan. We never reuse a pre-existing Docling
+// server (e.g. an orphan left by a previous run); each server start picks the
+// first *free* port at or above this and spins up a fresh Docling there.
 const PDF_PARSER_PORT = parseInt(process.env.PDF_PARSER_PORT || '5001', 10);
+// Upper bound of the scan. The range can overlap common dev services (e.g. Vite
+// 5173, Postgres 5432), but the probe is skip-only — occupied ports are skipped,
+// never reused and never killed — so scanning across them is safe.
+const PDF_PARSER_PORT_SCAN_END = Math.max(
+  PDF_PARSER_PORT,
+  parseInt(process.env.PDF_PARSER_PORT_MAX || '5999', 10),
+);
 const PDF_PARSER_TIMEOUT = parseInt(
   process.env.PDF_PARSER_TIMEOUT || '10000000',
   10,
@@ -16,6 +31,58 @@ const PDF_PARSER_TIMEOUT = parseInt(
 const PDF_PARSER_VENV_PATH =
   process.env.PDF_PARSER_VENV_PATH ||
   join(homedir(), '.heripo', 'pdf-parser-venv');
+
+/**
+ * Resolve whether a TCP port is free to bind on localhost. Skip-only probe — it
+ * never touches whatever is already listening, so it is safe to run across a
+ * range that may include other services.
+ */
+function isPortFree(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = net
+      .createServer()
+      .once('error', () => resolve(false))
+      .once('listening', () => {
+        tester.close(() => resolve(true));
+      })
+      .listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Find the first free port in [start, end] so a fresh Docling server can bind
+ * it. Existing/occupied ports are skipped, never reused and never killed.
+ */
+async function findFreeDoclingPort(
+  start: number,
+  end: number,
+): Promise<number> {
+  for (let port = start; port <= end; port++) {
+    if (await isPortFree(port)) return port;
+  }
+  throw new Error(
+    `No free Docling port available in range ${start}-${end}. ` +
+      'Close some processes in this range or raise PDF_PARSER_PORT_MAX.',
+  );
+}
+
+/**
+ * Best-effort lookup of the PID listening on a port (macOS `lsof`). Used only
+ * for log observability so a stuck server can be identified; failures are
+ * swallowed.
+ */
+async function findListeningPid(port: number): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('lsof', [
+      '-ti',
+      `tcp:${port}`,
+      '-sTCP:LISTEN',
+    ]);
+    return stdout.trim().split('\n')[0] || null;
+  } catch {
+    return null;
+  }
+}
 
 type PDFParserStatus =
   | 'ready'
@@ -31,6 +98,7 @@ class PDFParserManager {
   private readinessPromise: Promise<void> | null = null;
   private initialized = false;
   private isShuttingDown = false;
+  private activePort: number | null = null;
 
   // Task-specific loggers for forwarding PDF parser logs to frontend
   private taskLoggers: Map<string, LoggerMethods> = new Map();
@@ -172,9 +240,23 @@ class PDFParserManager {
     );
 
     try {
+      // Always start a fresh Docling on the first free port in the scan range —
+      // never reuse a pre-existing/orphaned server. killExistingProcess stays
+      // false because the chosen port is already free (so there is no bind race
+      // from killing a process mid-startup).
+      const port = await findFreeDoclingPort(
+        PDF_PARSER_PORT,
+        PDF_PARSER_PORT_SCAN_END,
+      );
+      this.activePort = port;
+      logger.info(
+        `[PDFParserManager] Starting a fresh Docling server on free port ${port} ` +
+          `(scanned ${PDF_PARSER_PORT}-${PDF_PARSER_PORT_SCAN_END}; existing servers are never reused)`,
+      );
+
       this.parser = new PDFParser({
         logger,
-        port: PDF_PARSER_PORT,
+        port,
         timeout: PDF_PARSER_TIMEOUT,
         venvPath: PDF_PARSER_VENV_PATH,
         killExistingProcess: false,
@@ -184,11 +266,16 @@ class PDFParserManager {
       await this.parser.init();
 
       this.initialized = true;
-      logger.info('[PDFParserManager] PDFParser initialized successfully');
+      const pid = await findListeningPid(port);
+      logger.info(
+        `[PDFParserManager] Docling server ready on port ${port}` +
+          (pid ? ` (pid ${pid})` : ''),
+      );
     } catch (error) {
       this.parser = null;
       this.initPromise = null;
       this.initialized = false;
+      this.activePort = null;
       logger.error(
         '[PDFParserManager] PDFParser initialization failed:',
         error,
@@ -214,11 +301,14 @@ class PDFParserManager {
 
       this.isShuttingDown = true;
 
-      console.log('[PDFParserManager] Shutting down...');
+      console.log(
+        `[PDFParserManager] Shutting down Docling server${this.activePort ? ` on port ${this.activePort}` : ''}...`,
+      );
       if (this.parser) {
         await this.parser.dispose();
         this.parser = null;
       }
+      this.activePort = null;
       console.log('[PDFParserManager] Shutdown complete');
     };
 

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -195,53 +195,83 @@ function calculateTotalCost(usage: TokenUsageReport): number {
   return Math.round(total * 1_000_000) / 1_000_000;
 }
 
-function buildPDFCorrectionOptions(
-  options: QueuedTask['options'],
-): PDFConvertOptions['correction'] {
-  const taskModels = options.correction.models.reviewAssistanceTasks;
-  const reviewAssistanceTasks: NonNullable<
+type ReviewAssistanceTaskModelIds =
+  QueuedTask['options']['correction']['models']['reviewAssistanceTasks'];
+
+/**
+ * Resolve a per-task review-assistance model map (primary or fallback) into
+ * `LanguageModel` instances. Tasks without an id are skipped.
+ */
+function buildReviewAssistanceTaskModels(
+  taskModels: ReviewAssistanceTaskModelIds,
+): NonNullable<
+  PDFConvertOptions['correction']['models']['reviewAssistanceTasks']
+> {
+  const resolved: NonNullable<
     PDFConvertOptions['correction']['models']['reviewAssistanceTasks']
   > = {};
 
   if (taskModels?.textOcrHanja) {
-    reviewAssistanceTasks.text_ocr_hanja = createModel(taskModels.textOcrHanja);
+    resolved.text_ocr_hanja = createModel(taskModels.textOcrHanja);
   }
   if (taskModels?.textIntegrity) {
-    reviewAssistanceTasks.text_integrity = createModel(
-      taskModels.textIntegrity,
-    );
+    resolved.text_integrity = createModel(taskModels.textIntegrity);
   }
   if (taskModels?.textRoleFootnote) {
-    reviewAssistanceTasks.text_role_footnote = createModel(
-      taskModels.textRoleFootnote,
-    );
+    resolved.text_role_footnote = createModel(taskModels.textRoleFootnote);
   }
   if (taskModels?.tables) {
-    reviewAssistanceTasks.tables = createModel(taskModels.tables);
+    resolved.tables = createModel(taskModels.tables);
   }
   if (taskModels?.picturesCaptions) {
-    reviewAssistanceTasks.pictures_captions = createModel(
-      taskModels.picturesCaptions,
-    );
+    resolved.pictures_captions = createModel(taskModels.picturesCaptions);
   }
   if (taskModels?.layoutBboxOrder) {
-    reviewAssistanceTasks.layout_bbox_order = createModel(
-      taskModels.layoutBboxOrder,
-    );
+    resolved.layout_bbox_order = createModel(taskModels.layoutBboxOrder);
   }
+
+  return resolved;
+}
+
+function buildPDFCorrectionOptions(
+  options: QueuedTask['options'],
+): PDFConvertOptions['correction'] {
+  const models = options.correction.models;
+  const reviewAssistanceTasks = buildReviewAssistanceTaskModels(
+    models.reviewAssistanceTasks,
+  );
+  const reviewAssistanceTasksFallback = buildReviewAssistanceTaskModels(
+    models.reviewAssistanceTasksFallback,
+  );
 
   const stageRetries = options.correction.maxRetries;
   const correction: PDFConvertOptions['correction'] = {
     models: {
-      textCorrection: createModel(options.correction.models.textCorrection),
-      pageGate: createModel(options.correction.models.pageGate),
-      reviewAssistance: createModel(options.correction.models.reviewAssistance),
-      tableCorrection: options.correction.models.tableCorrection
-        ? createModel(options.correction.models.tableCorrection)
+      textCorrection: createModel(models.textCorrection),
+      textCorrectionFallback: models.textCorrectionFallback
+        ? createModel(models.textCorrectionFallback)
+        : undefined,
+      pageGate: createModel(models.pageGate),
+      pageGateFallback: models.pageGateFallback
+        ? createModel(models.pageGateFallback)
+        : undefined,
+      reviewAssistance: createModel(models.reviewAssistance),
+      reviewAssistanceFallback: models.reviewAssistanceFallback
+        ? createModel(models.reviewAssistanceFallback)
+        : undefined,
+      tableCorrection: models.tableCorrection
+        ? createModel(models.tableCorrection)
+        : undefined,
+      tableCorrectionFallback: models.tableCorrectionFallback
+        ? createModel(models.tableCorrectionFallback)
         : undefined,
       reviewAssistanceTasks:
         Object.keys(reviewAssistanceTasks).length > 0
           ? reviewAssistanceTasks
+          : undefined,
+      reviewAssistanceTasksFallback:
+        Object.keys(reviewAssistanceTasksFallback).length > 0
+          ? reviewAssistanceTasksFallback
           : undefined,
     },
     concurrency: options.correction.concurrency,
@@ -254,9 +284,12 @@ function buildPDFCorrectionOptions(
       tableCorrection: stageRetries?.tableCorrection ?? options.maxRetries,
     },
     outputLanguage: options.correction.outputLanguage,
-    // Demo runs have no human reviewer, so auto-apply every valid correction
-    // (tables, low-confidence proposals, structural edits) into the output
-    // instead of routing them to the backoffice "대기 / proposal" queue.
+    // Demo runs the text-correction stage only — the review-assistance stage
+    // (per-page eligibility gate + structural correction runner) is skipped.
+    reviewAssistanceEnabled: false,
+    // Only relevant when review assistance is enabled: demo runs have no human
+    // reviewer, so every valid command would auto-apply instead of routing to a
+    // proposal queue. Kept for when review assistance is re-enabled.
     forceAutoApply: true,
   };
   return correction;
@@ -415,6 +448,13 @@ export async function runTaskWorker(
       ...(options.languageDetectionModel
         ? {
             languageDetectionModel: createModel(options.languageDetectionModel),
+            ...(options.languageDetectionFallbackModel
+              ? {
+                  languageDetectionFallbackModel: createModel(
+                    options.languageDetectionFallbackModel,
+                  ),
+                }
+              : {}),
           }
         : {}),
       ...(isPublicMode && !task.isOtpBypass && options.documentValidationModel

--- a/apps/demo-web/src/lib/validations/schemas/task.ts
+++ b/apps/demo-web/src/lib/validations/schemas/task.ts
@@ -41,12 +41,21 @@ const correctionMaxRetriesSchema = z
   .optional();
 
 const correctionOptionsSchema = z.object({
+  // Each correction slot can take a local primary model with a cloud fallback
+  // (mirrors heripo-web's backoffice config). The `*Fallback` ids are carried
+  // as defaults in DEFAULT_FORM_VALUES; the UI does not expose them, so they
+  // round-trip through `JSON.stringify(options)` without a dedicated selector.
   models: z.object({
     textCorrection: llmModelSchema,
+    textCorrectionFallback: llmModelSchema.optional(),
     pageGate: llmModelSchema,
+    pageGateFallback: llmModelSchema.optional(),
     reviewAssistance: llmModelSchema,
+    reviewAssistanceFallback: llmModelSchema.optional(),
     tableCorrection: llmModelSchema.optional(),
+    tableCorrectionFallback: llmModelSchema.optional(),
     reviewAssistanceTasks: correctionTaskModelSchema,
+    reviewAssistanceTasksFallback: correctionTaskModelSchema,
   }),
   concurrency: z
     .object({
@@ -76,8 +85,9 @@ export const processingOptionsSchema = z.object({
   // Document type validation
   documentValidationModel: llmModelSchema.optional(),
 
-  // PDF language detection for OCR language hints
+  // PDF language detection for OCR language hints (local primary + cloud fallback)
   languageDetectionModel: llmModelSchema.optional(),
+  languageDetectionFallbackModel: llmModelSchema.optional(),
 
   // Force image PDF pre-conversion
   forceImagePdf: z.boolean().default(false),

--- a/packages/pdf-parser/src/core/correction-options.test.ts
+++ b/packages/pdf-parser/src/core/correction-options.test.ts
@@ -106,4 +106,15 @@ describe('normalizePDFCorrectionOptions', () => {
     expect(above.temperature).toBe(2);
     expect(below.temperature).toBe(0);
   });
+
+  test('defaults reviewAssistanceEnabled to true and honors an explicit value', () => {
+    expect(
+      normalizePDFCorrectionOptions(correction()).reviewAssistanceEnabled,
+    ).toBe(true);
+    expect(
+      normalizePDFCorrectionOptions(
+        correction({ reviewAssistanceEnabled: false }),
+      ).reviewAssistanceEnabled,
+    ).toBe(false);
+  });
 });

--- a/packages/pdf-parser/src/core/correction-options.ts
+++ b/packages/pdf-parser/src/core/correction-options.ts
@@ -59,6 +59,12 @@ export interface PDFCorrectionOptions {
    * Enabled by the engine demo; defaults to false everywhere else.
    */
   forceAutoApply?: boolean;
+  /**
+   * When false, the review-assistance stage (the per-page eligibility gate plus
+   * the structural review-assistance runner) is skipped entirely and only the
+   * text-correction stage runs. Defaults to true.
+   */
+  reviewAssistanceEnabled?: boolean;
   temperature?: number;
 }
 
@@ -73,6 +79,7 @@ export interface NormalizedPDFCorrectionOptions {
   autoApplyThreshold: number;
   proposalThreshold: number;
   forceAutoApply: boolean;
+  reviewAssistanceEnabled: boolean;
   temperature: number;
 }
 
@@ -100,6 +107,7 @@ export const PDF_CORRECTION_DEFAULTS: Omit<
   autoApplyThreshold: 0.85,
   proposalThreshold: 0.5,
   forceAutoApply: false,
+  reviewAssistanceEnabled: true,
   temperature: 0,
 };
 
@@ -236,6 +244,9 @@ export function normalizePDFCorrectionOptions(
     proposalThreshold,
     forceAutoApply:
       value.forceAutoApply ?? PDF_CORRECTION_DEFAULTS.forceAutoApply,
+    reviewAssistanceEnabled:
+      value.reviewAssistanceEnabled ??
+      PDF_CORRECTION_DEFAULTS.reviewAssistanceEnabled,
     temperature: normalizeTemperature(
       value.temperature,
       PDF_CORRECTION_DEFAULTS.temperature,

--- a/packages/pdf-parser/src/core/post-docling-correction-pipeline.test.ts
+++ b/packages/pdf-parser/src/core/post-docling-correction-pipeline.test.ts
@@ -172,6 +172,28 @@ describe('PostDoclingCorrectionPipeline', () => {
     expect(originalCallback).toHaveBeenCalledWith('/test/output');
   });
 
+  test('skips review assistance and the page gate when reviewAssistanceEnabled is false', async () => {
+    const originalCallback = vi.fn();
+
+    const wrapped = pipeline.wrapCallback(
+      '/tmp/test.pdf',
+      'report-1',
+      correctionOptions({ reviewAssistanceEnabled: false }),
+      originalCallback,
+    );
+
+    await wrapped('/test/output');
+
+    expect(mockPageProcessorInstance.correctAndSave).toHaveBeenCalledWith(
+      '/test/output',
+      textCorrectionModel,
+      expect.objectContaining({ reviewAssistanceGate: undefined }),
+    );
+    expect(ReviewAssistanceRunner).not.toHaveBeenCalled();
+    expect(mockRunnerInstance.analyzeAndSave).not.toHaveBeenCalled();
+    expect(originalCallback).toHaveBeenCalledWith('/test/output');
+  });
+
   test('extracts PDF text references and passes them to both correction stages', async () => {
     const pageTexts = new Map([[1, 'extracted text']]);
     mockTextExtractorInstance.extractText.mockResolvedValue(pageTexts);

--- a/packages/pdf-parser/src/core/post-docling-correction-pipeline.ts
+++ b/packages/pdf-parser/src/core/post-docling-correction-pipeline.ts
@@ -53,45 +53,52 @@ export class PostDoclingCorrectionPipeline {
           onTokenUsage: options.onTokenUsage,
           documentLanguages: options.ocr_lang,
           pageTexts,
-          reviewAssistanceGate: {
-            model: correction.models.pageGate,
-            fallback: correction.models.pageGateFallback,
-            maxRetries: correction.maxRetries.pageGate,
-            temperature: correction.temperature,
-            outputLanguage: correction.outputLanguage,
-          },
+          // When review assistance is disabled, omit the gate entirely so the
+          // per-page eligibility checks (pageGate LLM calls + sidecar report)
+          // never run — only text correction executes.
+          reviewAssistanceGate: correction.reviewAssistanceEnabled
+            ? {
+                model: correction.models.pageGate,
+                fallback: correction.models.pageGateFallback,
+                maxRetries: correction.maxRetries.pageGate,
+                temperature: correction.temperature,
+                outputLanguage: correction.outputLanguage,
+              }
+            : undefined,
         },
       );
 
-      const runner = new ReviewAssistanceRunner(this.logger);
-      await runner.analyzeAndSave(
-        outputDir,
-        reportId,
-        this.buildReviewAssistanceModelResolver(correction),
-        {
-          pdfPath,
-          pageTexts,
-          pageGateModel: correction.models.pageGate,
-          pageGateFallback: correction.models.pageGateFallback,
-          pageGateMaxRetries: correction.maxRetries.pageGate,
-          pageGateTemperature: correction.temperature,
-          pageConcurrency: correction.concurrency.pages,
-          taskConcurrency: correction.concurrency.reviewTasks,
-          modelConcurrency: correction.modelConcurrency,
-          workItemTimeoutMs: correction.workItemTimeoutMs,
-          autoApplyThreshold: correction.autoApplyThreshold,
-          proposalThreshold: correction.proposalThreshold,
-          forceAutoApply: correction.forceAutoApply,
-          maxRetries: correction.maxRetries.reviewAssistance,
-          tableMaxRetries: correction.maxRetries.tableCorrection,
-          temperature: correction.temperature,
-          outputLanguage: correction.outputLanguage,
-          aggregator: options.aggregator,
-          abortSignal,
-          onTokenUsage: options.onTokenUsage,
-          onProgress: options.onReviewAssistanceProgress,
-        },
-      );
+      if (correction.reviewAssistanceEnabled) {
+        const runner = new ReviewAssistanceRunner(this.logger);
+        await runner.analyzeAndSave(
+          outputDir,
+          reportId,
+          this.buildReviewAssistanceModelResolver(correction),
+          {
+            pdfPath,
+            pageTexts,
+            pageGateModel: correction.models.pageGate,
+            pageGateFallback: correction.models.pageGateFallback,
+            pageGateMaxRetries: correction.maxRetries.pageGate,
+            pageGateTemperature: correction.temperature,
+            pageConcurrency: correction.concurrency.pages,
+            taskConcurrency: correction.concurrency.reviewTasks,
+            modelConcurrency: correction.modelConcurrency,
+            workItemTimeoutMs: correction.workItemTimeoutMs,
+            autoApplyThreshold: correction.autoApplyThreshold,
+            proposalThreshold: correction.proposalThreshold,
+            forceAutoApply: correction.forceAutoApply,
+            maxRetries: correction.maxRetries.reviewAssistance,
+            tableMaxRetries: correction.maxRetries.tableCorrection,
+            temperature: correction.temperature,
+            outputLanguage: correction.outputLanguage,
+            aggregator: options.aggregator,
+            abortSignal,
+            onTokenUsage: options.onTokenUsage,
+            onProgress: options.onReviewAssistanceProgress,
+          },
+        );
+      }
 
       await originalCallback(outputDir);
     };


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR makes demo-web run only the post-Docling text-correction stage, using a local LM Studio Gemma model with a cloud fallback so demo parsing can avoid the heavier review-assistance pipeline. It also prevents stale Docling processes from being reused by starting each parser instance on a freshly discovered free port.

## Changes

- Added `reviewAssistanceEnabled` to `PDFCorrectionOptions`, `NormalizedPDFCorrectionOptions`, and `PDF_CORRECTION_DEFAULTS`, defaulting to `true` for backward compatibility.
- Updated `PostDoclingCorrectionPipeline` to omit `reviewAssistanceGate` and skip `ReviewAssistanceRunner.analyzeAndSave()` when `reviewAssistanceEnabled` is `false`.
- Configured demo-web correction defaults to use `lmstudio/gemma-4-26b-a4b-it-mlx` for `textCorrection` with `openai/gpt-5.4` as `textCorrectionFallback`.
- Set demo-web correction concurrency to `pages: 2` and `modelConcurrency: 3`, and passed `reviewAssistanceEnabled: false` from `buildPDFCorrectionOptions()`.
- Added optional fallback model fields in `processingOptionsSchema`, including `textCorrectionFallback`, `pageGateFallback`, `reviewAssistanceFallback`, `tableCorrectionFallback`, `reviewAssistanceTasksFallback`, and `languageDetectionFallbackModel`.
- Hid review-assistance-only controls in `AdvancedOptionsCard` and `ProcessingOptionsCard` behind `REVIEW_ASSISTANCE_UI`, leaving text-correction controls visible.
- Added the missing `2 concurrent` page-concurrency option in the processing options UI.
- Updated `PDFParserManager` to scan `PDF_PARSER_PORT` through `PDF_PARSER_PORT_MAX`, select the first free port, start a fresh Docling server there, and log the chosen port and listener PID.
- Added tests for `reviewAssistanceEnabled` normalization and for skipping page-gate/review-assistance execution when disabled.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #