### PR TITLE
chore(demo-web): update LLM models, pricing, and README documentation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -168,7 +168,7 @@ heripo-engine/
 
 - **macOS** (Apple Silicon 또는 Intel)
 - **Node.js** >= 24.0.0
-- **pnpm** >= 10.0.0
+- **pnpm** >= 11
 - **Python** 3.9 - 3.12 (⚠️ Python 3.13+는 지원하지 않음)
 - **jq** (JSON 처리 도구)
 - **poppler** (PDF 텍스트 추출 도구)

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ For detailed architecture explanation, see [docs/architecture.md](./docs/archite
 
 - **macOS** (Apple Silicon or Intel)
 - **Node.js** >= 24.0.0
-- **pnpm** >= 10.0.0
+- **pnpm** >= 11
 - **Python** 3.9 - 3.12 (⚠️ Python 3.13+ is not supported)
 - **jq** (JSON processing tool)
 - **poppler** (PDF text extraction tools)

--- a/apps/demo-web/README.ko.md
+++ b/apps/demo-web/README.ko.md
@@ -73,7 +73,7 @@ Demo Web은 heripo engine의 PDF 파싱 및 문서 처리 기능을 실시간으
 ### Node.js 및 패키지 관리자
 
 - **Node.js** >= 24.0.0
-- **pnpm** >= 10.0.0
+- **pnpm** >= 11
 
 ### LLM API 키
 

--- a/apps/demo-web/README.md
+++ b/apps/demo-web/README.md
@@ -73,7 +73,7 @@ This application depends on `@heripo/pdf-parser`, which has specific system requ
 ### Node.js and Package Manager
 
 - **Node.js** >= 24.0.0
-- **pnpm** >= 10.0.0
+- **pnpm** >= 11
 
 ### LLM API Keys
 

--- a/apps/demo-web/src/features/upload/constants/llm-models.ts
+++ b/apps/demo-web/src/features/upload/constants/llm-models.ts
@@ -11,13 +11,23 @@ export interface LLMModel {
 export const LLM_MODELS: LLMModel[] = [
   // OpenAI
   {
-    id: 'openai/gpt-5.5',
-    label: 'GPT-5.5',
+    id: 'openai/gpt-5.6-sol',
+    label: 'GPT-5.6 Sol',
     provider: 'OpenAI',
   },
   {
-    id: 'openai/gpt-5.4',
-    label: 'GPT-5.4',
+    id: 'openai/gpt-5.6-terra',
+    label: 'GPT-5.6 Terra',
+    provider: 'OpenAI',
+  },
+  {
+    id: 'openai/gpt-5.6-luna',
+    label: 'GPT-5.6 Luna',
+    provider: 'OpenAI',
+  },
+  {
+    id: 'openai/gpt-5.5',
+    label: 'GPT-5.5',
     provider: 'OpenAI',
   },
   {
@@ -39,12 +49,12 @@ export const LLM_MODELS: LLMModel[] = [
   // Anthropic
   {
     id: 'anthropic/claude-opus-4-8',
-    label: 'Claude Opus 4.6',
+    label: 'Claude Opus 4.8',
     provider: 'Anthropic',
   },
   {
-    id: 'anthropic/claude-sonnet-4-6',
-    label: 'Claude Sonnet 4.6',
+    id: 'anthropic/claude-sonnet-5',
+    label: 'Claude Sonnet 5',
     provider: 'Anthropic',
   },
   {
@@ -234,23 +244,8 @@ export const LLM_MODELS: LLMModel[] = [
     provider: 'LM Studio',
   },
   {
-    id: 'lmstudio/qwen3.6-35b-a3b-mlx',
+    id: 'lmstudio/qwen3.6-35b-a3b',
     label: 'Qwen 3.6 35B-A3B (MLX)',
-    provider: 'LM Studio',
-  },
-  {
-    id: 'lmstudio/qwen3.6-27b-mlx',
-    label: 'Qwen 3.6 27B (MLX)',
-    provider: 'LM Studio',
-  },
-  {
-    id: 'lmstudio/qwen3.5-27b',
-    label: 'Qwen 3.5 27B',
-    provider: 'LM Studio',
-  },
-  {
-    id: 'lmstudio/qwen3.5-9b-mlx',
-    label: 'Qwen 3.5 9B (MLX)',
     provider: 'LM Studio',
   },
 ];

--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -57,8 +57,8 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
     workItemTimeoutMs: 1_800_000,
   },
   // LLM Models
-  fallbackModel: 'openai/gpt-5.4-mini',
-  validatorModel: 'openai/gpt-5.4-mini',
+  fallbackModel: 'openai/gpt-5.6-luna',
+  validatorModel: 'openai/gpt-5.6-luna',
   pageRangeParserModel: 'together/MiniMaxAI/MiniMax-M3',
   tocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
   visionTocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -55,6 +55,9 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'gpt-5.2': { input: 1.75, output: 14 },
     'gpt-5.4': { input: 2.5, output: 15 },
     'gpt-5.5': { input: 5, output: 30 },
+    'gpt-5.6-sol': { input: 5, output: 30 },
+    'gpt-5.6-terra': { input: 2.5, output: 15 },
+    'gpt-5.6-luna': { input: 1, output: 6 },
     'gpt-5.4-mini': { input: 0.75, output: 4.5 },
     'gpt-5-mini': { input: 0.25, output: 2 },
     // Google
@@ -65,9 +68,13 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'gemini-3.1-flash-lite-preview': { input: 0.25, output: 1.5 },
     // Claude
     'anthropic/claude-opus-4-8': { input: 5, output: 25 },
+    'anthropic/claude-sonnet-5': { input: 3, output: 15 },
     'anthropic/claude-sonnet-4-6': { input: 3, output: 15 },
     'anthropic/claude-haiku-4-5': { input: 1, output: 5 },
     // VLM strategy models (provider-prefixed keys from TokenUsageReport)
+    'openai/gpt-5.6-sol': { input: 5, output: 30 },
+    'openai/gpt-5.6-terra': { input: 2.5, output: 15 },
+    'openai/gpt-5.6-luna': { input: 1, output: 6 },
     'openai/gpt-5.4': { input: 2.5, output: 15 },
     'openai/gpt-5.2': { input: 1.75, output: 14 },
     'openai/gpt-5.1': { input: 1.25, output: 10 },

--- a/packages/pdf-parser/README.ko.md
+++ b/packages/pdf-parser/README.ko.md
@@ -65,7 +65,7 @@
 brew install node
 ```
 
-#### 2. pnpm >= 11.0.0
+#### 2. pnpm >= 11
 
 ```bash
 npm install -g pnpm
@@ -653,10 +653,25 @@ type PDFConvertOptions = {
 interface PDFCorrectionOptions {
   models: {
     textCorrection: LanguageModel; // 필수: 페이지 텍스트와 표 셀 OCR 보정
+    textCorrectionFallback?: LanguageModel; // 선택: textCorrection 실패 시 fallback
     pageGate: LanguageModel; // 필수: 구조 Review Assistance page gate
+    pageGateFallback?: LanguageModel; // 선택: pageGate 실패 시 fallback
     reviewAssistance: LanguageModel; // 필수: 기본 구조 review 모델
+    reviewAssistanceFallback?: LanguageModel; // 선택: reviewAssistance 공통 fallback
     tableCorrection?: LanguageModel; // 선택: 표 전용 보정 override
+    tableCorrectionFallback?: LanguageModel; // 선택: tableCorrection 실패 시 fallback
     reviewAssistanceTasks?: Partial<
+      Record<
+        | 'text_ocr_hanja'
+        | 'text_integrity'
+        | 'text_role_footnote'
+        | 'tables'
+        | 'pictures_captions'
+        | 'layout_bbox_order',
+        LanguageModel
+      >
+    >;
+    reviewAssistanceTasksFallback?: Partial<
       Record<
         | 'text_ocr_hanja'
         | 'text_integrity'
@@ -687,6 +702,9 @@ interface PDFCorrectionOptions {
   };
   autoApplyThreshold?: number; // 자동 적용 최소 confidence (기본값: 0.85)
   proposalThreshold?: number; // sidecar proposal 최소 confidence (기본값: 0.5)
+  forceAutoApply?: boolean; // true일 경우, confidence 임계값에 관계없이 review-assistance 명령을 자동 적용 (기본값: false)
+  reviewAssistanceEnabled?: boolean; // false일 경우, review-assistance 단계를 완전히 건너뜀 (기본값: true)
+  tableCorrectionEnabled?: boolean; // false일 경우, table-correction 작업을 건너뜀 (기본값: true)
   temperature?: number; // VLM 생성 temperature (기본값: 0)
 }
 ```

--- a/packages/pdf-parser/README.md
+++ b/packages/pdf-parser/README.md
@@ -65,7 +65,7 @@
 brew install node
 ```
 
-#### 2. pnpm >= 11.0.0
+#### 2. pnpm >= 11
 
 ```bash
 npm install -g pnpm
@@ -653,10 +653,25 @@ type PDFConvertOptions = {
 interface PDFCorrectionOptions {
   models: {
     textCorrection: LanguageModel; // Required: page text and table-cell OCR correction
+    textCorrectionFallback?: LanguageModel; // Optional: fallback for text correction
     pageGate: LanguageModel; // Required: structural Review Assistance page gate
+    pageGateFallback?: LanguageModel; // Optional: fallback for page gate
     reviewAssistance: LanguageModel; // Required: default structural review model
+    reviewAssistanceFallback?: LanguageModel; // Optional: common fallback for review assistance
     tableCorrection?: LanguageModel; // Optional: table-specific correction override
+    tableCorrectionFallback?: LanguageModel; // Optional: fallback for table correction
     reviewAssistanceTasks?: Partial<
+      Record<
+        | 'text_ocr_hanja'
+        | 'text_integrity'
+        | 'text_role_footnote'
+        | 'tables'
+        | 'pictures_captions'
+        | 'layout_bbox_order',
+        LanguageModel
+      >
+    >;
+    reviewAssistanceTasksFallback?: Partial<
       Record<
         | 'text_ocr_hanja'
         | 'text_integrity'
@@ -687,6 +702,9 @@ interface PDFCorrectionOptions {
   };
   autoApplyThreshold?: number; // Minimum confidence for direct mutation (default: 0.85)
   proposalThreshold?: number; // Minimum confidence for sidecar proposal (default: 0.5)
+  forceAutoApply?: boolean; // When true, review-assistance commands auto-apply regardless of threshold (default: false)
+  reviewAssistanceEnabled?: boolean; // When false, review-assistance is skipped completely (default: true)
+  tableCorrectionEnabled?: boolean; // When false, table-correction is skipped (default: true)
   temperature?: number; // VLM generation temperature (default: 0)
 }
 ```


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [x] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [x] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

This PR updates the available LLM model list and pricing configuration in `demo-web` to reflect newly released GPT-5.6 variants (Sol, Terra, Luna) and Claude Sonnet 5, while removing outdated models and
revising the default fallback/validator models. It also documents newly added `PDFCorrectionOptions` fields (per-role fallback models, `forceAutoApply`, `reviewAssistanceEnabled`, `tableCorrectionEnabled`) in
the `@heripo/pdf-parser` README files.

## Changes

- **`apps/demo-web/src/features/upload/constants/llm-models.ts`**: Added `GPT-5.6 Sol`, `GPT-5.6 Terra`, `GPT-5.6 Luna`, and `GPT-5.5` entries; updated `Claude Opus 4.8` and `Claude Sonnet 5` labels; removed
deprecated LM Studio models (`qwen3.6-27b-mlx`, `qwen3.5-27b`, `qwen3.5-9b-mlx`); fixed `lmstudio/qwen3.6-35b-a3b-mlx` model ID to `qwen3.6-35b-a3b`
- **`apps/demo-web/src/features/upload/types/form-values.ts`**: Changed default `fallbackModel` and `validatorModel` from `openai/gpt-5.4-mini` to `openai/gpt-5.6-luna`
- **`apps/demo-web/src/lib/cost/model-pricing.ts`**: Added pricing entries for `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` (both unprefixed and `openai/`-prefixed keys), and `anthropic/claude-sonnet-5`
- **`packages/pdf-parser/README.md` & `README.ko.md`**: Documented new optional fallback model fields (`textCorrectionFallback`, `pageGateFallback`, `reviewAssistanceFallback`, `tableCorrectionFallback`,
`reviewAssistanceTasksFallback`) and new boolean flags (`forceAutoApply`, `reviewAssistanceEnabled`, `tableCorrectionEnabled`) in the `PDFCorrectionOptions` interface; updated pnpm version requirement from `>=
11.0.0` to `>= 11`
- **Root `README.md` & `README.ko.md`**: Minor content update

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #