### PR TITLE
feat(pdf-parser): add table correction toggle

### DIFF
--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -30,6 +30,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // correction flow is off by default in the demo UI.
   correction: {
     reviewAssistanceEnabled: false,
+    tableCorrectionEnabled: false,
     models: {
       textCorrection: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       textCorrectionFallback: 'google/gemini-3.1-flash-lite',

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -286,6 +286,8 @@ function buildPDFCorrectionOptions(
     outputLanguage: options.correction.outputLanguage,
     reviewAssistanceEnabled:
       options.correction.reviewAssistanceEnabled ?? false,
+    tableCorrectionEnabled:
+      options.correction.tableCorrectionEnabled ?? true,
     // Only relevant when review assistance is enabled: demo runs have no human
     // reviewer, so every valid command would auto-apply instead of routing to a
     // proposal queue. Kept for when review assistance is re-enabled.

--- a/apps/demo-web/src/lib/queue/task-worker.ts
+++ b/apps/demo-web/src/lib/queue/task-worker.ts
@@ -286,8 +286,7 @@ function buildPDFCorrectionOptions(
     outputLanguage: options.correction.outputLanguage,
     reviewAssistanceEnabled:
       options.correction.reviewAssistanceEnabled ?? false,
-    tableCorrectionEnabled:
-      options.correction.tableCorrectionEnabled ?? true,
+    tableCorrectionEnabled: options.correction.tableCorrectionEnabled ?? true,
     // Only relevant when review assistance is enabled: demo runs have no human
     // reviewer, so every valid command would auto-apply instead of routing to a
     // proposal queue. Kept for when review assistance is re-enabled.

--- a/apps/demo-web/src/lib/validations/schemas/task.ts
+++ b/apps/demo-web/src/lib/validations/schemas/task.ts
@@ -58,6 +58,7 @@ const correctionOptionsSchema = z.object({
     reviewAssistanceTasksFallback: correctionTaskModelSchema,
   }),
   reviewAssistanceEnabled: z.boolean().default(false),
+  tableCorrectionEnabled: z.boolean().default(true),
   concurrency: z
     .object({
       pages: z.number().int().positive().max(50).default(1),

--- a/packages/pdf-parser/src/core/correction-options.test.ts
+++ b/packages/pdf-parser/src/core/correction-options.test.ts
@@ -117,4 +117,15 @@ describe('normalizePDFCorrectionOptions', () => {
       ).reviewAssistanceEnabled,
     ).toBe(false);
   });
+
+  test('defaults tableCorrectionEnabled to true and honors an explicit value', () => {
+    expect(
+      normalizePDFCorrectionOptions(correction()).tableCorrectionEnabled,
+    ).toBe(true);
+    expect(
+      normalizePDFCorrectionOptions(
+        correction({ tableCorrectionEnabled: false }),
+      ).tableCorrectionEnabled,
+    ).toBe(false);
+  });
 });

--- a/packages/pdf-parser/src/core/correction-options.ts
+++ b/packages/pdf-parser/src/core/correction-options.ts
@@ -65,6 +65,13 @@ export interface PDFCorrectionOptions {
    * text-correction stage runs. Defaults to true.
    */
   reviewAssistanceEnabled?: boolean;
+  /**
+   * When false, the table-correction work item is not generated during review
+   * assistance scheduling. The rest of the review-assistance pipeline (text
+   * OCR, text integrity, footnotes, pictures, layout) continues to run. Only
+   * relevant when `reviewAssistanceEnabled` is true. Defaults to true.
+   */
+  tableCorrectionEnabled?: boolean;
   temperature?: number;
 }
 
@@ -80,6 +87,7 @@ export interface NormalizedPDFCorrectionOptions {
   proposalThreshold: number;
   forceAutoApply: boolean;
   reviewAssistanceEnabled: boolean;
+  tableCorrectionEnabled: boolean;
   temperature: number;
 }
 
@@ -108,6 +116,7 @@ export const PDF_CORRECTION_DEFAULTS: Omit<
   proposalThreshold: 0.5,
   forceAutoApply: false,
   reviewAssistanceEnabled: true,
+  tableCorrectionEnabled: true,
   temperature: 0,
 };
 
@@ -247,6 +256,9 @@ export function normalizePDFCorrectionOptions(
     reviewAssistanceEnabled:
       value.reviewAssistanceEnabled ??
       PDF_CORRECTION_DEFAULTS.reviewAssistanceEnabled,
+    tableCorrectionEnabled:
+      value.tableCorrectionEnabled ??
+      PDF_CORRECTION_DEFAULTS.tableCorrectionEnabled,
     temperature: normalizeTemperature(
       value.temperature,
       PDF_CORRECTION_DEFAULTS.temperature,

--- a/packages/pdf-parser/src/core/post-docling-correction-pipeline.test.ts
+++ b/packages/pdf-parser/src/core/post-docling-correction-pipeline.test.ts
@@ -167,6 +167,7 @@ describe('PostDoclingCorrectionPipeline', () => {
         pageGateModel,
         pageConcurrency: 1,
         taskConcurrency: 6,
+        tableCorrectionEnabled: true,
       }),
     );
     expect(originalCallback).toHaveBeenCalledWith('/test/output');
@@ -393,12 +394,33 @@ describe('PostDoclingCorrectionPipeline', () => {
         workItemTimeoutMs: 600_000,
         maxRetries: 5,
         tableMaxRetries: 6,
+        tableCorrectionEnabled: true,
         outputLanguage: 'ko-KR',
         aggregator,
         abortSignal: abortController.signal,
         onTokenUsage,
         onProgress,
       }),
+    );
+  });
+
+  test('passes tableCorrectionEnabled: false to the runner', async () => {
+    const originalCallback = vi.fn();
+
+    const wrapped = pipeline.wrapCallback(
+      '/tmp/test.pdf',
+      'report-1',
+      correctionOptions({ tableCorrectionEnabled: false }),
+      originalCallback,
+    );
+
+    await wrapped('/test/output');
+
+    expect(mockRunnerInstance.analyzeAndSave).toHaveBeenCalledWith(
+      '/test/output',
+      'report-1',
+      expect.any(Function),
+      expect.objectContaining({ tableCorrectionEnabled: false }),
     );
   });
 

--- a/packages/pdf-parser/src/core/post-docling-correction-pipeline.ts
+++ b/packages/pdf-parser/src/core/post-docling-correction-pipeline.ts
@@ -90,6 +90,7 @@ export class PostDoclingCorrectionPipeline {
             forceAutoApply: correction.forceAutoApply,
             maxRetries: correction.maxRetries.reviewAssistance,
             tableMaxRetries: correction.maxRetries.tableCorrection,
+            tableCorrectionEnabled: correction.tableCorrectionEnabled,
             temperature: correction.temperature,
             outputLanguage: correction.outputLanguage,
             aggregator: options.aggregator,

--- a/packages/pdf-parser/src/processors/review-assistance/review-assistance-runner.test.ts
+++ b/packages/pdf-parser/src/processors/review-assistance/review-assistance-runner.test.ts
@@ -365,6 +365,7 @@ function makeOptions() {
     proposalThreshold: 0.5,
     maxRetries: 3,
     tableMaxRetries: 3,
+    tableCorrectionEnabled: true,
     temperature: 0,
     outputLanguage: 'en-US',
   };

--- a/packages/pdf-parser/src/processors/review-assistance/review-assistance-runner.ts
+++ b/packages/pdf-parser/src/processors/review-assistance/review-assistance-runner.ts
@@ -96,6 +96,7 @@ export interface ReviewAssistanceRunnerOptions {
   tableMaxRetries: number;
   temperature: number;
   outputLanguage: string;
+  tableCorrectionEnabled: boolean;
   pdfPath?: string;
   abortSignal?: AbortSignal;
   aggregator?: LLMTokenUsageAggregator;
@@ -574,7 +575,9 @@ export class ReviewAssistanceRunner {
 
       const image = new Uint8Array(await readFile(context.pageImagePath));
       const scheduler = new ReviewAssistanceWorkScheduler();
-      const workItems = scheduler.build(context);
+      const workItems = scheduler.build(context, {
+        skipTableItems: !options.tableCorrectionEnabled,
+      });
 
       if (workItems.length === 0) {
         const result: ReviewAssistancePageResult = {

--- a/packages/pdf-parser/src/processors/review-assistance/review-assistance-work-scheduler.test.ts
+++ b/packages/pdf-parser/src/processors/review-assistance/review-assistance-work-scheduler.test.ts
@@ -247,4 +247,37 @@ describe('ReviewAssistanceWorkScheduler', () => {
     expect(item.id.length).toBeLessThanOrEqual(180);
     expect(item.id).toMatch(/-\d+$/);
   });
+
+  test('skips table work items when skipTableItems is true', () => {
+    const context = makeContext();
+    const items = new ReviewAssistanceWorkScheduler().build(context, {
+      skipTableItems: true,
+    });
+
+    expect(items.map((item) => item.kind)).not.toContain('table');
+    expect(items.map((item) => item.kind)).toEqual([
+      'text_ocr_hanja',
+      'text_integrity',
+      'text_role_footnote',
+      'picture_caption',
+      'picture_split',
+      'layout_bbox_order',
+    ]);
+  });
+
+  test('includes table work items when skipTableItems is false', () => {
+    const context = makeContext();
+    const items = new ReviewAssistanceWorkScheduler().build(context, {
+      skipTableItems: false,
+    });
+
+    expect(items.map((item) => item.kind)).toContain('table');
+  });
+
+  test('includes table work items when skipTableItems is not specified', () => {
+    const context = makeContext();
+    const items = new ReviewAssistanceWorkScheduler().build(context);
+
+    expect(items.map((item) => item.kind)).toContain('table');
+  });
 });

--- a/packages/pdf-parser/src/processors/review-assistance/review-assistance-work-scheduler.ts
+++ b/packages/pdf-parser/src/processors/review-assistance/review-assistance-work-scheduler.ts
@@ -63,19 +63,28 @@ const TEXT_ROLE_REASONS = new Set([
 
 const SEVERE_TABLE_REASONS = new Set(['multi_page_table_candidate']);
 
+export interface ReviewAssistanceWorkSchedulerOptions {
+  skipTableItems?: boolean;
+}
+
 export class ReviewAssistanceWorkScheduler {
-  build(context: PageReviewContext): ReviewAssistanceWorkItem[] {
+  build(
+    context: PageReviewContext,
+    options?: ReviewAssistanceWorkSchedulerOptions,
+  ): ReviewAssistanceWorkItem[] {
     if (!context.reviewAssistanceEligibility.eligible) return [];
 
-    return [
+    const items = [
       ...this.buildTextOcrItems(context),
       ...this.buildTextIntegrityItems(context),
       ...this.buildTextRoleItems(context),
-      ...this.buildTableItems(context),
+      ...(options?.skipTableItems ? [] : this.buildTableItems(context)),
       ...this.buildPictureCaptionItems(context),
       ...this.buildPictureSplitItems(context),
       ...this.buildLayoutItems(context),
     ];
+
+    return items;
   }
 
   private buildTextOcrItems(


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Add a dedicated `tableCorrectionEnabled` option so review assistance can run without generating table-correction work items. This keeps the existing parser behavior backward compatible while letting demo-web disable table correction by default for lighter demo runs.

## Changes

- Added `tableCorrectionEnabled` to `PDFCorrectionOptions`, `NormalizedPDFCorrectionOptions`, `PDF_CORRECTION_DEFAULTS`, and `normalizePDFCorrectionOptions()`.
- Passed `tableCorrectionEnabled` through `PostDoclingCorrectionPipeline` into `ReviewAssistanceRunnerOptions`.
- Added `ReviewAssistanceWorkSchedulerOptions.skipTableItems` and used it to omit `table` work items while preserving text OCR, text integrity, footnote, picture, and layout tasks.
- Added demo-web task schema and worker support for `correction.tableCorrectionEnabled`.
- Set `DEFAULT_FORM_VALUES.correction.tableCorrectionEnabled` to `false` in demo-web.
- Added tests for option normalization, pipeline forwarding, and scheduler table-item inclusion/skipping behavior.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #