### PR TITLE
chore(demo-web): update page range parser model

### DIFF
--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -59,7 +59,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // LLM Models
   fallbackModel: 'openai/gpt-5.4-mini',
   validatorModel: 'openai/gpt-5.4-mini',
-  pageRangeParserModel: 'lmstudio/qwen3.6-35b-a3b-mlx',
+  pageRangeParserModel: 'together/MiniMaxAI/MiniMax-M3',
   tocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
   visionTocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
   captionParserModel: 'lmstudio/gemma-4-26b-a4b-it-mlx',


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR updates the default page range parser model used by the demo web upload form. The change aligns page range parsing with the MiniMax-M3 provider already used by adjacent extraction defaults, reducing reliance on the previous local LM Studio model for this step.

## Changes

- Updated `DEFAULT_FORM_VALUES.pageRangeParserModel` in `apps/demo-web/src/features/upload/types/form-values.ts`
- Changed the default model from `lmstudio/qwen3.6-35b-a3b-mlx` to `together/MiniMaxAI/MiniMax-M3`

## Breaking Changes

- [x] None
- If any, describe migration steps: N/A

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #