### PR TITLE
feat(demo-web): default to GPT-5.6 Luna and update pricing

### DIFF
--- a/apps/demo-web/src/features/upload/types/form-values.ts
+++ b/apps/demo-web/src/features/upload/types/form-values.ts
@@ -20,7 +20,7 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   file: null,
   threadCount: 4,
   // Document type validation
-  documentValidationModel: 'together/MiniMaxAI/MiniMax-M3',
+  documentValidationModel: 'openai/gpt-5.6-luna',
   // PDF language detection for OCR language hints
   languageDetectionModel: 'lmstudio/gemma-4-26b-a4b-it-mlx',
   // Force image PDF pre-conversion
@@ -36,12 +36,12 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
       textCorrectionFallback: 'google/gemini-3.1-flash-lite',
       pageGate: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       reviewAssistance: 'lmstudio/gemma-4-26b-a4b-it-mlx',
-      tableCorrection: 'together/MiniMaxAI/MiniMax-M3',
+      tableCorrection: 'openai/gpt-5.6-luna',
       reviewAssistanceTasks: {
         textOcrHanja: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         textIntegrity: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         textRoleFootnote: 'lmstudio/gemma-4-26b-a4b-it-mlx',
-        tables: 'together/MiniMaxAI/MiniMax-M3',
+        tables: 'openai/gpt-5.6-luna',
         picturesCaptions: 'lmstudio/gemma-4-26b-a4b-it-mlx',
         layoutBboxOrder: 'lmstudio/gemma-4-26b-a4b-it-mlx',
       },
@@ -59,9 +59,9 @@ export const DEFAULT_FORM_VALUES: ProcessingFormValues = {
   // LLM Models
   fallbackModel: 'openai/gpt-5.6-luna',
   validatorModel: 'openai/gpt-5.6-luna',
-  pageRangeParserModel: 'together/MiniMaxAI/MiniMax-M3',
-  tocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
-  visionTocExtractorModel: 'together/MiniMaxAI/MiniMax-M3',
+  pageRangeParserModel: 'openai/gpt-5.6-luna',
+  tocExtractorModel: 'openai/gpt-5.6-luna',
+  visionTocExtractorModel: 'openai/gpt-5.6-luna',
   captionParserModel: 'lmstudio/gemma-4-26b-a4b-it-mlx',
   // Batch & Retry
   textCleanerBatchSize: 20,

--- a/apps/demo-web/src/lib/cost/model-pricing.ts
+++ b/apps/demo-web/src/lib/cost/model-pricing.ts
@@ -56,8 +56,8 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'gpt-5.4': { input: 2.5, output: 15 },
     'gpt-5.5': { input: 5, output: 30 },
     'gpt-5.6-sol': { input: 5, output: 30 },
-    'gpt-5.6-terra': { input: 2.5, output: 15 },
-    'gpt-5.6-luna': { input: 1, output: 6 },
+    'gpt-5.6-terra': { input: 2, output: 12 },
+    'gpt-5.6-luna': { input: 0.2, output: 1.2 },
     'gpt-5.4-mini': { input: 0.75, output: 4.5 },
     'gpt-5-mini': { input: 0.25, output: 2 },
     // Google
@@ -73,8 +73,8 @@ export const MODEL_PRICING: Record<string, { input: number; output: number }> =
     'anthropic/claude-haiku-4-5': { input: 1, output: 5 },
     // VLM strategy models (provider-prefixed keys from TokenUsageReport)
     'openai/gpt-5.6-sol': { input: 5, output: 30 },
-    'openai/gpt-5.6-terra': { input: 2.5, output: 15 },
-    'openai/gpt-5.6-luna': { input: 1, output: 6 },
+    'openai/gpt-5.6-terra': { input: 2, output: 12 },
+    'openai/gpt-5.6-luna': { input: 0.2, output: 1.2 },
     'openai/gpt-5.4': { input: 2.5, output: 15 },
     'openai/gpt-5.2': { input: 1.75, output: 14 },
     'openai/gpt-5.1': { input: 1.25, output: 10 },


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [x] `demo-web`
- [ ] `docs`
- [ ] Other (root configs, CI, etc.)

## Summary

Update demo processing defaults to use GPT-5.6 Luna instead of MiniMax for consistent model behavior across validation, extraction, and correction flows. Refresh GPT-5.6 Terra and Luna cost calculations to match the current OpenAI API pricing.

## Changes

- Replaced all MiniMax defaults in `DEFAULT_FORM_VALUES` with `openai/gpt-5.6-luna`.
- Updated GPT-5.6 Terra pricing to `$2 input / $12 output` per 1M tokens.
- Updated GPT-5.6 Luna pricing to `$0.20 input / $1.20 output` per 1M tokens.
- Updated both provider-prefixed and unprefixed pricing entries in `model-pricing.ts`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #