### PR TITLE
feat(demo-web): hide token costs in official demo

### DIFF
--- a/apps/demo-web/src/app/api/tasks/[taskId]/result/route.ts
+++ b/apps/demo-web/src/app/api/tasks/[taskId]/result/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { existsSync, readFileSync } from 'fs';
 import { NextResponse } from 'next/server';
 
+import { resolveTokenCostUSD } from '~/lib/api/task-response';
 import { getTaskByIdForSession } from '~/lib/db/repositories/task-repository';
 import { getOrCreateSessionId } from '~/lib/session';
 import {
@@ -59,6 +60,7 @@ export async function GET(
         imagesCount: task.imagesCount,
         tablesCount: task.tablesCount,
         tokenUsage: task.tokenUsage,
+        tokenCostUSD: resolveTokenCostUSD(task.tokenUsage),
         createdAt: task.createdAt,
         completedAt: task.completedAt,
       },

--- a/apps/demo-web/src/app/api/tasks/[taskId]/route.ts
+++ b/apps/demo-web/src/app/api/tasks/[taskId]/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { rmSync } from 'fs';
 import { NextResponse } from 'next/server';
 
+import { toTaskApiResponse } from '~/lib/api/task-response';
 import { sampleTaskConfig } from '~/lib/config/public-mode';
 import { deleteLogsByTaskId } from '~/lib/db/repositories/log-repository';
 import {
@@ -42,7 +43,7 @@ export async function GET(
     const position = queueManager.getQueuePosition(taskId);
 
     return NextResponse.json({
-      ...task,
+      ...toTaskApiResponse(task),
       queuePosition: position > 0 ? position : undefined,
     });
   } catch (error) {

--- a/apps/demo-web/src/app/api/tasks/route.ts
+++ b/apps/demo-web/src/app/api/tasks/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { NextResponse } from 'next/server';
 
+import { toTaskApiResponse } from '~/lib/api/task-response';
 import { verifyTOTP } from '~/lib/auth/totp';
 import { isTurnstileTokenValid } from '~/lib/auth/turnstile';
 import { publicModeConfig } from '~/lib/config/public-mode';
@@ -349,7 +350,7 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.json({
-      tasks: result.tasks,
+      tasks: result.tasks.map(toTaskApiResponse),
       total: result.total,
       limit,
       offset,

--- a/apps/demo-web/src/app/result/[taskId]/page.tsx
+++ b/apps/demo-web/src/app/result/[taskId]/page.tsx
@@ -131,7 +131,10 @@ function ResultContent({ taskId }: { taskId: string }) {
               />
             </div>
           </div>
-          <TokenUsageChart tokenUsage={task.tokenUsage} />
+          <TokenUsageChart
+            tokenUsage={task.tokenUsage}
+            tokenCostUSD={task.tokenCostUSD}
+          />
           <NextStageBanner />
         </div>
       </div>

--- a/apps/demo-web/src/features/process/components/live-token-usage-card.tsx
+++ b/apps/demo-web/src/features/process/components/live-token-usage-card.tsx
@@ -4,6 +4,7 @@ import type { TokenUsageReport } from '@heripo/model';
 
 import { Fragment, useMemo } from 'react';
 
+import { publicModeConfig } from '~/lib/config/public-mode';
 import { FALLBACK_RATE } from '~/lib/cost/exchange-rate';
 import {
   calculateComponentCost,
@@ -22,11 +23,12 @@ import {
 import { useExchangeRate } from '~/features/result/hooks/use-exchange-rate';
 
 interface LiveTokenUsageCardProps {
-  tokenUsage?: TokenUsageReport;
+  tokenUsage?: TokenUsageReport | null;
 }
 
 export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
-  const { data: exchangeRateResult } = useExchangeRate();
+  const showCost = !publicModeConfig.isOfficialDemo;
+  const { data: exchangeRateResult } = useExchangeRate(showCost);
 
   const exchangeRate = exchangeRateResult?.rate ?? FALLBACK_RATE;
   const isFallbackRate = exchangeRateResult?.isFallback ?? true;
@@ -67,16 +69,21 @@ export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
         <div className="space-y-4">
           {/* Summary */}
           <div className="bg-muted/50 space-y-3 rounded-lg p-4">
-            {/* Exchange Rate Info */}
-            <div className="text-muted-foreground text-xs">
-              Exchange Rate: ₩{exchangeRate.toLocaleString()}/USD
-              {isFallbackRate && (
-                <span className="text-yellow-600"> (default)</span>
-              )}
-            </div>
+            {showCost && (
+              <div className="text-muted-foreground text-xs">
+                Exchange Rate: ₩{exchangeRate.toLocaleString()}/USD
+                {isFallbackRate && (
+                  <span className="text-yellow-600"> (default)</span>
+                )}
+              </div>
+            )}
 
             {/* Token & Cost Grid */}
-            <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+            <div
+              className={`grid grid-cols-2 gap-4 ${
+                showCost ? 'md:grid-cols-5' : 'md:grid-cols-3'
+              }`}
+            >
               <div>
                 <p className="text-muted-foreground text-sm">Input Tokens</p>
                 <p className="text-lg font-semibold">
@@ -95,18 +102,22 @@ export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
                   {(total.totalTokens ?? 0).toLocaleString()}
                 </p>
               </div>
-              <div>
-                <p className="text-muted-foreground text-sm">Cost (USD)</p>
-                <p className="text-lg font-semibold">
-                  ${totalCostUsd.toFixed(4)}
-                </p>
-              </div>
-              <div>
-                <p className="text-muted-foreground text-sm">Cost (KRW)</p>
-                <p className="text-lg font-semibold">
-                  ₩{totalCostKrw.toLocaleString()}
-                </p>
-              </div>
+              {showCost && (
+                <>
+                  <div>
+                    <p className="text-muted-foreground text-sm">Cost (USD)</p>
+                    <p className="text-lg font-semibold">
+                      ${totalCostUsd.toFixed(4)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground text-sm">Cost (KRW)</p>
+                    <p className="text-lg font-semibold">
+                      ₩{totalCostKrw.toLocaleString()}
+                    </p>
+                  </div>
+                </>
+              )}
             </div>
           </div>
 
@@ -130,12 +141,16 @@ export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
                   <th className="px-4 py-2 text-right text-sm font-medium">
                     Total
                   </th>
-                  <th className="px-4 py-2 text-right text-sm font-medium">
-                    Cost (USD)
-                  </th>
-                  <th className="px-4 py-2 text-right text-sm font-medium">
-                    Cost (KRW)
-                  </th>
+                  {showCost && (
+                    <>
+                      <th className="px-4 py-2 text-right text-sm font-medium">
+                        Cost (USD)
+                      </th>
+                      <th className="px-4 py-2 text-right text-sm font-medium">
+                        Cost (KRW)
+                      </th>
+                    </>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -161,12 +176,16 @@ export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
                         <td className="px-4 py-2 text-right text-sm font-medium">
                           {comp.total.totalTokens.toLocaleString()}
                         </td>
-                        <td className="px-4 py-2 text-right text-sm font-medium">
-                          ${compCost.toFixed(4)}
-                        </td>
-                        <td className="px-4 py-2 text-right text-sm font-medium">
-                          ₩{compCostKrw.toLocaleString()}
-                        </td>
+                        {showCost && (
+                          <>
+                            <td className="px-4 py-2 text-right text-sm font-medium">
+                              ${compCost.toFixed(4)}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm font-medium">
+                              ₩{compCostKrw.toLocaleString()}
+                            </td>
+                          </>
+                        )}
                       </tr>
                       {/* Phase detail rows */}
                       {comp.phases.map((phase) => {
@@ -194,12 +213,16 @@ export function LiveTokenUsageCard({ tokenUsage }: LiveTokenUsageCardProps) {
                             <td className="text-muted-foreground px-4 py-2 text-right text-sm">
                               {phase.total.totalTokens.toLocaleString()}
                             </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right text-sm">
-                              ${phaseCost.toFixed(6)}
-                            </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right text-sm">
-                              ₩{phaseCostKrw.toLocaleString()}
-                            </td>
+                            {showCost && (
+                              <>
+                                <td className="text-muted-foreground px-4 py-2 text-right text-sm">
+                                  ${phaseCost.toFixed(6)}
+                                </td>
+                                <td className="text-muted-foreground px-4 py-2 text-right text-sm">
+                                  ₩{phaseCostKrw.toLocaleString()}
+                                </td>
+                              </>
+                            )}
                           </tr>
                         );
                       })}

--- a/apps/demo-web/src/features/process/hooks/use-task-stream.ts
+++ b/apps/demo-web/src/features/process/hooks/use-task-stream.ts
@@ -30,7 +30,7 @@ export interface TaskStreamState {
   resultUrl?: string;
   isConnected: boolean;
   vlmFallbackTriggered: boolean;
-  tokenUsage?: TokenUsageReport;
+  tokenUsage?: TokenUsageReport | null;
 }
 
 const INITIAL_STATE: TaskStreamState = {
@@ -112,7 +112,7 @@ export function useTaskStream(taskId: string | null): TaskStreamState {
 
     eventSource.addEventListener('token-usage', (e: MessageEvent) => {
       if (isCleanedUp) return;
-      const data = JSON.parse(e.data) as TokenUsageReport;
+      const data = JSON.parse(e.data) as TokenUsageReport | null;
       setState((prev) => ({ ...prev, tokenUsage: data }));
     });
 

--- a/apps/demo-web/src/features/result/components/token-usage-chart.tsx
+++ b/apps/demo-web/src/features/result/components/token-usage-chart.tsx
@@ -4,6 +4,7 @@ import type { TokenUsageReport } from '@heripo/model';
 
 import { Fragment, useMemo } from 'react';
 
+import { publicModeConfig } from '~/lib/config/public-mode';
 import { FALLBACK_RATE } from '~/lib/cost/exchange-rate';
 import {
   calculateComponentCost,
@@ -24,19 +25,24 @@ import { useExchangeRate } from '../hooks/use-exchange-rate';
 
 interface TokenUsageChartProps {
   tokenUsage?: unknown;
+  tokenCostUSD?: number | null;
 }
 
-export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
+export function TokenUsageChart({
+  tokenUsage,
+  tokenCostUSD,
+}: TokenUsageChartProps) {
   const usage = tokenUsage as TokenUsageReport | null;
-  const { data: exchangeRateResult } = useExchangeRate();
+  const showCost = !publicModeConfig.isOfficialDemo;
+  const { data: exchangeRateResult } = useExchangeRate(showCost);
 
   const exchangeRate = exchangeRateResult?.rate ?? FALLBACK_RATE;
   const isFallbackRate = exchangeRateResult?.isFallback ?? true;
 
   const totalCostUsd = useMemo(() => {
     if (!usage?.components) return 0;
-    return calculateTotalCostUsd(usage.components);
-  }, [usage]);
+    return tokenCostUSD ?? calculateTotalCostUsd(usage.components);
+  }, [tokenCostUSD, usage]);
 
   const totalCostKrw = Math.round(totalCostUsd * exchangeRate);
 
@@ -70,16 +76,21 @@ export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
         <div className="space-y-4">
           {/* Summary */}
           <div className="bg-muted/50 space-y-3 rounded-lg p-4">
-            {/* Exchange Rate Info */}
-            <div className="text-muted-foreground text-xs">
-              Exchange Rate: ₩{exchangeRate.toLocaleString()}/USD
-              {isFallbackRate && (
-                <span className="text-yellow-600"> (default)</span>
-              )}
-            </div>
+            {showCost && (
+              <div className="text-muted-foreground text-xs">
+                Exchange Rate: ₩{exchangeRate.toLocaleString()}/USD
+                {isFallbackRate && (
+                  <span className="text-yellow-600"> (default)</span>
+                )}
+              </div>
+            )}
 
             {/* Token & Cost Grid */}
-            <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
+            <div
+              className={`grid grid-cols-2 gap-4 ${
+                showCost ? 'md:grid-cols-5' : 'md:grid-cols-3'
+              }`}
+            >
               <div>
                 <p className="text-muted-foreground text-sm">Input Tokens</p>
                 <p className="text-lg font-semibold">
@@ -98,18 +109,22 @@ export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
                   {(total.totalTokens ?? 0).toLocaleString()}
                 </p>
               </div>
-              <div>
-                <p className="text-muted-foreground text-sm">Cost (USD)</p>
-                <p className="text-lg font-semibold">
-                  ${totalCostUsd.toFixed(4)}
-                </p>
-              </div>
-              <div>
-                <p className="text-muted-foreground text-sm">Cost (KRW)</p>
-                <p className="text-lg font-semibold">
-                  ₩{totalCostKrw.toLocaleString()}
-                </p>
-              </div>
+              {showCost && (
+                <>
+                  <div>
+                    <p className="text-muted-foreground text-sm">Cost (USD)</p>
+                    <p className="text-lg font-semibold">
+                      ${totalCostUsd.toFixed(4)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground text-sm">Cost (KRW)</p>
+                    <p className="text-lg font-semibold">
+                      ₩{totalCostKrw.toLocaleString()}
+                    </p>
+                  </div>
+                </>
+              )}
             </div>
           </div>
 
@@ -133,12 +148,16 @@ export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
                   <th className="px-4 py-2 text-right text-sm font-medium">
                     Total
                   </th>
-                  <th className="px-4 py-2 text-right text-sm font-medium">
-                    Cost (USD)
-                  </th>
-                  <th className="px-4 py-2 text-right text-sm font-medium">
-                    Cost (KRW)
-                  </th>
+                  {showCost && (
+                    <>
+                      <th className="px-4 py-2 text-right text-sm font-medium">
+                        Cost (USD)
+                      </th>
+                      <th className="px-4 py-2 text-right text-sm font-medium">
+                        Cost (KRW)
+                      </th>
+                    </>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -164,12 +183,16 @@ export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
                         <td className="px-4 py-2 text-right text-sm font-medium">
                           {comp.total.totalTokens.toLocaleString()}
                         </td>
-                        <td className="px-4 py-2 text-right text-sm font-medium">
-                          ${compCost.toFixed(4)}
-                        </td>
-                        <td className="px-4 py-2 text-right text-sm font-medium">
-                          ₩{compCostKrw.toLocaleString()}
-                        </td>
+                        {showCost && (
+                          <>
+                            <td className="px-4 py-2 text-right text-sm font-medium">
+                              ${compCost.toFixed(4)}
+                            </td>
+                            <td className="px-4 py-2 text-right text-sm font-medium">
+                              ₩{compCostKrw.toLocaleString()}
+                            </td>
+                          </>
+                        )}
                       </tr>
                       {/* Phase detail rows */}
                       {comp.phases.map((phase) => {
@@ -197,12 +220,16 @@ export function TokenUsageChart({ tokenUsage }: TokenUsageChartProps) {
                             <td className="text-muted-foreground px-4 py-2 text-right text-sm">
                               {phase.total.totalTokens.toLocaleString()}
                             </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right text-sm">
-                              ${phaseCost.toFixed(6)}
-                            </td>
-                            <td className="text-muted-foreground px-4 py-2 text-right text-sm">
-                              ₩{phaseCostKrw.toLocaleString()}
-                            </td>
+                            {showCost && (
+                              <>
+                                <td className="text-muted-foreground px-4 py-2 text-right text-sm">
+                                  ${phaseCost.toFixed(6)}
+                                </td>
+                                <td className="text-muted-foreground px-4 py-2 text-right text-sm">
+                                  ₩{phaseCostKrw.toLocaleString()}
+                                </td>
+                              </>
+                            )}
                           </tr>
                         );
                       })}

--- a/apps/demo-web/src/features/result/hooks/use-exchange-rate.ts
+++ b/apps/demo-web/src/features/result/hooks/use-exchange-rate.ts
@@ -7,10 +7,11 @@ import { fetchUsdToKrw } from '~/lib/cost/exchange-rate';
  *
  * Caches for 1 hour to minimize API calls.
  */
-export function useExchangeRate() {
+export function useExchangeRate(enabled = true) {
   return useQuery({
     queryKey: ['exchange-rate', 'usd-krw'],
     queryFn: fetchUsdToKrw,
+    enabled,
     staleTime: 1000 * 60 * 60, // 1 hour
     gcTime: 1000 * 60 * 60 * 24, // 24 hours
   });

--- a/apps/demo-web/src/features/tasks/components/task-list-table.tsx
+++ b/apps/demo-web/src/features/tasks/components/task-list-table.tsx
@@ -21,7 +21,7 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 import type { Task, TaskStatus } from '~/lib/api/tasks';
-import { sampleTaskConfig } from '~/lib/config/public-mode';
+import { publicModeConfig, sampleTaskConfig } from '~/lib/config/public-mode';
 import { calculateCost } from '~/lib/cost/model-pricing';
 
 import { Badge } from '~/components/ui/badge';
@@ -166,6 +166,7 @@ export function TaskListTable() {
   const tasks = data?.tasks ?? [];
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / ITEMS_PER_PAGE);
+  const showCost = !publicModeConfig.isOfficialDemo;
 
   if (tasks.length === 0 && page === 0) {
     return (
@@ -195,7 +196,9 @@ export function TaskListTable() {
           <TableRow>
             <TableHead className="min-w-52">Filename</TableHead>
             <TableHead className="w-28">Status</TableHead>
-            <TableHead className="min-w-28 text-right">Cost (USD)</TableHead>
+            {showCost && (
+              <TableHead className="min-w-28 text-right">Cost (USD)</TableHead>
+            )}
             <TableHead className="w-24 text-right">Chapters</TableHead>
             <TableHead className="w-20 text-right">Images</TableHead>
             <TableHead className="min-w-48">Created</TableHead>
@@ -221,12 +224,14 @@ export function TaskListTable() {
                 </div>
               </TableCell>
               <TableCell>{getStatusBadge(task.status)}</TableCell>
-              <TableCell className="text-right">
-                {(() => {
-                  const cost = calculateTotalCost(task.tokenUsage);
-                  return cost !== null ? `$${cost.toFixed(4)}` : '-';
-                })()}
-              </TableCell>
+              {showCost && (
+                <TableCell className="text-right">
+                  {(() => {
+                    const cost = calculateTotalCost(task.tokenUsage);
+                    return cost !== null ? `$${cost.toFixed(4)}` : '-';
+                  })()}
+                </TableCell>
+              )}
               <TableCell className="text-right">
                 {task.chaptersCount ?? '-'}
               </TableCell>

--- a/apps/demo-web/src/lib/api/task-response.ts
+++ b/apps/demo-web/src/lib/api/task-response.ts
@@ -1,0 +1,34 @@
+import type { TokenUsageReport } from '@heripo/model';
+
+import { publicModeConfig } from '~/lib/config/public-mode';
+import { calculateTotalCostUsd } from '~/lib/cost/token-usage-utils';
+import type { Task } from '~/lib/db/repositories/task-repository';
+
+export interface TokenCostApiFields {
+  tokenCostUSD: number | null;
+}
+
+export type TaskApiResponse = Task & TokenCostApiFields;
+
+function isTokenUsageReport(value: unknown): value is TokenUsageReport {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as TokenUsageReport).components)
+  );
+}
+
+export function resolveTokenCostUSD(tokenUsage: unknown | null): number | null {
+  if (publicModeConfig.isOfficialDemo || !isTokenUsageReport(tokenUsage)) {
+    return null;
+  }
+
+  return calculateTotalCostUsd(tokenUsage.components);
+}
+
+export function toTaskApiResponse(task: Task): TaskApiResponse {
+  return {
+    ...task,
+    tokenCostUSD: resolveTokenCostUSD(task.tokenUsage),
+  };
+}

--- a/apps/demo-web/src/lib/api/tasks.ts
+++ b/apps/demo-web/src/lib/api/tasks.ts
@@ -4,6 +4,7 @@ import type {
   ProcessedFootnote,
   ProcessedImage,
   ProcessedTable,
+  TokenUsageReport,
 } from '@heripo/model';
 
 import type { ProcessingOptions } from '~/features/upload';
@@ -25,7 +26,8 @@ export interface Task {
   imagesCount: number | null;
   tablesCount: number | null;
   totalPages: number | null;
-  tokenUsage: unknown | null;
+  tokenUsage: TokenUsageReport | null;
+  tokenCostUSD: number | null;
   createdAt: string;
   startedAt: string | null;
   completedAt: string | null;
@@ -60,7 +62,8 @@ export interface TaskResultResponse {
     chaptersCount: number;
     imagesCount: number;
     tablesCount: number;
-    tokenUsage: unknown;
+    tokenUsage: TokenUsageReport | null;
+    tokenCostUSD: number | null;
     createdAt: string;
     completedAt: string;
   };


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR prevents official demo users from seeing model token cost amounts while preserving token usage visibility for transparency. It also moves cost exposure behind a shared API response helper so task list, task detail, and result responses apply the same public-mode policy.

## Changes

- Added `apps/demo-web/src/lib/api/task-response.ts` with `resolveTokenCostUSD()` and `toTaskApiResponse()` to return `tokenCostUSD: null` in official demo mode.
- Updated task list, task detail, and result API routes to use the shared token cost response policy.
- Added `tokenCostUSD` to demo-web task/result API types and passed it into `TokenUsageChart`.
- Hid USD/KRW cost columns, exchange-rate text, and cost summary cards in `LiveTokenUsageCard`, `TokenUsageChart`, and `TaskListTable` when `publicModeConfig.isOfficialDemo` is enabled.
- Updated `useExchangeRate()` to skip exchange-rate fetching when cost display is disabled.
- Allowed streamed token usage state to be `null` so official demo masking can be represented safely.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #