### PR TITLE
chore(deps): bump pnpm to v11.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "typescript-eslint": "^8.66.0",
     "vite": "^8.2.1"
   },
-  "packageManager": "pnpm@11.10.0",
+  "packageManager": "pnpm@11.20.0",
   "engines": {
     "node": ">=24"
   }


### PR DESCRIPTION
## Affected Package(s)

<!-- Check all that apply -->

- [ ] `@heripo/pdf-parser`
- [ ] `@heripo/document-processor`
- [ ] `@heripo/model`
- [ ] `@heripo/logger`
- [ ] `@heripo/shared` (internal)
- [ ] `demo-web`
- [ ] `docs`
- [x] Other (root configs, CI, etc.)

## Summary

루트 `package.json`의 `packageManager` 필드에 지정된 pnpm 버전을 `11.10.0`에서 `11.20.0`으로 업그레이드합니다. 최신 pnpm 패치/기능을 반영하고 모든 개발자와 CI 환경이 동일한 pnpm 버전을 사용하도록 유지하기 위한 변경입니다.

## Changes

- `package.json`의 `packageManager` 필드를 `pnpm@11.10.0` → `pnpm@11.20.0`으로 업데이트

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `pnpm lint` `pnpm typecheck` `pnpm build` `pnpm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #