### PR TITLE
feat(demo-web): add demo auto-correction opt-in flow

### DIFF
--- a/apps/demo-web/src/app/page.tsx
+++ b/apps/demo-web/src/app/page.tsx
@@ -12,6 +12,7 @@ import { publicModeConfig } from '~/lib/config/public-mode';
 
 import { MobileWarningBanner } from '~/components/layout/mobile-warning-banner';
 import { SampleResultsBanner } from '~/components/layout/sample-results-banner';
+import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import { PipelineStepper } from '~/components/pipeline/pipeline-stepper';
 import { Card, CardContent } from '~/components/ui/card';
 import {
@@ -257,6 +258,9 @@ function HomePageContent() {
             <form onSubmit={handleFormSubmit}>
               {/* Known Limitations Banner */}
               <KnownLimitationsBanner />
+
+              {/* Auto-correction Notice */}
+              <AutoCorrectionDemoNoticeBanner />
 
               {/* Info Banner - Always visible in public mode when not blocked */}
               {isPublicMode && !isBlocked && rateLimit && (

--- a/apps/demo-web/src/app/page.tsx
+++ b/apps/demo-web/src/app/page.tsx
@@ -10,9 +10,9 @@ import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import type { ApiResponseError } from '~/lib/api/tasks';
 import { publicModeConfig } from '~/lib/config/public-mode';
 
+import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import { MobileWarningBanner } from '~/components/layout/mobile-warning-banner';
 import { SampleResultsBanner } from '~/components/layout/sample-results-banner';
-import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import { PipelineStepper } from '~/components/pipeline/pipeline-stepper';
 import { Card, CardContent } from '~/components/ui/card';
 import {

--- a/apps/demo-web/src/app/result/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/result/[taskId]/page.tsx
@@ -2,9 +2,9 @@
 
 import { Suspense, use } from 'react';
 
+import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import { MobileWarningBanner } from '~/components/layout/mobile-warning-banner';
 import { PipelineBreadcrumb } from '~/components/pipeline/pipeline-breadcrumb';
-import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import {
   Card,
   CardContent,

--- a/apps/demo-web/src/app/result/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/result/[taskId]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, use } from 'react';
 
 import { MobileWarningBanner } from '~/components/layout/mobile-warning-banner';
 import { PipelineBreadcrumb } from '~/components/pipeline/pipeline-breadcrumb';
+import { AutoCorrectionDemoNoticeBanner } from '~/components/layout/auto-correction-demo-notice-banner';
 import {
   Card,
   CardContent,
@@ -86,6 +87,7 @@ function ResultContent({ taskId }: { taskId: string }) {
             onDownloadAll={downloadAll}
             isDownloading={isDownloading}
           />
+          <AutoCorrectionDemoNoticeBanner />
           {task.isSample && <SampleDataBanner />}
           <PreprocessingInfoBanner />
           <ResultSummaryCards

--- a/apps/demo-web/src/components/layout/auto-correction-demo-notice-banner.tsx
+++ b/apps/demo-web/src/components/layout/auto-correction-demo-notice-banner.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { CheckCircle2, Info } from 'lucide-react';
+
+import { publicModeConfig } from '~/lib/config/public-mode';
+import { useBrowserLanguage } from '~/lib/hooks/use-browser-language';
+
+const text = {
+  ko: {
+    title: '데모 안내: 자동 보정은 생략됩니다',
+    description:
+      '온라인 데모는 처리 시간이 길어질 수 있는 자동 보정(텍스트 교정, 구조 보정, 표 보정, 이미지 분리/합치기, 캡션 보정)을 생략합니다.',
+    next: '로컬에서 엔진을 실행하면 이 옵션들을 켜서 전체 보정 파이프라인을 사용할 수 있습니다.',
+  },
+  en: {
+    title: 'Demo Notice: Auto-correction Is Skipped',
+    description:
+      'The online demo skips auto-correction that takes longer to run, including text correction, structural correction, table correction, image split/merge, and caption correction.',
+    next: 'You can enable these options and use the full correction pipeline by running the engine locally.',
+  },
+} as const;
+
+export function AutoCorrectionDemoNoticeBanner() {
+  const lang = useBrowserLanguage();
+
+  if (!publicModeConfig.isPublicMode) {
+    return null;
+  }
+
+  const t = text[lang];
+
+  return (
+    <div className="mb-6 rounded-lg border border-indigo-200 bg-indigo-50 p-4">
+      <div className="flex items-start gap-3">
+        <Info className="mt-0.5 h-5 w-5 shrink-0 text-indigo-600" />
+        <div className="space-y-2">
+          <h3 className="font-medium text-indigo-900">{t.title}</h3>
+          <p className="text-sm text-indigo-800">{t.description}</p>
+          <p className="flex items-start gap-1.5 text-sm text-indigo-700">
+            <CheckCircle2 className="mt-0.5 h-4 w-4" />
+            {t.next}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/demo-web/src/features/upload/components/processing-options-card.tsx
+++ b/apps/demo-web/src/features/upload/components/processing-options-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Eye, Info } from 'lucide-react';
+import { CheckSquare, Eye, Info } from 'lucide-react';
 
 import { cn } from '~/lib/utils';
 
@@ -52,9 +52,8 @@ interface OptionalStringFieldApi {
 
 const NONE_VALUE = '__none__';
 
-// Review-assistance correction is disabled in the demo — only the text-correction
-// stage runs (see `reviewAssistanceEnabled: false` in task-worker.ts). Its UI
-// controls are hidden behind this flag; flip to true to re-expose them.
+// Review-assistance correction controls are hidden behind this flag; flip to true
+// to re-expose them.
 const REVIEW_ASSISTANCE_UI: boolean = false;
 
 /**
@@ -253,6 +252,37 @@ export function ProcessingOptionsCard({
               disabled={disabled}
               optional
             />
+          )}
+        </form.Field>
+
+        <form.Field name="correction.reviewAssistanceEnabled">
+          {(field: BooleanFieldApi) => (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <div>
+                  <label className="text-sm font-medium">
+                    Auto Correction
+                  </label>
+                  <p className="text-muted-foreground text-xs">
+                    Enable review-assistance based correction stages (page gate,
+                    review tasks, table/caption fixes)
+                  </p>
+                </div>
+                <div className="ml-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <CheckSquare className="h-3.5 w-3.5" />
+                  <span>{field.state.value ? 'On' : 'Off'}</span>
+                </div>
+              </div>
+              <div className="flex justify-end">
+                <DisabledWrapper disabled={disabled}>
+                  <ToggleSwitch
+                    checked={field.state.value}
+                    onChange={() => field.handleChange(!field.state.value)}
+                    disabled={disabled}
+                  />
+                </DisabledWrapper>
+              </div>
+            </div>
           )}
         </form.Field>
 

--- a/apps/demo-web/src/features/upload/components/processing-options-card.tsx
+++ b/apps/demo-web/src/features/upload/components/processing-options-card.tsx
@@ -260,15 +260,13 @@ export function ProcessingOptionsCard({
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <div>
-                  <label className="text-sm font-medium">
-                    Auto Correction
-                  </label>
+                  <label className="text-sm font-medium">Auto Correction</label>
                   <p className="text-muted-foreground text-xs">
                     Enable review-assistance based correction stages (page gate,
                     review tasks, table/caption fixes)
                   </p>
                 </div>
-                <div className="ml-2 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <div className="text-muted-foreground ml-2 flex items-center gap-1.5 text-xs">
                   <CheckSquare className="h-3.5 w-3.5" />
                   <span>{field.state.value ? 'On' : 'Off'}</span>
                 </div>

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -26,13 +26,10 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // Mandatory post-Docling correction.
-  // NOTE: review assistance (the structural correction logic) is disabled for
-  // the demo — only the text-correction stage runs (see `reviewAssistanceEnabled:
-  // false` in task-worker.ts). Accordingly, only `textCorrection` uses a local
-  // model (LM Studio gemma 26b) with a cloud fallback so it still completes if
-  // the local model fails; every other slot stays on the original cloud models
-  // and is inert while review assistance is off.
+  // review-assistanceEnabled defaults to false so the heavier automatic
+  // correction flow is off by default in the demo UI.
   correction: {
+    reviewAssistanceEnabled: false,
     models: {
       textCorrection: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       textCorrectionFallback: 'google/gemini-3.1-flash-lite',

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -284,9 +284,8 @@ function buildPDFCorrectionOptions(
       tableCorrection: stageRetries?.tableCorrection ?? options.maxRetries,
     },
     outputLanguage: options.correction.outputLanguage,
-    // Demo runs the text-correction stage only — the review-assistance stage
-    // (per-page eligibility gate + structural correction runner) is skipped.
-    reviewAssistanceEnabled: false,
+    reviewAssistanceEnabled:
+      options.correction.reviewAssistanceEnabled ?? false,
     // Only relevant when review assistance is enabled: demo runs have no human
     // reviewer, so every valid command would auto-apply instead of routing to a
     // proposal queue. Kept for when review assistance is re-enabled.

--- a/apps/demo-web/src/lib/validations/schemas/task.ts
+++ b/apps/demo-web/src/lib/validations/schemas/task.ts
@@ -57,6 +57,7 @@ const correctionOptionsSchema = z.object({
     reviewAssistanceTasks: correctionTaskModelSchema,
     reviewAssistanceTasksFallback: correctionTaskModelSchema,
   }),
+  reviewAssistanceEnabled: z.boolean().default(false),
   concurrency: z
     .object({
       pages: z.number().int().positive().max(50).default(1),


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR adds a user-controllable auto-correction setting to the demo workflow so long-running correction stages are no longer forced off by default.  
It also surfaces a clear notice in the demo UI to explain that full auto-correction is skipped in public demo mode and how to enable the complete pipeline locally.  
The change makes the behavior explicit and configurable without altering existing data-flow defaults for typical users.

## Changes

- Added `AutoCorrectionDemoNoticeBanner` component in `apps/demo-web/src/components/layout/auto-correction-demo-notice-banner.tsx` to explain auto-correction behavior in public mode (localized Korean/English copy).
- Rendered the new banner in `apps/demo-web/src/app/page.tsx` and `apps/demo-web/src/app/result/[taskId]/page.tsx` so the notice is visible on both upload and result screens.
- Added an `Auto Correction` toggle field (`form.Field name="correction.reviewAssistanceEnabled"`) in `apps/demo-web/src/features/upload/components/processing-options-card.tsx` to let users enable/disable review-assistance based correction stages.
- Updated `DEFAULT_FORM_VALUES` in `apps/demo-web/src/features/upload/types/form-values.ts` to include `reviewAssistanceEnabled` with default `false` and clarified comments accordingly.
- Added `reviewAssistanceEnabled: z.boolean().default(false)` to `correctionOptionsSchema` in `apps/demo-web/src/lib/validations/schemas/task.ts` and passed the value into `buildPDFCorrectionOptions` in `apps/demo-web/src/lib/queue/task-worker.ts` instead of hardcoding `false`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #