### PR TITLE
chore(demo-web): add MiniMax M3 as default model

### DIFF
--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -142,6 +142,11 @@ export const LLM_MODELS: LLMModel[] = [
     provider: 'Together',
   },
   {
+    id: 'together/MiniMaxAI/MiniMax-M3',
+    label: 'MiniMax M3',
+    provider: 'Together',
+  },
+  {
     id: 'together/openai/gpt-oss-120b',
     label: 'OpenAI GPT-OSS 120B',
     provider: 'Together',

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -20,7 +20,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   file: null,
   threadCount: 4,
   // Document type validation
-  documentValidationModel: 'openai/gpt-5.4-mini',
+  documentValidationModel: 'together/MiniMaxAI/MiniMax-M3',
   // PDF language detection for OCR language hints
   languageDetectionModel: 'lmstudio/gemma-4-e4b-it-mlx',
   // Force image PDF pre-conversion
@@ -35,12 +35,12 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
       textCorrectionFallback: 'google/gemini-3.1-flash-lite',
       pageGate: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       reviewAssistance: 'lmstudio/gemma-4-26b-a4b-it-mlx',
-      tableCorrection: 'openai/gpt-5.4-mini',
+      tableCorrection: 'together/MiniMaxAI/MiniMax-M3',
       reviewAssistanceTasks: {
         textOcrHanja: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         textIntegrity: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         textRoleFootnote: 'lmstudio/gemma-4-26b-a4b-it-mlx',
-        tables: 'openai/gpt-5.4-mini',
+        tables: 'together/MiniMaxAI/MiniMax-M3',
         picturesCaptions: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         layoutBboxOrder: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       },
@@ -59,8 +59,8 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   fallbackModel: 'openai/gpt-5.4-mini',
   validatorModel: 'openai/gpt-5.4-mini',
   pageRangeParserModel: 'lmstudio/gemma-4-31b-it-mlx',
-  tocExtractorModel: 'lmstudio/gemma-4-e4b-it-mlx',
-  visionTocExtractorModel: 'lmstudio/gemma-4-31b-it-mlx',
+  tocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
+  visionTocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
   captionParserModel: 'lmstudio/gemma-4-e4b-it-mlx',
   // Batch & Retry
   textCleanerBatchSize: 20,

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -30,6 +30,7 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'zai-org/GLM-4.7': { input: 0.45, output: 2 },
     'Qwen/Qwen3-235B-A22B-Thinking-2507': { input: 0.65, output: 3 },
     'MiniMaxAI/MiniMax-M2.5': { input: 0.3, output: 1.2 },
+    'MiniMaxAI/MiniMax-M3': { input: 0.3, output: 1.2 },
     'zai-org/GLM-4.5-Air-FP8': { input: 0.2, output: 1.1 },
     'Qwen/Qwen3-Next-80B-A3B-Thinking': { input: 0.15, output: 1.5 },
     'Qwen/Qwen3-Coder-Next-FP8': { input: 0.5, output: 1.2 },


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR updates the demo web app to expose MiniMax M3 as an available Together-hosted LLM and uses it for several default processing tasks. The change keeps the upload workflow aligned with the current preferred model set while preserving pricing visibility for cost estimates.

## Changes

- Added `together/MiniMaxAI/MiniMax-M3` to `LLM_MODELS` in `llm-models.ts` with the `MiniMax M3` label and `Together` provider.
- Replaced several default `openai/gpt-5.4-mini` and LM Studio model references in `DEFAULT_FORM_VALUES` with `together/MiniMaxAI/MiniMax-M3`.
- Updated defaults for `documentValidationModel`, `tableCorrection`, `reviewAssistanceTasks.tables`, `tocExtractorModel`, and `visionTocExtractorModel`.
- Added `MiniMaxAI/MiniMax-M3` pricing metadata to `MODEL_PRICING` with the same input/output rates as MiniMax M2.5.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #