### PR TITLE
chore(demo-web): update default LLM models

### DIFF
--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -22,7 +22,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // Document type validation
   documentValidationModel: 'together/MiniMaxAI/MiniMax-M3',
   // PDF language detection for OCR language hints
-  languageDetectionModel: 'lmstudio/gemma-4-e4b-it-mlx',
+  languageDetectionModel: 'lmstudio/gemma-4-26b-a4b-it-mlx',
   // Force image PDF pre-conversion
   forceImagePdf: false,
   // Mandatory post-Docling correction.
@@ -62,7 +62,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   pageRangeParserModel: 'lmstudio/gemma-4-31b-it-mlx',
   tocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
   visionTocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
-  captionParserModel: 'lmstudio/gemma-4-e4b-it-mlx',
+  captionParserModel: 'lmstudio/gemma-4-26b-a4b-it-mlx',
   // Batch & Retry
   textCleanerBatchSize: 20,
   captionParserBatchSize: 0,


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR updates the demo web upload form defaults to use a newer local Gemma model for language detection and caption parsing. The change keeps the processing configuration aligned with the intended LLM setup for OCR language hints and post-processing tasks.

## Changes

- Updated `DEFAULT_FORM_VALUES.languageDetectionModel` in `apps/demo-web/src/features/upload/types/form-values.ts` from `lmstudio/gemma-4-e4b-it-mlx` to `lmstudio/gemma-4-26b-a4b-it-mlx`.
- Updated `DEFAULT_FORM_VALUES.captionParserModel` in `apps/demo-web/src/features/upload/types/form-values.ts` from `lmstudio/gemma-4-e4b-it-mlx` to `lmstudio/gemma-4-26b-a4b-it-mlx`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #