### PR TITLE
chore(demo-web): refresh demo LLM model defaults

### DIFF
--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -11,6 +11,11 @@ export interface LLMModel {
 export const LLM_MODELS: LLMModel[] = [
   // OpenAI
   {
+    id: 'openai/gpt-5.5',
+    label: 'GPT-5.5',
+    provider: 'OpenAI',
+  },
+  {
     id: 'openai/gpt-5.4',
     label: 'GPT-5.4',
     provider: 'OpenAI',
@@ -38,7 +43,7 @@ export const LLM_MODELS: LLMModel[] = [
 
   // Anthropic
   {
-    id: 'anthropic/claude-opus-4-6',
+    id: 'anthropic/claude-opus-4-8',
     label: 'Claude Opus 4.6',
     provider: 'Anthropic',
   },
@@ -60,8 +65,8 @@ export const LLM_MODELS: LLMModel[] = [
     provider: 'Google',
   },
   {
-    id: 'google/gemini-3-flash-preview',
-    label: 'Gemini 3 Flash Preview',
+    id: 'google/gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
     provider: 'Google',
   },
   {

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // Document type validation
   documentValidationModel: 'openai/gpt-5.4',
   // PDF language detection for OCR language hints
-  languageDetectionModel: 'openai/gpt-5.4',
+  languageDetectionModel: 'lmstudio/gemma-4-e4b-it-mlx',
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // Mandatory post-Docling correction.
@@ -36,16 +36,16 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
     models: {
       textCorrection: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       textCorrectionFallback: 'openai/gpt-5.4',
-      pageGate: 'google/gemini-3.1-flash-lite',
-      reviewAssistance: 'google/gemini-3.1-flash-lite',
+      pageGate: 'lmstudio/gemma-4-26b-a4b-it-mlx',
+      reviewAssistance: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       tableCorrection: 'openai/gpt-5-mini',
       reviewAssistanceTasks: {
-        textOcrHanja: 'google/gemini-3.1-flash-lite',
-        textIntegrity: 'google/gemini-3.1-flash-lite',
-        textRoleFootnote: 'google/gemini-3.1-flash-lite',
+        textOcrHanja: 'lmstudio/gemma-4-26b-a4b-it-mlx',
+        textIntegrity: 'lmstudio/gemma-4-26b-a4b-it-mlx',
+        textRoleFootnote: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         tables: 'openai/gpt-5-mini',
-        picturesCaptions: 'google/gemini-3.1-flash-lite',
-        layoutBboxOrder: 'google/gemini-3.1-flash-lite',
+        picturesCaptions: 'lmstudio/gemma-4-26b-a4b-it-mlx',
+        layoutBboxOrder: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       },
     },
     concurrency: {
@@ -61,10 +61,10 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // LLM Models
   fallbackModel: 'openai/gpt-5.4',
   validatorModel: 'openai/gpt-5.4',
-  pageRangeParserModel: 'google/gemini-3-flash-preview',
-  tocExtractorModel: 'together/Qwen/Qwen3-235B-A22B-Instruct-2507-tput',
-  visionTocExtractorModel: 'google/gemini-3-flash-preview',
-  captionParserModel: 'together/Qwen/Qwen3-235B-A22B-Instruct-2507-tput',
+  pageRangeParserModel: 'lmstudio/gemma-4-31b-it-mlx',
+  tocExtractorModel: 'lmstudio/gemma-4-e4b-it-mlx',
+  visionTocExtractorModel: 'lmstudio/gemma-4-31b-it-mlx',
+  captionParserModel: 'lmstudio/gemma-4-e4b-it-mlx',
   // Batch & Retry
   textCleanerBatchSize: 20,
   captionParserBatchSize: 0,

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -20,7 +20,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   file: null,
   threadCount: 4,
   // Document type validation
-  documentValidationModel: 'openai/gpt-5.4',
+  documentValidationModel: 'openai/gpt-5.4-mini',
   // PDF language detection for OCR language hints
   languageDetectionModel: 'lmstudio/gemma-4-e4b-it-mlx',
   // Force image PDF pre-conversion
@@ -35,7 +35,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   correction: {
     models: {
       textCorrection: 'lmstudio/gemma-4-26b-a4b-it-mlx',
-      textCorrectionFallback: 'openai/gpt-5.4',
+      textCorrectionFallback: 'google/gemini-3.1-flash-lite',
       pageGate: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       reviewAssistance: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       tableCorrection: 'openai/gpt-5-mini',
@@ -59,8 +59,8 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
     workItemTimeoutMs: 1_800_000,
   },
   // LLM Models
-  fallbackModel: 'openai/gpt-5.4',
-  validatorModel: 'openai/gpt-5.4',
+  fallbackModel: 'openai/gpt-5.4-mini',
+  validatorModel: 'openai/gpt-5.4-mini',
   pageRangeParserModel: 'lmstudio/gemma-4-31b-it-mlx',
   tocExtractorModel: 'lmstudio/gemma-4-e4b-it-mlx',
   visionTocExtractorModel: 'lmstudio/gemma-4-31b-it-mlx',

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -53,15 +53,17 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'gpt-5.1': { input: 1.25, output: 10 },
     'gpt-5.2': { input: 1.75, output: 14 },
     'gpt-5.4': { input: 2.5, output: 15 },
+    'gpt-5.5': { input: 5, output: 30 },
     'gpt-5.4-mini': { input: 0.75, output: 4.5 },
     'gpt-5-mini': { input: 0.25, output: 2 },
     // Google
+    'google/gemini-3.5-flash': { input: 1.5, output: 9 },
     'gemini-3-flash-preview': { input: 0.5, output: 3 },
     'gemini-3.1-pro-preview': { input: 2, output: 12 },
     'gemini-3.1-flash-lite': { input: 0.25, output: 1.5 },
     'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
     // Claude
-    'anthropic/claude-opus-4-6': { input: 5, output: 25 },
+    'anthropic/claude-opus-4-8': { input: 5, output: 25 },
     'anthropic/claude-sonnet-4-6': { input: 3, output: 15 },
     'anthropic/claude-haiku-4-5': { input: 1, output: 5 },
     // VLM strategy models (provider-prefixed keys from TokenUsageReport)


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Refresh the demo upload defaults so local LM Studio models handle more of the PDF processing workflow while smaller cloud models remain available where appropriate. This also keeps the model selector and cost estimator aligned with the newer model IDs used by the demo configuration.

## Changes

- Added `openai/gpt-5.5` to `LLM_MODELS` and `MODEL_PRICING`.
- Updated Claude and Gemini model IDs in `llm-models.ts` and `model-pricing.ts`.
- Changed `DEFAULT_FORM_VALUES` to use LM Studio Gemma models for language detection, page range parsing, TOC extraction, captions, page gates, and review assistance tasks.
- Switched validation and fallback defaults to `openai/gpt-5.4-mini`.
- Updated fallback and task-specific correction models to better match the current demo processing setup.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #